### PR TITLE
Improve blog index spacing and image layout

### DIFF
--- a/theme/static/css/all.css
+++ b/theme/static/css/all.css
@@ -73,6 +73,22 @@ a.tag:first-letter {
 .entry-content figure {
   overflow: hidden; }
 
+/* Blog index: tighten summary spacing and float images */
+article:not(.single) .entry-content > :first-child {
+  margin-top: 0; }
+
+article:not(.single) .entry-content figure {
+  float: right;
+  width: 35%;
+  margin: 0 0 0.5em 1em;
+  max-height: 15em;
+  overflow: hidden; }
+
+article:not(.single) .entry-content figure img {
+  width: 100%;
+  max-height: 14em;
+  object-fit: cover; }
+
 .entry-content a:first-letter {
   color: lightslategrey;
   text-shadow: none; }


### PR DESCRIPTION
## Summary
- Remove excess top margin between article title/date and content on the blog index page
- Float article images to the right at 35% width with max-height cap, so text wraps beside them
- Scoped to index summaries only via `article:not(.single)` — full article pages are unaffected

## Test plan
- [ ] Check jappie.me index — title-to-text gap should be tighter
- [ ] Articles with images (Death to type classes, Stacked against us, Firmware lemons) should have images floated right with text wrapping
- [ ] Full article pages (e.g. /death-to-type-classes.html) should be unchanged
- [ ] Mobile (375px) — images still fit, layout not broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)