### PR TITLE
Fix Controle step to describe working test shop

### DIFF
--- a/shake/PenguinTemplates.hs
+++ b/shake/PenguinTemplates.hs
@@ -218,7 +218,7 @@ mijnwebwinkelMigrationPage = penguinBaseTemplate "MijnWebwinkel naar Shopify mig
           " \8212 Ons programma crawlt uw MijnWebwinkel-shop en slaat alle data op."
         H.li $ do
           H.strong "Controle"
-          " \8212 U krijgt een rapport met aantallen: producten, vertalingen, ontbrekende data."
+          " \8212 U krijgt een werkende Shopify-testshop die u zelf kunt controleren voordat we live gaan."
         H.li $ do
           H.strong "Import"
           " \8212 We importeren alles in uw Shopify-shop: producten, vertalingen, collections, redirects."


### PR DESCRIPTION
## Summary
- The "Controle" step in the migration process incorrectly described delivering a data rapport
- Changed to describe delivering a working Shopify test shop the customer can verify before going live

## Test plan
- [ ] Check jappiesoftware.com/migrate-mijnwebwinkel.html — "Controle" step should mention a working test shop

🤖 Generated with [Claude Code](https://claude.com/claude-code)