### PR TITLE
Replace penguin.engineer with jappiesoftware.com

### DIFF
--- a/content-nl/back-to-netherlands.md
+++ b/content-nl/back-to-netherlands.md
@@ -83,7 +83,7 @@ en het aanbod van Daisee was niet zo mooi als ik had verwacht.
 Terug thuis ben ik,
 niet dat het slecht is, gewoon plotseling.
 Ik blijf hier een tijdje,
-op afstand werken voor Daisee als een [bedrijf](http://penguin.engineer/)!
+op afstand werken voor Daisee als een [bedrijf](https://jappiesoftware.com/)!
 Ondertussen werkt Daisee aan een werkvisum voor Australië.
 Dit lijkt veel beter dan de Filipijnen,
 dat voelde meer als een gouden kooi.

--- a/content/back-to-netherlands.md
+++ b/content/back-to-netherlands.md
@@ -83,7 +83,7 @@ and the offer from Daisee wasn't as nice as I expected.
 Back home I am,
 not that it's bad, just sudden.
 I'll be staying here for some time,
-doing remote work for Daisee as a [company](http://penguin.engineer/)!
+doing remote work for Daisee as a [company](https://jappiesoftware.com/)!
 Meanwhile Daisee is working on a work visa for Australia.
 This seems much better than the Philippines,
 which felt more like a golden prison.

--- a/default.nix
+++ b/default.nix
@@ -30,8 +30,8 @@ pkgs.stdenv.mkDerivation {
     find _site \( -name '*.jpg' -o -name '*.jpeg' \) -exec jpegtran -copy none -optimize -progressive -outfile {} {} \;
   '';
   installPhase = ''
-    mkdir -p $out/jappieklooster.nl $out/penguin.engineer
+    mkdir -p $out/jappieklooster.nl $out/jappiesoftware.com
     cp -r _site/* $out/jappieklooster.nl/
-    cp -r _penguin-site/* $out/penguin.engineer/
+    cp -r _penguin-site/* $out/jappiesoftware.com/
   '';
 }

--- a/nginx/sites-available/jappiesoftware.com
+++ b/nginx/sites-available/jappiesoftware.com
@@ -19,11 +19,11 @@ server {
 	listen [::]:80;
 
 	#main website
-	root /var/www/penguin.engineer;
+	root /var/www/jappiesoftware.com;
 
 	index index.html index.htm index.nginx-debian.html;
 
-	server_name penguin.engineer penguin.engineer;
+	server_name jappiesoftware.com jappiesoftware.com;
 
 	location / {
 		add_header X-Frame-Options "SAMEORIGIN";

--- a/penguin/blog.css
+++ b/penguin/blog.css
@@ -1,4 +1,4 @@
-/* Blog-specific styles for penguin.engineer */
+/* Blog-specific styles for jappiesoftware.com */
 
 .blog-listing {
   max-width: 48rem;

--- a/penguin/content/agentic-development-founder-guide.org
+++ b/penguin/content/agentic-development-founder-guide.org
@@ -125,7 +125,7 @@ bugs.
 This guide distils lessons from producing 50,000 lines of code with AI agents
 across multiple production systems. For the full technical breakdown — including
 specific prompting techniques, testing strategies, and failure modes — see the
-[[https://penguin.engineer/blog/a-practical-guide-to-agentic-software-development.html][detailed technical write-up]].
+[[https://jappiesoftware.com/blog/a-practical-guide-to-agentic-software-development.html][detailed technical write-up]].
 
 * Let's talk
 

--- a/shake/Shakefile.hs
+++ b/shake/Shakefile.hs
@@ -536,7 +536,7 @@ copyStaticAssets = do
 -- Penguin site generation
 -- =============================================================================
 
--- | Generate the penguin.engineer site into _penguin-site/
+-- | Generate the jappiesoftware.com site into _penguin-site/
 generatePenguinSite :: SiteConfig -> [Article] -> IO ()
 generatePenguinSite config articles = do
   let sortedArticles = sortBy (\a b -> compare (Down (articleDate a)) (Down (articleDate b))) articles

--- a/shake/Types.hs
+++ b/shake/Types.hs
@@ -169,8 +169,8 @@ penguinSiteConfig :: SiteConfig
 penguinSiteConfig = SiteConfig
   { siteAuthor = "Jappie J. T. Klooster"
   , siteName   = "Jappie Software B.V."
-  , siteUrl    = "https://penguin.engineer"
-  , feedDomain = "https://penguin.engineer"
+  , siteUrl    = "https://jappiesoftware.com"
+  , feedDomain = "https://jappiesoftware.com"
   , feedAtom   = "blog/atom"
   , siteLinks  =
       [ NavLink "Services" "#services" "What I offer" "services"


### PR DESCRIPTION
## Summary
- Replace all `penguin.engineer` references with `jappiesoftware.com` since the domain no longer exists
- Fix "detailed technical write-up" link in founder guide article
- Update `siteUrl` and `feedDomain` in `penguinSiteConfig`
- Update nix build output directory name
- Update blog content links in back-to-netherlands posts (EN + NL)
- Rename and update nginx config
- Update CSS and code comments

## Test plan
- [ ] Build succeeds (`cabal build` / `nix-build`)
- [ ] Deployed site URLs and RSS feed reference jappiesoftware.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)