### PR TITLE
Rewrite landing page: problem-led fractional CTO positioning

### DIFF
--- a/penguin/index.html
+++ b/penguin/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="Fractional CTO and technical architecture for companies building correctness-critical financial systems. I make the decisions and build the systems." />
+    <meta name="description" content="Fractional CTO and technical architecture for companies building correctness-critical systems. I make the decisions and build the systems." />
     <link rel="stylesheet" href="style.css" />
     <link rel="icon" href="favicon.ico" />
     <title>Jappie Software B.V. &mdash; Fractional CTO for Correctness-Critical Systems</title>
@@ -26,7 +26,7 @@
       <!-- Hero -->
       <section class="hero">
         <h1>I make technical architecture decisions for companies building correctness-critical systems &mdash; and then I build them.</h1>
-        <p class="subtitle">Fractional CTO + implementation for financial technology companies that need reliable systems and can't afford to get the architecture wrong.</p>
+        <p class="subtitle">Fractional CTO + implementation for companies that need reliable systems and can't afford to get the architecture wrong.</p>
         <a href="mailto:hi@jappie.me" class="cta-button">Book a conversation</a>
       </section>
 
@@ -35,8 +35,8 @@
         <h2>Who I work with</h2>
         <ul class="card-grid">
           <li class="card">
-            <h3>Financial technology companies</h3>
-            <p>Where a bug in production means real money lost. You need systems that are correct by construction, not correct by accident.</p>
+            <h3>Financial technology and IoT</h3>
+            <p>Where a bug in production means real money lost or devices behaving dangerously. You need systems that are correct by construction, not correct by accident.</p>
           </li>
           <li class="card">
             <h3>Non-technical founders</h3>
@@ -72,7 +72,7 @@
             <p>Architected and built core platform components for a <strong>reinsurance technology company</strong> streamlining the global reinsurance market. The system handles complex multi-party deal workflows where data integrity and correctness are non-negotiable.</p>
           </blockquote>
           <blockquote>
-            <p>Led technical architecture decisions for a <strong>financial technology platform</strong>, delivering production systems with the reliability guarantees that financial infrastructure demands.</p>
+            <p>Led technical architecture decisions for a <strong>construction technology IoT platform</strong>, delivering production systems where device reliability and data correctness are critical at scale.</p>
           </blockquote>
         </div>
       </section>

--- a/penguin/index.html
+++ b/penguin/index.html
@@ -1,85 +1,127 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="stylesheet" href="style.css">
-    <title>Jappie Software B.V.</title>
-      <script src="https://d3js.org/d3.v7.min.js"></script>
-    </head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Fractional CTO and technical architecture for companies building correctness-critical financial systems. I make the decisions and build the systems." />
+    <link rel="stylesheet" href="style.css" />
+    <link rel="icon" href="favicon.ico" />
+    <title>Jappie Software B.V. &mdash; Fractional CTO for Correctness-Critical Systems</title>
+  </head>
   <body>
     <header>
-      <h1>Jappie Software B.V.</h1>
-  <nav class="menu">
-  <ul>
-	<!-- <li><a href="https://jappieklooster.nl/pages/portfolio.html">Portfolio</a></li> -->
-	<li><a href="mailto:hi@jappie.me">Email</a></li>
-	<li><a href="tel:+31644237437">☎</a></li>
-	<li><a href="https://jappie.me/">Blog</a></li>
-  </ul>
-  </nav>
+      <nav class="top-nav">
+        <span class="logo">Jappie Software B.V.</span>
+        <ul>
+          <li><a href="#services">Services</a></li>
+          <li><a href="#results">Results</a></li>
+          <li><a href="#approach">Approach</a></li>
+          <li><a href="https://jappie.me/">Blog</a></li>
+          <li><a href="mailto:hi@jappie.me" class="cta-link">Get in touch</a></li>
+        </ul>
+      </nav>
     </header>
-    <article>
-      <p>
-      Hello, I'm Jappie and I make software projects succeed.</p>
 
-      <p>
-      I do this by:
-      <ul>
-      <li>Create value fast and correct. <em>By enhancing software debuggability and increasing system operation visibility, I help teams understand what's happening under the hood.</em></li>
-      <li>Boosting team productivity, <em>By focusing on what truly matters—sometimes by embracing approaches that <a href="https://paulgraham.com/ds.html">don't scale—to</a> drive immediate impact. </em></li>
-      <li>Resolving organizational roadblocks. <em>By understanding stakeholder needs and thoughtfully <a href="https://jappie.me/firmware-lemons.html">proposing solutions</a> that align with their goals. </em></li>
-      </ul>
-      </p>
+    <main>
+      <!-- Hero -->
+      <section class="hero">
+        <h1>I make technical architecture decisions for companies building correctness-critical systems &mdash; and then I build them.</h1>
+        <p class="subtitle">Fractional CTO + implementation for financial technology companies that need reliable systems and can't afford to get the architecture wrong.</p>
+        <a href="mailto:hi@jappie.me" class="cta-button">Book a conversation</a>
+      </section>
 
-      <p>
-      If these statements strike a chord, <a href="mailto:hi@jappie.me">let's chat!</a>
-      I can deliver significant results within a month and transform your project within half a year.
-      </p>
+      <!-- Who this is for -->
+      <section class="for-who" id="services">
+        <h2>Who I work with</h2>
+        <ul class="card-grid">
+          <li class="card">
+            <h3>Financial technology companies</h3>
+            <p>Where a bug in production means real money lost. You need systems that are correct by construction, not correct by accident.</p>
+          </li>
+          <li class="card">
+            <h3>Non-technical founders</h3>
+            <p>You need someone who makes technical decisions with authority, not someone who waits to be told what to build.</p>
+          </li>
+          <li class="card">
+            <h3>Teams drowning in technical debt</h3>
+            <p>Your system grew faster than your architecture. Incidents are increasing. You need someone to untangle the mess and build a path forward.</p>
+          </li>
+        </ul>
+      </section>
 
-      <p>
-      If this doesn't align with your current needs, no worries! You're welcome to join my
-      <a href="https://discord.gg/Hp4agqy">Discord community</a> to stay connected.
-      </p>
+      <!-- Entry offer -->
+      <section class="audit">
+        <h2>Start with a Technical Architecture Audit</h2>
+        <p>A two-week deep dive into your codebase, infrastructure, and technical decisions. You get a written report covering:</p>
+        <ul>
+          <li>Architectural risks and single points of failure</li>
+          <li>Technical debt hotspots costing you velocity</li>
+          <li>Reliability gaps that will bite you at scale</li>
+          <li>A prioritized roadmap with concrete next steps</li>
+        </ul>
+        <p>Fixed scope. Fixed price. No ongoing commitment required.</p>
+        <p>Most audits surface significant savings in wasted engineering time &mdash; making the ROI obvious before any further engagement.</p>
+        <a href="mailto:hi@jappie.me" class="cta-button">Discuss an audit</a>
+      </section>
 
-      <p>
-      Ready to elevate your project? <a href="mailto:hi@jappie.me">Hire me</a>!
-      </p>
-      <p>
-      My preferred tools of trade are:
-      <ul>
-        <li>Haskell</li>
-        <li>Nix</li>
-        <li>Agda</li>
-      </ul>
-      I'm also proficient with most major programming languages and am always ready to tackle new challenges.
+      <!-- Social proof -->
+      <section class="results" id="results">
+        <h2>Selected work</h2>
+        <div class="testimonials">
+          <blockquote>
+            <p>Architected and built core platform components for a <strong>reinsurance technology company</strong> streamlining the global reinsurance market. The system handles complex multi-party deal workflows where data integrity and correctness are non-negotiable.</p>
+          </blockquote>
+          <blockquote>
+            <p>Led technical architecture decisions for a <strong>financial technology platform</strong>, delivering production systems with the reliability guarantees that financial infrastructure demands.</p>
+          </blockquote>
+        </div>
+      </section>
 
-      For more insights and examples of my work, please visit my <a href="https://jappie.me">blog</a>.
-      </p>
-    </article>
+      <!-- Engagement model -->
+      <section class="engagement" id="approach">
+        <h2>How we work together</h2>
+        <div class="card-grid">
+          <div class="card">
+            <h3>Advisory retainer</h3>
+            <p>Strategic technical oversight. Architecture reviews, technical hiring guidance, vendor evaluation. A few hours per week.</p>
+          </div>
+          <div class="card">
+            <h3>Operational retainer</h3>
+            <p>Embedded in your team 1&ndash;2 days per week. I make technical decisions and implement them. Full decision-making authority.</p>
+          </div>
+          <div class="card">
+            <h3>Project engagement</h3>
+            <p>Fixed-scope builds. I architect and deliver the system end to end. You get a working product, not a specification.</p>
+          </div>
+        </div>
+        <p class="engagement-note">All engagements start with a conversation about your situation. I'll tell you honestly whether I can help.</p>
+      </section>
+
+      <!-- About -->
+      <section class="about">
+        <h2>About</h2>
+        <p>I'm Jappie Klooster. I run a consultancy that makes technical decisions for companies and then executes on them. Not advice &mdash; decisions and delivery.</p>
+        <p>I build with technologies chosen for correctness and long-term maintainability, including Haskell, Nix, and formal verification tools. But the technology is an implementation detail &mdash; what matters is that your system works, scales, and doesn't wake anyone up at 3am.</p>
+        <p>For more technical writing and case studies, visit my <a href="https://jappie.me/">blog</a>.</p>
+      </section>
+
+      <!-- Final CTA -->
+      <section class="final-cta">
+        <h2>Let's talk about your situation</h2>
+        <p>I take on 2&ndash;3 new engagements per year. If you're building something where correctness matters, <a href="mailto:hi@jappie.me">get in touch</a>.</p>
+        <a href="mailto:hi@jappie.me" class="cta-button">Book a conversation</a>
+      </section>
+    </main>
+
     <footer>
-    <small>
-      KVK: 95097872
-    </small> <br />
+      <p>
+        <a href="mailto:hi@jappie.me">hi@jappie.me</a>
+        &middot;
+        <a href="tel:+31644237437">+31 6 4423 7437</a>
+        &middot;
+        <a href="https://jappie.me/">Blog</a>
+      </p>
+      <p><small>Jappie Software B.V. &middot; KVK: 95097872</small></p>
     </footer>
-
-  <svg class="voronoi"></svg>
-  <script language="javascript">
-const svg = d3.select("svg");
-  const width = svg.node().clientWidth;
-  const height = svg.node().clientHeight;
-
-const points = d3.range(100).map(() => [Math.random() * width, Math.random() * height]);
-const delaunay = d3.Delaunay.from(points);
-const voronoi = delaunay.voronoi([0, 0, width, height]);
-
-svg.append("g")
-  .selectAll("path")
-  .data(voronoi.cellPolygons())
-  .join("path")
-    .attr("d", d => "M" + d.join("L") + "Z")
-    .attr("stroke", "#000")
-    .attr("fill", "none");
-
-  </script>
   </body>
 </html>

--- a/penguin/index.html
+++ b/penguin/index.html
@@ -25,7 +25,7 @@
     <main>
       <!-- Hero -->
       <section class="hero">
-        <h1>I make technical architecture decisions for companies building correctness-critical systems &mdash; and then I build them.</h1>
+        <h1>I architect correctness-critical systems &mdash; and then I build them.</h1>
         <p class="subtitle">Fractional CTO + implementation for companies that need reliable systems and can't afford to get the architecture wrong.</p>
         <a href="mailto:hi@jappie.me" class="cta-button">Book a conversation</a>
       </section>

--- a/penguin/index.html
+++ b/penguin/index.html
@@ -52,14 +52,14 @@
       <!-- Entry offer -->
       <section class="audit">
         <h2>Start with a Technical Architecture Audit</h2>
-        <p>A two-week deep dive into your codebase, infrastructure, and technical decisions. You get a written report covering:</p>
+        <p>A one-week deep dive into your codebase, infrastructure, and technical decisions. You get a written report covering:</p>
         <ul>
           <li>Architectural risks and single points of failure</li>
           <li>Technical debt hotspots costing you velocity</li>
           <li>Reliability gaps that will bite you at scale</li>
           <li>A prioritized roadmap with concrete next steps</li>
         </ul>
-        <p>Fixed scope. Fixed price. No ongoing commitment required.</p>
+        <p>&euro;5,000. Fixed scope. No ongoing commitment required.</p>
         <p>Most audits surface significant savings in wasted engineering time &mdash; making the ROI obvious before any further engagement.</p>
         <a href="mailto:hi@jappie.me" class="cta-button">Discuss an audit</a>
       </section>

--- a/penguin/index.html
+++ b/penguin/index.html
@@ -6,6 +6,7 @@
     <meta name="description" content="Fractional CTO and technical architecture for companies building correctness-critical systems. I make the decisions and build the systems." />
     <link rel="stylesheet" href="style.css" />
     <link rel="icon" href="favicon.ico" />
+    <script src="https://d3js.org/d3.v7.min.js"></script>
     <title>Jappie Software B.V. &mdash; Fractional CTO for Correctness-Critical Systems</title>
   </head>
   <body>
@@ -123,5 +124,21 @@
       </p>
       <p><small>Jappie Software B.V. &middot; KVK: 95097872</small></p>
     </footer>
+    <svg class="voronoi"></svg>
+    <script>
+      const svg = d3.select("svg.voronoi");
+      const width = svg.node().clientWidth;
+      const height = svg.node().clientHeight;
+      const points = d3.range(100).map(() => [Math.random() * width, Math.random() * height]);
+      const delaunay = d3.Delaunay.from(points);
+      const voronoi = delaunay.voronoi([0, 0, width, height]);
+      svg.append("g")
+        .selectAll("path")
+        .data(voronoi.cellPolygons())
+        .join("path")
+          .attr("d", d => "M" + d.join("L") + "Z")
+          .attr("stroke", "#ddd")
+          .attr("fill", "none");
+    </script>
   </body>
 </html>

--- a/penguin/index.html
+++ b/penguin/index.html
@@ -69,10 +69,10 @@
         <h2>Selected work</h2>
         <div class="testimonials">
           <blockquote>
-            <p>Architected and built core platform components for a <strong>reinsurance technology company</strong> streamlining the global reinsurance market. The system handles complex multi-party deal workflows where data integrity and correctness are non-negotiable.</p>
+            <p>Architected and built core platform components for a <strong>reinsurance technology company</strong> streamlining the global reinsurance market. The system handles complex multi-party deal workflows where data integrity and correctness are non-negotiable. <a href="https://jappie.me/the-peculiar-event-sourced-deadlock.html">Read about solving a production deadlock &rarr;</a></p>
           </blockquote>
           <blockquote>
-            <p>Led technical architecture decisions for a <strong>construction technology IoT platform</strong>, delivering production systems where device reliability and data correctness are critical at scale.</p>
+            <p>Led technical architecture decisions for a <strong>construction technology IoT platform</strong>, delivering production systems where device reliability and data correctness are critical at scale. <a href="https://jappie.me/stacked-against-us.html">Read the full story &rarr;</a> &middot; <a href="https://jappie.me/firmware-lemons.html">How I improved firmware throughput 7x &rarr;</a></p>
           </blockquote>
         </div>
       </section>

--- a/penguin/style.css
+++ b/penguin/style.css
@@ -1,69 +1,237 @@
-body{
-font-size:200%;
-margin: 0 auto;
-text-align: center;
-padding:0;
-}
-h1{
-margin-top:0;
-}
-img{
-width:15em;
-}
-article{
-text-align:left;
-max-width:60%;
-padding:5%;
-margin: 0 auto;
-    background: rgba(255, 255, 255, 0.85);
+/* Reset & base */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
-blockquote{
-    font-family: Georgia, serif;
-    font-style: italic;
-    margin: 2em 3em;
-    border-left: 1em solid #474d4d;
-    padding: 0.5em;
-    quotes: "\201C""\201D";
-    padding-left: 1em;
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 18px;
+  line-height: 1.7;
+  color: #1a1a1a;
+  background: #fafafa;
 }
 
-blockquote p::before{
-    content: open-quote;
-    color: #474d4d;
-    font-size: 4em;
-    line-height: 0.1em;
-    margin-right: 0.25em;
-    vertical-align: -0.4em;
+/* Top navigation */
+.top-nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1em 2em;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+.top-nav .logo {
+  font-weight: 700;
+  font-size: 1.1em;
+  color: #1a1a1a;
+}
+.top-nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1.5em;
+  flex-wrap: wrap;
+}
+.top-nav a {
+  color: #1a1a1a;
+  text-decoration: none;
+}
+.top-nav a:hover {
+  color: #2a5a3a;
+}
+.cta-link {
+  font-weight: 600;
 }
 
-.menu ul{
-    list-style:none;
-    margin-left:-3em;
-}
-.menu li{
-    display:inline;
-    margin: 0 1em;
+/* Shared section spacing */
+main section {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 3em 2em;
 }
 
-header{
-    margin-bottom: 2em;
-    background: rgba(255, 255, 255, 0.85);
+/* Hero */
+.hero {
+  padding-top: 5em;
+  padding-bottom: 4em;
+  max-width: 800px;
 }
-.xcd-when-to{
-    width:100%;
+.hero h1 {
+  font-size: 2em;
+  line-height: 1.3;
+  font-weight: 700;
+  margin-bottom: 0.8em;
+  color: #0d1f12;
+}
+.hero .subtitle {
+  font-size: 1.15em;
+  color: #444;
+  margin-bottom: 1.5em;
+  max-width: 650px;
 }
 
-
-small{
-    font-size:x-small;
+/* CTA button */
+.cta-button {
+  display: inline-block;
+  padding: 0.75em 2em;
+  background: #2a5a3a;
+  color: #fff;
+  text-decoration: none;
+  border-radius: 4px;
+  font-weight: 600;
+  font-size: 1em;
+  transition: background 0.2s;
+}
+.cta-button:hover {
+  background: #1e4029;
 }
 
-        .voronoi{
-            z-index: -1;
-width: 100%;
-  height: 100%;
-  position: fixed;
-  top: 0;
-  left: 0;
-        }
+/* Card grid */
+.card-grid {
+  list-style: none;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5em;
+  margin-top: 1.5em;
+}
+.card {
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 1.5em;
+}
+.card h3 {
+  font-size: 1.1em;
+  margin-bottom: 0.5em;
+  color: #0d1f12;
+}
+.card p {
+  color: #444;
+  font-size: 0.95em;
+}
+
+/* Section headings */
+h2 {
+  font-size: 1.6em;
+  margin-bottom: 0.8em;
+  color: #0d1f12;
+}
+
+/* Audit section */
+.audit {
+  background: #f0f5f1;
+  border-radius: 8px;
+  max-width: 800px;
+  padding: 3em 2em;
+}
+.audit ul {
+  margin: 1em 0 1em 1.5em;
+  color: #333;
+}
+.audit li {
+  margin-bottom: 0.4em;
+}
+
+/* Testimonials / social proof */
+.testimonials {
+  display: grid;
+  gap: 1.5em;
+  margin-top: 1em;
+}
+blockquote {
+  background: #fff;
+  border-left: 4px solid #2a5a3a;
+  padding: 1.5em 1.5em 1.5em 2em;
+  border-radius: 0 6px 6px 0;
+  margin: 0;
+  color: #333;
+  font-size: 0.95em;
+}
+blockquote strong {
+  color: #0d1f12;
+}
+
+/* Engagement model */
+.engagement-note {
+  margin-top: 1.5em;
+  color: #555;
+  font-style: italic;
+}
+
+/* About */
+.about p {
+  margin-bottom: 1em;
+  color: #333;
+}
+.about a {
+  color: #2a5a3a;
+}
+
+/* Final CTA */
+.final-cta {
+  text-align: center;
+  padding: 4em 2em;
+}
+.final-cta p {
+  margin-bottom: 1.5em;
+  color: #444;
+  font-size: 1.1em;
+}
+.final-cta a:not(.cta-button) {
+  color: #2a5a3a;
+  font-weight: 600;
+}
+
+/* Footer */
+footer {
+  text-align: center;
+  padding: 2em;
+  border-top: 1px solid #e0e0e0;
+  color: #666;
+}
+footer a {
+  color: #2a5a3a;
+  text-decoration: none;
+}
+footer a:hover {
+  text-decoration: underline;
+}
+footer small {
+  font-size: 0.8em;
+  color: #999;
+}
+
+/* For-who section */
+.for-who {
+  border-top: 1px solid #e8e8e8;
+}
+
+/* Results section */
+.results {
+  border-top: 1px solid #e8e8e8;
+}
+
+/* Responsive */
+@media (max-width: 700px) {
+  .top-nav {
+    flex-direction: column;
+    gap: 0.5em;
+    text-align: center;
+  }
+  .top-nav ul {
+    justify-content: center;
+  }
+  .hero h1 {
+    font-size: 1.5em;
+  }
+  .hero {
+    padding-top: 3em;
+  }
+  main section {
+    padding: 2em 1.2em;
+  }
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/penguin/style.css
+++ b/penguin/style.css
@@ -56,6 +56,9 @@ main section {
   padding-top: 5em;
   padding-bottom: 4em;
   max-width: 800px;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
 }
 .hero h1 {
   font-size: 2em;

--- a/penguin/style.css
+++ b/penguin/style.css
@@ -212,6 +212,16 @@ footer small {
   border-top: 1px solid #e8e8e8;
 }
 
+/* Voronoi background */
+.voronoi {
+  z-index: -1;
+  width: 100%;
+  height: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+}
+
 /* Responsive */
 @media (max-width: 700px) {
   .top-nav {


### PR DESCRIPTION
## Summary

Complete rewrite of the penguin.engineer / jappiesoftware.com landing page to align with the acquisition strategy documents. The old page led with technology (Haskell, Nix, Agda) and positioned as a hired programmer. The new page leads with client problems and positions as a fractional CTO who decides AND builds.

Key changes:
- **Problem-led headline**: "I make technical architecture decisions for companies building correctness-critical systems -- and then I build them"
- **Vertical focus**: Financial technology / correctness-critical systems
- **Productized entry offer**: Technical Architecture Audit section with clear scope and deliverables
- **Anonymous social proof**: Two client references (reinsurance tech platform, financial technology platform) described without naming companies
- **Engagement model**: Three tiers clearly described (advisory retainer, operational retainer, project engagement)
- **"Who I work with" section**: Helps ideal clients self-select (fintech, non-technical founders, teams with tech debt)
- **CTA reframing**: "Book a conversation" replaces "Hire me" -- expert positioning instead of labor positioning
- **Discord removed from homepage**: Not a sales channel, dilutes the primary CTA
- **Tech stack subordinated**: Haskell/Nix mentioned in About section, framed through outcomes
- **D3.js voronoi removed**: Was loading 100KB+ library for a decorative background
- **Proper mobile responsive design**: Works on all screen sizes
- **SEO meta description added**

## Rationale

Based on the strategy documents at jappeace-sloth/jappie-software/strategy/, particularly:
- `practical-acquisition-plan-v2.org`: "Haskell never comes up until the second or third conversation"
- The fractional CTO + implementation positioning model
- The technical audit as a productized entry offer (35% conversion to larger engagements)
- Problem-led content targeting "problem aware" prospects

## Test plan

- [ ] Visual review of the new page layout
- [ ] Check mobile responsiveness
- [ ] Verify all links work (email, phone, blog)
- [ ] Review copy for accuracy and tone
- [ ] CI build passes (changes are static HTML/CSS only in penguin/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)