### PR TITLE
talks: bump reveal.js to 5.2.1

### DIFF
--- a/npins/sources.json
+++ b/npins/sources.json
@@ -17,10 +17,10 @@
       "version_upper_bound": null,
       "release_prefix": null,
       "submodules": false,
-      "version": "4.1.0",
-      "revision": "0582f57517c97a4c7bfeb58762138c78883f94c5",
-      "url": "https://api.github.com/repos/hakimel/reveal.js/tarball/refs/tags/4.1.0",
-      "hash": "sha256-oN77CUmmvrzObhQbORXAujjb+4IkiYbKVLsi7hddsIM="
+      "version": "5.2.1",
+      "revision": "25e52e26af09933a98afb24cfdd3574e9055034d",
+      "url": "https://api.github.com/repos/hakimel/reveal.js/tarball/refs/tags/5.2.1",
+      "hash": "sha256-f5g09Xj4XF+v6Y6zW13R4PUTWkAt3wwGpa9nSypUV6w="
     }
   },
   "version": 7


### PR DESCRIPTION
## Summary

- npins migration left reveal.js pinned at 4.1.0. Bump to 5.2.1, the
  latest reveal.js whose plugin filenames still match what pandoc 3.7
  emits.
- 6.0.0 renamed `plugin/<name>/<name>.js` → `plugin/<name>/plugin.js`,
  so reveal.js 6 + pandoc would 404 the notes/search/zoom plugins.
  Verified by attempting the upgrade locally: core loaded, plugins 404'd.

## Test plan

- [x] `make build` in `talks/` succeeds
- [x] `hostdir` + `category-adts.html` + `ai-talk.html` in a browser:
      0 console errors, all 7 reveal.js asset requests `200 OK`, URL
      hash `#/title-slide` confirms reveal initialized

🤖 Generated with [Claude Code](https://claude.com/claude-code)