### PR TITLE
Fix card button spacing and blog heading hierarchy

### DIFF
--- a/penguin/blog.css
+++ b/penguin/blog.css
@@ -50,6 +50,14 @@
 .summary {
   color: #444;
 }
+.summary h1,
+.summary h2,
+.summary h3 {
+  font-size: 1.1em;
+  color: #555;
+  margin-top: 0.5em;
+  margin-bottom: 0.3em;
+}
 
 /* Pagination */
 .pagination {

--- a/penguin/style.css
+++ b/penguin/style.css
@@ -113,6 +113,10 @@ main section {
   color: #444;
   font-size: 0.95em;
 }
+.card .cta-button {
+  margin-top: 1em;
+  padding: 0.5em 1.2em;
+}
 
 /* Section headings */
 h2 {


### PR DESCRIPTION
## Summary
- Add top margin and reduce padding on CTA buttons inside product cards so "Learn more" has breathing room and fits on one line
- Style h1/h2/h3 inside blog summary previews to be smaller and lighter, preventing the double-heading effect on the blog index

## Test plan
- [ ] Check /migrate-mijnwebwinkel.html list alignment (from previous merged PR)
- [ ] Check homepage Products section — "Learn more" button should have space above it and not line-break
- [ ] Check /blog/ — article content headings ("Introduction", etc.) should look subordinate to the article title

🤖 Generated with [Claude Code](https://claude.com/claude-code)