### PR TITLE
talks: source nixpkgs and reveal.js via npins

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -5,6 +5,22 @@
       "name": "nixpkgs-unstable",
       "url": "https://releases.nixos.org/nixpkgs/nixpkgs-26.05pre960315.608d0cadfed2/nixexprs.tar.xz",
       "hash": "sha256-ng4mTBcXO6Nc1cTlXxCPkI49nDJbwFNg/DBhx7YkymE="
+    },
+    "reveal.js": {
+      "type": "GitRelease",
+      "repository": {
+        "type": "GitHub",
+        "owner": "hakimel",
+        "repo": "reveal.js"
+      },
+      "pre_releases": false,
+      "version_upper_bound": null,
+      "release_prefix": null,
+      "submodules": false,
+      "version": "4.1.0",
+      "revision": "0582f57517c97a4c7bfeb58762138c78883f94c5",
+      "url": "https://api.github.com/repos/hakimel/reveal.js/tarball/refs/tags/4.1.0",
+      "hash": "sha256-oN77CUmmvrzObhQbORXAujjb+4IkiYbKVLsi7hddsIM="
     }
   },
   "version": 7

--- a/talks/default.nix
+++ b/talks/default.nix
@@ -1,15 +1,7 @@
 {
-  pkgs ? import (builtins.fetchTarball {
-    # nixpkgs-unstable 2020.11.16
-    url = "https://github.com/NixOS/nixpkgs/archive/bc714f86a515a558c2f595e1a090e882d08bd7ca.tar.gz";
-  }) { },
-
-  revealjs ? pkgs.fetchFromGitHub {
-    owner = "hakimel";
-    repo = "reveal.js";
-    rev = "4.1.0";
-    sha256 = "10xhblbyw8mvak58d294hbxxnf5sq0akj6qldv7brgm6944zppm0";
-  },
+  sources ? import ../npins,
+  pkgs ? import sources.nixpkgs { },
+  revealjs ? sources."reveal.js",
   org-files ? [
     "category-adts"
     "ai-talk"


### PR DESCRIPTION
## Summary

- Follow-up to #56. The 2020 nixpkgs tarball and inline `fetchFromGitHub`
  for reveal.js were hardcoded in `talks/default.nix` — every other
  dependency in this repo already flows through `npins`.
- Pin reveal.js v4.1.0 via `npins add github hakimel reveal.js --at 4.1.0`
  and consume both nixpkgs and reveal.js from `../npins` in
  `talks/default.nix`.

## Test plan

- [x] `make build` in `talks/` succeeds
- [x] `result/reveal.js` symlink resolves to the same store path as the
      previous inline `fetchFromGitHub` did → content unchanged
- [x] Generated HTML still references `reveal.js/dist/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)