### PR TITLE
requirements.txt: Add list of PyPI packages required by this system

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+#   This project also requires various pelican plugins that are submodules:
+#     git submodule update --init --recursive
+markdown
+pelican
+pelican-minify
+smartypants
+typogrify


### PR DESCRIPTION
These are not installed by any automated code in this repo, but can be manually installed with `pip install $(cat requirements.txt)`. (You may want to start a virtual environment first.)

Whether used or not by you, it's a help for any others who want to quickly set up a virtual environment and try to build your site.

After installing this it still doesn't run for me:

```
[16:27:44] WARNING  Feeds generated without SITEURL set properly may not be valid                                settings.py:679
           ERROR    Cannot load plugin `minify`                                                                    _utils.py:117
                    Cannot import plugin `minify`                                                                               
           WARNING  `assets` failed to load dependency `webassets`.`assets` plugin not loaded.                      assets.py:74
           ERROR    Could not process ./compare.org                                                            generators.py:684
                    [Errno 2] No such file or directory: 'emacs'                                                                
...
```
There's no minify in the `pelican-plugins` dir; I don't know if it's supposed to be there or supposed to come from somewhere else.