### PR TITLE
Retarget landing page for pre-seed founders

### DIFF
--- a/penguin/index.html
+++ b/penguin/index.html
@@ -3,11 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="Fractional CTO and technical architecture for companies building correctness-critical systems. I make the decisions and build the systems." />
+    <meta name="description" content="Fractional CTO for startups. Technical leadership for non-technical founders &mdash; I make the technology decisions so you can focus on your business." />
     <link rel="stylesheet" href="style.css" />
     <link rel="icon" href="favicon.ico" />
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <title>Jappie Software B.V. &mdash; Fractional CTO for Correctness-Critical Systems</title>
+    <title>Jappie Software B.V. &mdash; Fractional CTO for Startups</title>
   </head>
   <body>
     <header>
@@ -26,8 +26,8 @@
     <main>
       <!-- Hero -->
       <section class="hero">
-        <h1>I architect correctness-critical systems &mdash; and then I build them.</h1>
-        <p class="subtitle">Fractional CTO + implementation for companies that need reliable systems and can't afford to get the architecture wrong.</p>
+        <h1>Your startup needs technical leadership &mdash; not just another developer.</h1>
+        <p class="subtitle">I&rsquo;m a fractional CTO who makes the technology decisions so you can focus on growing your business. No jargon, no guesswork &mdash; just a clear technical direction.</p>
         <a href="mailto:hi@jappie.me" class="cta-button">Book a conversation</a>
       </section>
 
@@ -36,33 +36,33 @@
         <h2>Who I work with</h2>
         <ul class="card-grid">
           <li class="card">
-            <h3>Financial technology and IoT</h3>
-            <p>Where a bug in production means real money lost or devices behaving dangerously. You need systems that are correct by construction, not correct by accident.</p>
+            <h3>Non-technical founders building a tech product</h3>
+            <p>You have the vision and the customers, but you need someone who can translate that into the right technology choices &mdash; and make sure they get built properly.</p>
           </li>
           <li class="card">
-            <h3>Non-technical founders</h3>
-            <p>You need someone who makes technical decisions with authority, not someone who waits to be told what to build.</p>
+            <h3>Startups scaling past their MVP</h3>
+            <p>Your agency-built prototype is breaking under real usage. You need someone to assess what you have, decide what to keep, and chart a path to a system that scales.</p>
           </li>
           <li class="card">
-            <h3>Teams drowning in technical debt</h3>
-            <p>Your system grew faster than your architecture. Incidents are increasing. You need someone to untangle the mess and build a path forward.</p>
+            <h3>Funded startups hiring their first engineers</h3>
+            <p>You&rsquo;re ready to build a team but don&rsquo;t know how to evaluate developers or set technical direction. I help you hire right and get your engineering culture started.</p>
           </li>
         </ul>
       </section>
 
       <!-- Entry offer -->
       <section class="audit">
-        <h2>Start with a Technical Architecture Audit</h2>
-        <p>A one-week deep dive into your codebase, infrastructure, and technical decisions. You get a written report covering:</p>
+        <h2>Start with a Technical Review</h2>
+        <p>A one-day assessment of where your technology stands and what to do next. You get a written report covering:</p>
         <ul>
-          <li>Architectural risks and single points of failure</li>
-          <li>Technical debt hotspots costing you velocity</li>
-          <li>Reliability gaps that will bite you at scale</li>
-          <li>A prioritized roadmap with concrete next steps</li>
+          <li>How your current setup is working (and where it&rsquo;s not)</li>
+          <li>The biggest risks that could slow you down or cost you money</li>
+          <li>What to prioritize in the next 3 months</li>
+          <li>Clear recommendations you can act on immediately</li>
         </ul>
-        <p>&euro;5,000. Fixed scope. No ongoing commitment required.</p>
-        <p>Most audits surface significant savings in wasted engineering time &mdash; making the ROI obvious before any further engagement.</p>
-        <a href="mailto:hi@jappie.me" class="cta-button">Discuss an audit</a>
+        <p>&euro;1,000. Fixed scope. No ongoing commitment required.</p>
+        <p>Most reviews uncover quick wins that save far more than the cost &mdash; and give you clarity on whether you need ongoing technical leadership.</p>
+        <a href="mailto:hi@jappie.me" class="cta-button">Book a review</a>
       </section>
 
       <!-- Social proof -->
@@ -70,13 +70,13 @@
         <h2>Selected work</h2>
         <div class="testimonials">
           <blockquote>
-            <p>Architected and built core platform components for a <strong>reinsurance technology company</strong> streamlining the global reinsurance market. The system handles complex multi-party deal workflows where data integrity and correctness are non-negotiable. <a href="https://jappie.me/the-peculiar-event-sourced-deadlock.html">Read about solving a production deadlock &rarr;</a></p>
+            <p>Helped a <strong>reinsurance technology startup</strong> build and ship their core platform &mdash; taking the product from early architecture to handling live deals in production. <a href="https://jappie.me/the-peculiar-event-sourced-deadlock.html">Read about solving a production issue &rarr;</a></p>
           </blockquote>
           <blockquote>
-            <p>Led technical architecture decisions for a <strong>construction technology IoT platform</strong>, delivering production systems where device reliability and data correctness are critical at scale. <a href="https://jappie.me/stacked-against-us.html">Read the full story &rarr;</a> &middot; <a href="https://jappie.me/firmware-lemons.html">How I improved firmware throughput 7x &rarr;</a></p>
+            <p>Served as technical lead for a <strong>construction IoT startup</strong>, making architecture decisions that let them scale from pilot to production. Improved device performance 7x along the way. <a href="https://jappie.me/stacked-against-us.html">Read the full story &rarr;</a> &middot; <a href="https://jappie.me/firmware-lemons.html">The 7x improvement &rarr;</a></p>
           </blockquote>
           <blockquote>
-            <p>Designed a new architecture for <strong>Cabal</strong>, Haskell's core package manager used by every Haskell project. Wrote the formal proposal, built consensus among the maintainers, and got it <a href="https://github.com/haskell/cabal-proposals/pull/5#issuecomment-4306838512">accepted by the core team &rarr;</a></p>
+            <p>Mentored early-stage founders on technical strategy through accelerator programs, helping non-technical teams make confident technology decisions without overspending.</p>
           </blockquote>
         </div>
       </section>
@@ -87,15 +87,15 @@
         <div class="card-grid">
           <div class="card">
             <h3>Advisory retainer</h3>
-            <p>Strategic technical oversight. Architecture reviews, technical hiring guidance, vendor evaluation. A few hours per week.</p>
+            <p>A few hours per week of strategic guidance. I review your technical decisions, help you evaluate hires and vendors, and make sure you&rsquo;re spending your budget wisely.</p>
           </div>
           <div class="card">
             <h3>Operational retainer</h3>
-            <p>Embedded in your team 1&ndash;2 days per week. I make technical decisions and implement them. Full decision-making authority.</p>
+            <p>Embedded in your team 1&ndash;2 days per week. I set the technical direction, work alongside your developers, and make sure things get built right.</p>
           </div>
           <div class="card">
             <h3>Project engagement</h3>
-            <p>Fixed-scope builds. I architect and deliver the system end to end. You get a working product, not a specification.</p>
+            <p>Fixed-scope builds. I design and deliver the system end to end. You get a working product, not a specification document.</p>
           </div>
         </div>
         <p class="engagement-note">All engagements start with a conversation about your situation. I'll tell you honestly whether I can help.</p>
@@ -104,15 +104,15 @@
       <!-- About -->
       <section class="about">
         <h2>About</h2>
-        <p>I'm Jappie Klooster. I run a consultancy that makes technical decisions for companies and then executes on them. Not advice &mdash; decisions and delivery.</p>
-        <p>I build with technologies chosen for correctness and long-term maintainability, including Haskell, Nix, and formal verification tools. But the technology is an implementation detail &mdash; what matters is that your system works, scales, and doesn't wake anyone up at 3am.</p>
-        <p>For more technical writing and case studies, visit my <a href="https://jappie.me/">blog</a>.</p>
+        <p>I'm Jappie Klooster. I&rsquo;ve spent years helping startups make the right technical decisions &mdash; and then building the systems to back them up. Not advice that sits in a document &mdash; decisions and delivery.</p>
+        <p>I use technologies chosen for reliability and long-term maintainability (including Haskell and Nix), but the technology is an implementation detail &mdash; what matters is that your product works, scales, and doesn&rsquo;t fall over when your users show up.</p>
+        <p>For more writing and case studies, visit my <a href="https://jappie.me/">blog</a>.</p>
       </section>
 
       <!-- Final CTA -->
       <section class="final-cta">
-        <h2>Let's talk about your situation</h2>
-        <p>I take on 2&ndash;3 new engagements per year. If you're building something where correctness matters, <a href="mailto:hi@jappie.me">get in touch</a>.</p>
+        <h2>Let's talk about your startup</h2>
+        <p>If you&rsquo;re building something and need technical leadership you can trust, <a href="mailto:hi@jappie.me">get in touch</a>. I&rsquo;m always happy to have an initial conversation &mdash; no commitment required.</p>
         <a href="mailto:hi@jappie.me" class="cta-button">Book a conversation</a>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- Rewrites all copy on jappiesoftware.com to speak to non-technical founders from accelerator programs (Startupbootcamp, Techstars, Antler) instead of established companies
- Replaces one-week EUR 5,000 architecture audit with one-day EUR 1,000 technical review as entry point accessible to pre-seed budgets
- Drops Cabal case study and enterprise framing, adds accelerator mentoring as social proof

## Changes
- **Meta/title**: "Fractional CTO for Startups" instead of "Correctness-Critical Systems"
- **Hero**: Leads with founder's problem, not technical capability
- **Cards**: Non-technical founders, post-MVP scaling, first engineering hires
- **Entry offer**: One-day technical review at EUR 1,000 (proportional to time reduction)
- **Social proof**: Business outcomes framing, accelerator mentoring mention
- **Engagement models**: Softer "what this means for you" language
- **About**: Leads with startup experience, brief mention of tech stack
- **CTA**: Welcoming tone, no exclusivity signaling

## Test plan
- [ ] Open penguin/index.html in browser, verify all sections render correctly
- [ ] Check all mailto: and href links work
- [ ] Read through copy for tone consistency
- [ ] Verify no broken HTML structure


🤖 Generated with [Claude Code](https://claude.com/claude-code)