### PR TITLE
Fix list alignment on migrate-mijnwebwinkel page

### DIFF
--- a/penguin/style.css
+++ b/penguin/style.css
@@ -128,11 +128,21 @@ h2 {
   max-width: 800px;
   padding: 3em 2em;
 }
-.audit ul {
+.audit ul,
+.audit ol {
   margin: 1em 0 1em 1.5em;
   color: #333;
 }
 .audit li {
+  margin-bottom: 0.4em;
+}
+
+/* Results section lists */
+.results ul {
+  margin: 1em 0 1em 1.5em;
+  color: #333;
+}
+.results li {
   margin-bottom: 0.4em;
 }
 


### PR DESCRIPTION
## Summary
- The audit section ("Hoe het werkt") used an `<ol>` but CSS only had rules for `.audit ul` — the ordered list had no controlled margins
- The results section ("Waarom via ons?") `<ul>` had no list styling at all
- Both now have consistent `1.5em` left margins matching the page's existing list style conventions

## Test plan
- [ ] Visit /migrate-mijnwebwinkel.html and verify the numbered list in "Hoe het werkt" aligns with section text
- [ ] Verify the bullet list in "Waarom via ons?" aligns consistently with the ordered list above

🤖 Generated with [Claude Code](https://claude.com/claude-code)