### PR TITLE
Fix talks: load reveal.js locally; add hostdir to nix-shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -3,10 +3,14 @@
 }:
 let
   shake-blog = import ./shake { inherit sources pkgs; };
+  hostdir = pkgs.writeShellScriptBin "hostdir" ''
+    ${pkgs.lib.getExe pkgs.python3} -m http.server "$@"
+  '';
 in
 pkgs.mkShell {
   buildInputs = [
     shake-blog
+    hostdir
     pkgs.glibcLocales
   ];
   LANG = "en_US.UTF-8";

--- a/talks/default.nix
+++ b/talks/default.nix
@@ -41,11 +41,8 @@ pkgs.runCommand "talks" { } (
   ''
   + pkgs.lib.concatStrings (
     pkgs.lib.forEach file-paths (file: ''
-      ${pkgs.pandoc}/bin/pandoc -s -V theme=${theme} -t revealjs -o $out/${file.name}.html ${file.path}
+      ${pkgs.pandoc}/bin/pandoc -s -V theme=${theme} -V revealjs-url=reveal.js -t revealjs -o $out/${file.name}.html ${file.path}
     '')
   )
-  + ''
-    sed -i 's#//dist#/dist#g; s#//plugin#/plugin#g' $out/garbage.html
-  ''
 )
 # sed -i "s/plugins:\ \[/plugins: [ RevealHighlight, /" $out/${talk-name}.html


### PR DESCRIPTION
## Summary

- **reveal.js wasn't loading in the talks.** Pandoc 2.11.1.1's default
  `revealjs-url` has a trailing slash, producing broken
  `https://unpkg.com/reveal.js@^4//dist/...` URLs. The redirected unpkg
  responses get blocked by Chromium's Opaque Response Blocking, so
  `Reveal is not defined` and the slides never render. The local
  `reveal.js` symlink already in `$out` was just unused.
- Point pandoc at the local mirror with `-V revealjs-url=reveal.js` so
  the slides actually use the bundled reveal.js. Drop the now-obsolete
  `sed` that only patched `garbage.html`.
- Add `hostdir` to `shell.nix` so `make host` works without relying on
  a global install (mirrors the definition in jappeace/linux-config).
  Forwards `"$@"` so callers can pass a port or `--bind`.

## Test plan

- [x] `make build` in `talks/` succeeds
- [x] Generated HTML references `reveal.js/dist/...` (no `unpkg.com`)
- [x] `hostdir` available inside `nix-shell` and serves the dir
- [x] Loading `category-adts.html` in a browser: 0 console errors, all
      7 reveal.js asset requests `200 OK`, URL hash `#/title-slide`
      confirming Reveal initialized

🤖 Generated with [Claude Code](https://claude.com/claude-code)