### PR TITLE
Add Lightspeed migration landing page

### DIFF
--- a/shake/PenguinTemplates.hs
+++ b/shake/PenguinTemplates.hs
@@ -5,6 +5,7 @@ module PenguinTemplates
   , penguinArticlePage
   , mijnwebwinkelMigrationPage
   , ccvshopMigrationPage
+  , lightspeedMigrationPage
   , PageMeta(..)
   , defaultPageMeta
   ) where
@@ -205,6 +206,10 @@ penguinIndexPage = penguinBaseTemplate indexMeta $
           H.h3 "CCV Shop Migration Tool"
           H.p $ H.preEscapedToHtml ("Migrate your webshop from CCV Shop to Shopify &mdash; products, categories, translations, images, inventory and SEO redirects. Fully automated." :: Text)
           H.a ! A.href "/migrate-ccvshop.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Learn more &rarr;" :: Text)
+        H.li ! A.class_ "card" $ do
+          H.h3 "Lightspeed Migration Tool"
+          H.p $ H.preEscapedToHtml ("Migrate your webshop from Lightspeed to Shopify &mdash; products, categories, translations, images, inventory and SEO redirects. No traffic loss." :: Text)
+          H.a ! A.href "/migrate-lightspeed.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Learn more &rarr;" :: Text)
         H.li ! A.class_ "card" $ do
           H.h3 "Massapp"
           H.p "Bulk WhatsApp messaging for businesses. Reach your customers at scale through the official WhatsApp Business API."
@@ -643,6 +648,202 @@ ccvFaqJsonLd =
       , faqEntry
           "Hoe werken de SEO-redirects precies?"
           "We genereren automatisch 301-redirects van elke oude URL naar het nieuwe Shopify-adres. Uw Google-rankings en backlinks blijven behouden."
+      , "]}"
+      ]
+
+    faqEntry :: Text -> Text -> Text
+    faqEntry question answer = T.concat
+      [ "{\"@type\":\"Question\""
+      , ",\"name\":" <> jsonString question
+      , ",\"acceptedAnswer\":{\"@type\":\"Answer\""
+      , ",\"text\":" <> jsonString answer
+      , "}}"
+      ]
+
+    jsonString :: Text -> Text
+    jsonString txt = "\"" <> escapeJsonText txt <> "\""
+
+    escapeJsonText :: Text -> Text
+    escapeJsonText = T.concatMap escapeJsonChar
+
+    escapeJsonChar :: Char -> Text
+    escapeJsonChar '"'  = "\\\""
+    escapeJsonChar '\\' = "\\\\"
+    escapeJsonChar '\n' = "\\n"
+    escapeJsonChar '\r' = "\\r"
+    escapeJsonChar '\t' = "\\t"
+    escapeJsonChar c    = T.singleton c
+
+-- =============================================================================
+-- Lightspeed migration landing page
+-- =============================================================================
+
+lightspeedMigrationPage :: Html
+lightspeedMigrationPage = penguinBaseTemplate lightspeedMeta $
+  H.main $ do
+    -- Hero
+    H.section ! A.class_ "hero" $ do
+      H.h1 "Ontsnap Lightspeed"
+      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Lightspeed duwt u richting hun nieuwe platform of de deur uit. Ondertussen draait uw webshop op verouderde software die steeds minder krijgt. Wij verhuizen uw complete shop naar Shopify &mdash; geautomatiseerd, zonder dataverlies, zonder SEO-verlies." :: Text)
+      H.a ! A.href "mailto:hi@jappie.me?subject=Lightspeed%20migratie" ! A.class_ "cta-button" $ "Vraag een offerte aan"
+
+    -- What we migrate
+    H.section ! A.class_ "for-who" ! A.id "what" $ do
+      H.h2 "Wat we migreren"
+      H.ul ! A.class_ "card-grid" $ do
+        H.li ! A.class_ "card" $ do
+          H.h3 "Producten & varianten"
+          H.p "Alle producten inclusief titels, beschrijvingen, prijzen, afbeeldingen, SKU's en varianten. Automatisch overgezet naar Shopify-formaat."
+        H.li ! A.class_ "card" $ do
+          H.h3 "Meerdere talen"
+          H.p $ H.preEscapedToHtml ("Vertalingen worden correct gekoppeld. Uw klanten blijven uw shop in hun eigen taal zien &mdash; ook de URL-slugs." :: Text)
+        H.li ! A.class_ "card" $ do
+          H.h3 "Klantaccounts & bestellingen"
+          H.p "Klantgegevens, bestelgeschiedenis en accountdata worden overgezet zodat uw klanten direct kunnen inloggen op de nieuwe shop."
+        H.li ! A.class_ "card" $ do
+          H.h3 "SEO-redirects"
+          H.p "301-redirects van elke oude URL naar de nieuwe URL. Uw Google-posities en backlinks blijven behouden. Geen 70% verkeersverlies zoals bij een onbegeleide migratie."
+        H.li ! A.class_ "card" $ do
+          H.h3 $ H.preEscapedToHtml ("Categorie&euml;n & navigatie" :: Text)
+          H.p $ H.preEscapedToHtml ("De volledige categorieboom wordt overgezet naar Shopify Collections met vertaalde titels en het navigatiemenu." :: Text)
+        H.li ! A.class_ "card" $ do
+          H.h3 "Voorraad & prijzen"
+          H.p "Voorraadbeheer, staffelprijzen en per-variant pricing worden correct overgezet. Uw voorraadniveaus kloppen direct in Shopify."
+
+    -- How it works
+    H.section ! A.class_ "audit" $ do
+      H.h2 "Hoe het werkt"
+      H.ol $ do
+        H.li $ do
+          H.strong "Scan"
+          " \8212 Ons programma leest uw Lightspeed-shop volledig uit en slaat alle data op."
+        H.li $ do
+          H.strong "Controle"
+          " \8212 U krijgt een werkende testshop die u zelf kunt controleren voordat we live gaan."
+        H.li $ do
+          H.strong "Import"
+          " \8212 We importeren alles in uw Shopify-shop: producten, vertalingen, collections, redirects."
+        H.li $ do
+          H.strong "Verificatie"
+          " \8212 Samen controleren we steekproefsgewijs of alles klopt."
+
+    -- Pricing
+    H.section ! A.class_ "engagement" ! A.id "pricing" $ do
+      H.h2 "Prijzen"
+      H.div ! A.class_ "card-grid" $ do
+        H.div ! A.class_ "card" $ do
+          H.h3 "Volledige migratie"
+          H.p ! A.class_ "price" $ H.preEscapedToHtml ("Vanaf &euro;750" :: Text)
+          H.p $ H.preEscapedToHtml ("Producten, afbeeldingen, vertalingen, categorie&euml;n, klantdata, SEO-redirects en voorraad. Prijs afhankelijk van de omvang van uw webshop." :: Text)
+      H.p ! A.class_ "engagement-note" $ H.preEscapedToHtml ("Vaste prijs, vooraf afgesproken. Geen verrassingen. Betaling na succesvolle migratie." :: Text)
+
+    -- Why us
+    H.section ! A.class_ "results" $ do
+      H.h2 "Waarom via ons?"
+      H.div ! A.class_ "testimonials" $ do
+        H.blockquote $
+          H.p $ H.preEscapedToHtml ("U bent niet de enige: 59% van alle Lightspeed-vertrekkers kiest Shopify. Maar zonder begeleiding raakt u uw Google-posities kwijt &mdash; wij hebben verhalen gezien van 70% verkeersverlies bij een onbegeleide migratie. Wij zorgen dat uw SEO intact blijft." :: Text)
+      H.ul $ do
+        H.li $ H.strong "Geen risico" >> H.preEscapedToHtml (" &mdash; u betaalt pas na succesvolle migratie" :: Text)
+        H.li $ H.strong "SEO-behoud" >> H.preEscapedToHtml (" &mdash; 301-redirects zodat uw Google-posities niet verloren gaan" :: Text)
+        H.li $ H.strong "Geautomatiseerd" >> H.preEscapedToHtml (" &mdash; geen handmatig overtypen, geen kopieerfouten" :: Text)
+        H.li $ H.strong "Meertalig" >> H.preEscapedToHtml (" &mdash; vertalingen correct gekoppeld via offici&euml;le Shopify APIs" :: Text)
+        H.li $ H.strong "Controleerbaar" >> H.preEscapedToHtml (" &mdash; u krijgt een testshop en kunt alles verifi&euml;ren voor de overstap" :: Text)
+        H.li $ H.strong "Vaste prijs" >> H.preEscapedToHtml (" &mdash; geen uurtarief, u weet vooraf wat het kost" :: Text)
+
+    -- FAQ
+    H.section ! A.class_ "about" $ do
+      H.h2 "Veelgestelde vragen"
+      H.dl $ do
+        H.dt "Hoe lang duurt een migratie?"
+        H.dd "De technische migratie duurt meestal 1-2 werkdagen. De voorbereiding en controle erbij: reken op een week totaal."
+        H.dt "Kan ik mijn domeinnaam behouden?"
+        H.dd "Ja. Na de migratie wijst u uw domein naar Shopify. Alle oude URLs worden automatisch doorgestuurd."
+        H.dt "Wat als er iets niet klopt na de migratie?"
+        H.dd "We controleren samen steekproefsgewijs. Eventuele correcties zijn inbegrepen in de vaste prijs."
+        H.dt "Verlies ik mijn Google-posities?"
+        H.dd "Nee. Wij genereren automatisch 301-redirects voor elke URL. Dit is het belangrijkste onderdeel van een veilige migratie en de reden dat u dit niet zelf wilt doen."
+        H.dt "Werkt het ook voor meerdere talen?"
+        H.dd "Ja. Het programma ondersteunt elke taalcombinatie die Lightspeed en Shopify beide ondersteunen."
+        H.dt "Worden mijn klantaccounts overgezet?"
+        H.dd "Ja. Klantgegevens en bestelgeschiedenis worden meegenomen zodat uw klanten direct verder kunnen."
+
+    -- Technical details
+    H.section ! A.class_ "for-who" $ do
+      H.h2 "Technische details"
+      H.ul ! A.class_ "card-grid" $ do
+        H.li ! A.class_ "card" $ do
+          H.h3 "SEO-redirects"
+          H.p "Volledige 301-redirect mapping van elke oude URL naar het nieuwe Shopify-adres. Uw Google-rankings, backlinks en organisch verkeer blijven behouden."
+        H.li ! A.class_ "card" $ do
+          H.h3 "Bulk-aanpassingen"
+          H.p $ H.preEscapedToHtml ("Grootschalige wijzigingen aan uw productdata tijdens de migratie: alt-teksten genereren, prijzen aanpassen, beschrijvingen opschonen &mdash; alles in &eacute;&eacute;n keer." :: Text)
+        H.li ! A.class_ "card" $ do
+          H.h3 "Voorraad & staffelprijzen"
+          H.p "Per-variant voorraadbeheer en staffelprijzen worden correct overgezet naar Shopify. Inclusief prijsverschillen per maat of kleur."
+        H.li ! A.class_ "card" $ do
+          H.h3 "Vertalingen & URL-slugs"
+          H.p $ H.preEscapedToHtml ("Meertalige content wordt correct gekoppeld via de offici&euml;le Shopify API. Inclusief vertaalde URL-slugs." :: Text)
+        H.li ! A.class_ "card" $ do
+          H.h3 "Klantdata & accounts"
+          H.p "Klantaccounts en bestelgeschiedenis worden overgezet zodat uw klanten direct verder kunnen op de nieuwe shop."
+        H.li ! A.class_ "card" $ do
+          H.h3 "Testshop & verificatie"
+          H.p "U krijgt een volledige testshop om alles te controleren. Pas na uw goedkeuring gaan we live. Correcties zijn inbegrepen."
+
+    -- CTA
+    H.section ! A.class_ "final-cta" $ do
+      H.h2 "Klaar om te ontsnappen?"
+      H.p $ H.preEscapedToHtml ("Lightspeed gaat u niet helpen met deze overstap. Wij wel." :: Text)
+      H.p $ do
+        "Stuur een mail naar "
+        H.a ! A.href "mailto:hi@jappie.me?subject=Lightspeed%20migratie" $ "hi@jappie.me"
+        " met een link naar uw webshop. U ontvangt binnen twee werkdagen een offerte."
+      H.a ! A.href "mailto:hi@jappie.me?subject=Lightspeed%20migratie" ! A.class_ "cta-button" $ "Ontsnap nu"
+  where
+    lightspeedMeta :: PageMeta
+    lightspeedMeta = PageMeta
+      { pageMetaTitle       = "Ontsnap Lightspeed \8212 Migratie naar Shopify \8212 Jappie Software B.V."
+      , pageMetaDescription = "Geautomatiseerde migratie van Lightspeed naar Shopify. Producten, vertalingen, afbeeldingen, voorraad en SEO-redirects. Geen verkeersverlies. Vanaf \8364\&750."
+      , pageMetaLang        = "nl"
+      , pageMetaCanonical   = Just "https://jappiesoftware.com/migrate-lightspeed.html"
+      , pageMetaOgImage     = Nothing
+      , pageMetaExtraHead   = lightspeedFaqJsonLd
+      }
+
+-- | FAQ structured data (JSON-LD) for the Lightspeed migration page.
+lightspeedFaqJsonLd :: Html
+lightspeedFaqJsonLd =
+  H.script ! A.type_ "application/ld+json" $ H.preEscapedToHtml lsFaqJson
+  where
+    lsFaqJson :: Text
+    lsFaqJson = T.concat
+      [ "{\"@context\":\"https://schema.org\""
+      , ",\"@type\":\"FAQPage\""
+      , ",\"mainEntity\":["
+      , faqEntry
+          "Hoe lang duurt een migratie?"
+          "De technische migratie duurt meestal 1-2 werkdagen. De voorbereiding en controle erbij: reken op een week totaal."
+      , ","
+      , faqEntry
+          "Kan ik mijn domeinnaam behouden?"
+          "Ja. Na de migratie wijst u uw domein naar Shopify. Alle oude URLs worden automatisch doorgestuurd."
+      , ","
+      , faqEntry
+          "Wat als er iets niet klopt na de migratie?"
+          "We controleren samen steekproefsgewijs. Eventuele correcties zijn inbegrepen in de vaste prijs."
+      , ","
+      , faqEntry
+          "Verlies ik mijn Google-posities?"
+          "Nee. Wij genereren automatisch 301-redirects voor elke URL. Dit is het belangrijkste onderdeel van een veilige migratie."
+      , ","
+      , faqEntry
+          "Werkt het ook voor meerdere talen?"
+          "Ja. Het programma ondersteunt elke taalcombinatie die Lightspeed en Shopify beide ondersteunen."
+      , ","
+      , faqEntry
+          "Worden mijn klantaccounts overgezet?"
+          "Ja. Klantgegevens en bestelgeschiedenis worden meegenomen zodat uw klanten direct verder kunnen."
       , "]}"
       ]
 

--- a/shake/Shakefile.hs
+++ b/shake/Shakefile.hs
@@ -39,7 +39,7 @@ import WaiAppStatic.Types (ssIndices, unsafeToPiece, ssAddTrailingSlash)
 
 import Feed (generateAtomFeed)
 import Metadata (parseMarkdownMeta, parseOrgMeta, parseDateField, parseTags, isDraft)
-import PenguinTemplates (penguinIndexPage, penguinBlogIndexPage, penguinArticlePage, mijnwebwinkelMigrationPage, ccvshopMigrationPage)
+import PenguinTemplates (penguinIndexPage, penguinBlogIndexPage, penguinArticlePage, mijnwebwinkelMigrationPage, ccvshopMigrationPage, lightspeedMigrationPage)
 import Slug (toSlug)
 import Templates
   ( renderArticlePage
@@ -576,6 +576,7 @@ generatePenguinSite config articles = do
   -- Product pages
   writeHtmlFile "_penguin-site/migrate-mijnwebwinkel.html" mijnwebwinkelMigrationPage
   writeHtmlFile "_penguin-site/migrate-ccvshop.html" ccvshopMigrationPage
+  writeHtmlFile "_penguin-site/migrate-lightspeed.html" lightspeedMigrationPage
 
   -- Individual article pages
   mapM_ (\art ->
@@ -650,6 +651,7 @@ generatePenguinSitemap articles = T.unlines $
   , sitemapUrl "https://jappiesoftware.com/"
   , sitemapUrl "https://jappiesoftware.com/migrate-mijnwebwinkel.html"
   , sitemapUrl "https://jappiesoftware.com/migrate-ccvshop.html"
+  , sitemapUrl "https://jappiesoftware.com/migrate-lightspeed.html"
   , sitemapUrl "https://jappiesoftware.com/blog/"
   ]
   ++ map (\art -> sitemapUrl ("https://jappiesoftware.com/blog/" <> articleUrl art)) articles


### PR DESCRIPTION
## Summary
- Adds `/migrate-lightspeed.html` landing page targeting Lightspeed merchants
- Lightspeed has ~5,000 NL stores and 59% of leavers go to Shopify — biggest opportunity
- Same emotional "Ontsnap" messaging style as MWW/CCV pages
- Highlights SEO preservation (the 70% traffic loss fear) and "being pushed out" angle
- Includes sitemap entry and product card on index page

## Test plan
- [x] Nix build compiles successfully
- [ ] Verify page renders correctly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)