### PR TITLE
pelicanconf.py: Change date format to 'yyyy年mm月dd日'

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -93,7 +93,7 @@ JINJA_FILTERS = {'regex_replace':regex_replace, 'add_abbr_tags':add_abbr_tags}
 
 # the best date format is obviously signifying each number with the right word
 # chinese happens to do that very concisely
-DEFAULT_DATE_FORMAT = '%d日 %m月 %Y年'
+DEFAULT_DATE_FORMAT = '%Y年%m月%d日'
 
 ORG_READER_EMACS_LOCATION = "emacs"
 ORG_READER_EMACS_SETTINGS = os.path.abspath('lisp/config.el')


### PR DESCRIPTION
The old date format 'dd日 mm月 yyyy年' gets the characters right for western dates in Chinese and Japanese, but they would never be done in that order; in China and Japan dates are invariably given with the year first, then month, then day. (And without spaces.)

This also ensures that even for those who cannot read the characters the components will be obvious, since they need not figure out whether the year-last format is European (DD-MM-YYYY) or American (MM-DD-YYYY).

This has been tested to build as far as the errors in PR #14, so it appears that the config file is being read correctly.