### PR TITLE
Add MijnWebwinkel "Google-posities behouden" article page

### DIFF
--- a/shake/PenguinTemplates.hs
+++ b/shake/PenguinTemplates.hs
@@ -8,6 +8,7 @@ module PenguinTemplates
   , lightspeedMigrationPage
   , mijnwebwinkelWaaromPage
   , lightspeedWaaromPage
+  , mijnwebwinkelGooglePositiesPage
   , PageMeta(..)
   , defaultPageMeta
   ) where
@@ -1149,6 +1150,165 @@ lightspeedWaaromFaqJsonLd =
       , faqEntry
           "Waar gaan vertrekkende Lightspeed-shops naartoe?"
           "59% van de vertrekkende Lightspeed-shops kiest Shopify als bestemming."
+      , "]}"
+      ]
+
+    faqEntry :: Text -> Text -> Text
+    faqEntry question answer = T.concat
+      [ "{\"@type\":\"Question\""
+      , ",\"name\":" <> jsonString question
+      , ",\"acceptedAnswer\":{\"@type\":\"Answer\""
+      , ",\"text\":" <> jsonString answer
+      , "}}"
+      ]
+
+    jsonString :: Text -> Text
+    jsonString txt = "\"" <> escapeJsonText txt <> "\""
+
+    escapeJsonText :: Text -> Text
+    escapeJsonText = T.concatMap escapeJsonChar
+
+    escapeJsonChar :: Char -> Text
+    escapeJsonChar '"'  = "\\\""
+    escapeJsonChar '\\' = "\\\\"
+    escapeJsonChar '\n' = "\\n"
+    escapeJsonChar '\r' = "\\r"
+    escapeJsonChar '\t' = "\\t"
+    escapeJsonChar c    = T.singleton c
+
+-- =============================================================================
+-- "Google-posities behouden" article page (MijnWebwinkel SEO)
+-- =============================================================================
+
+-- | Benefit-led article for webshop owners: why most MijnWebwinkel migrations
+-- lose their Google rankings, and how the automated redirect tooling prevents
+-- it. Cluster article that links into both 'mijnwebwinkelWaaromPage' (why
+-- leave) and 'mijnwebwinkelMigrationPage' (the service).
+mijnwebwinkelGooglePositiesPage :: Html
+mijnwebwinkelGooglePositiesPage = penguinBaseTemplate googlePositiesMeta $
+  H.main $ do
+    -- Hero
+    H.section ! A.class_ "hero" $ do
+      H.h1 "Waarom de meeste MijnWebwinkel-migraties hun Google-posities verliezen"
+      H.p ! A.class_ "subtitle" $ "Uw webshop staat goed in Google. Bij een verkeerd uitgevoerde overstap bent u dat van de ene op de andere dag kwijt: oude adressen geven een foutmelding, Google haalt ze uit de resultaten, en uw verkeer zakt in. Het hoeft niet zo te gaan. Wij zorgen dat elke pagina mee verhuist."
+      H.a ! A.href "https://calendar.app.google/9h9uTzsPQoryEc6S7" ! A.class_ "cta-button" $ "Plan een vrijblijvend gesprek"
+
+    -- What goes wrong
+    H.section ! A.class_ "audit" $ do
+      H.h2 "Wat er misgaat bij een onbegeleide migratie"
+      H.p "Google kent uw webshop op de oude adressen (URLs). Elke productpagina, elke categorie en elke blogpost staat onder een vast webadres in de zoekresultaten. Stapt u over naar een nieuw platform, dan veranderen al die adressen."
+      H.p "Zonder maatregel gebeurt er dit: een bezoeker of Google klikt op het oude adres, komt op een foutpagina (404) terecht, en Google concludeert dat de pagina niet meer bestaat. De pagina verdwijnt uit de zoekresultaten, samen met de positie die u er jarenlang voor heeft opgebouwd. We hebben verhalen gezien van tot wel 70% verkeersverlies na een onbegeleide overstap."
+
+    -- Why MijnWebwinkel makes this hard
+    H.section ! A.class_ "for-who" $ do
+      H.h2 "Waarom juist MijnWebwinkel dit lastig maakt"
+      H.ul ! A.class_ "card-grid" $ do
+        H.li ! A.class_ "card" $ do
+          H.h3 "Honderden tot duizenden adressen"
+          H.p "Een serieuze webshop heeft al snel duizenden URLs. Die stuk voor stuk met de hand omleiden is onbegonnen werk en foutgevoelig."
+        H.li ! A.class_ "card" $ do
+          H.h3 "Onleesbare artikelcodes"
+          H.p "MijnWebwinkel verwerkt artikelcodes in de URLs die er willekeurig uitzien. Daardoor lijkt het onmogelijk om automatisch te bepalen welke oude URL bij welke nieuwe pagina hoort."
+        H.li ! A.class_ "card" $ do
+          H.h3 "Geen kant-en-klare redirects"
+          H.p "MijnWebwinkel geeft u geen overzicht van uw URLs of redirects mee. U moet die informatie zelf uit de shop halen voordat u kunt omleiden."
+
+    -- How we keep your rankings
+    H.section ! A.class_ "audit" $ do
+      H.h2 "Hoe wij uw posities behouden"
+      H.ol $ do
+        H.li $ do
+          H.strong "Alles vastleggen"
+          ". Ons programma crawlt uw volledige webshop en legt elke URL vast. Geen steekproef: echt elke pagina."
+        H.li $ do
+          H.strong "Automatisch omleiden"
+          ". Voor elke oude URL genereren we een 301-redirect naar de juiste nieuwe pagina. Een 301 vertelt Google dat de pagina permanent is verhuisd, zodat de positie meegaat."
+        H.li $ do
+          H.strong "Controleren voor live"
+          ". U krijgt een testshop en een verificatieoverzicht, zodat u zelf kunt zien dat de adressen kloppen voordat we overschakelen."
+        H.li $ do
+          H.strong "Posities verhuizen mee"
+          ". Google volgt de redirects, uw rankings en backlinks verhuizen mee naar de nieuwe shop, en uw bezoekers merken niets van de overstap."
+
+      -- Raw <details>/<summary>: Text.Blaze.Html5 exports neither the summary
+      -- element nor customParent, and the content is static, so a preEscaped
+      -- block (as used elsewhere in this file for the voronoi svg) is simplest.
+      H.preEscapedToHtml ("<details><summary>Voor de techneuten: kloppen die artikelcodes wel?</summary><p>De artikelcodes in MijnWebwinkel-URLs (de zogenoemde a-codes) lijken te veranderen, wat het idee geeft dat een redirectkaart al snel verouderd is. Wij hebben die codes over meerdere weken systematisch geobserveerd en vastgesteld dat ze een vast, eenduidig patroon volgen. Daardoor kunnen we de oude URLs betrouwbaar koppelen aan de nieuwe pagina's, ook de adressen met numerieke product-ID's. De volledige redirectkaart genereren we automatisch, niet met de hand.</p></details>" :: Text)
+
+    -- What this means for you
+    H.section ! A.class_ "results" $ do
+      H.h2 "Wat dit voor u betekent"
+      H.ul $ do
+        H.li $ do
+          H.strong "Geen verkeersverlies"
+          ". Uw bezoekers en uw Google-posities komen op de nieuwe shop terecht."
+        H.li $ do
+          H.strong "Geen omzetdip"
+          ". U houdt de organische bezoekers die normaal bij u kopen."
+        H.li $ do
+          H.strong "Geen handwerk"
+          ". De redirects worden automatisch en volledig gegenereerd, zonder kopieerfouten."
+      H.p $ do
+        "Lees ook "
+        H.a ! A.href "/waarom-mijnwebwinkel.html" $ "waarom MijnWebwinkel niet meer wordt doorontwikkeld"
+        ", of bekijk direct "
+        H.a ! A.href "/migrate-mijnwebwinkel.html" $ "onze migratieservice"
+        "."
+
+    -- FAQ
+    H.section ! A.class_ "about" $ do
+      H.h2 "Veelgestelde vragen"
+      H.dl $ do
+        H.dt "Verlies ik mijn Google-posities als ik van MijnWebwinkel migreer?"
+        H.dd "Niet als de migratie goed gebeurt. Het verlies ontstaat doordat oude URLs na de overstap niet meer bestaan en geen 301-redirect hebben. Wij genereren automatisch een redirect voor elke oude URL, zodat uw posities en backlinks behouden blijven."
+        H.dt "Hoe weet u zeker dat alle URLs worden afgevangen?"
+        H.dd "Ons programma crawlt uw volledige webshop en legt elke URL vast, niet een steekproef. Elke vastgelegde URL krijgt een redirect, die we voor de overstap samen met u verifiëren."
+        H.dt "De artikelcodes in MijnWebwinkel-URLs lijken te veranderen. Werkt dat dan wel?"
+        H.dd "Ja. We hebben die codes over meerdere weken geobserveerd en vastgesteld dat ze een vast, eenduidig patroon volgen. Daardoor kunnen we elke oude URL betrouwbaar naar de juiste nieuwe URL doorsturen."
+        H.dt "Hoe lang duurt het voordat Google de nieuwe URLs oppikt?"
+        H.dd "Google volgt 301-redirects doorgaans binnen enkele weken. Doordat de redirects vanaf dag een actief zijn, verliest u in de tussentijd geen verkeer."
+
+    -- CTA
+    H.section ! A.class_ "final-cta" $ do
+      H.h2 "Wilt u uw posities behouden?"
+      H.p "Plan een gratis, vrijblijvend gesprek. We bekijken samen uw webshop en geven direct een inschatting van de migratie en de redirects."
+      H.a ! A.href "https://calendar.app.google/9h9uTzsPQoryEc6S7" ! A.class_ "cta-button" $ "Plan een gesprek"
+  where
+    googlePositiesMeta :: PageMeta
+    googlePositiesMeta = PageMeta
+      { pageMetaTitle       = "Google-posities behouden bij MijnWebwinkel-migratie \8212 Jappie Software B.V."
+      , pageMetaDescription = "Bij een onbegeleide migratie van MijnWebwinkel verliest u uw Google-posities doordat oude URLs een foutmelding geven. Wij leggen elke URL vast en stellen 301-redirects in, zodat uw verkeer en rankings behouden blijven."
+      , pageMetaLang        = "nl"
+      , pageMetaCanonical   = Just "https://jappiesoftware.com/mijnwebwinkel-google-posities-behouden.html"
+      , pageMetaOgImage     = Nothing
+      , pageMetaExtraHead   = googlePositiesFaqJsonLd
+      }
+
+-- | FAQ structured data (JSON-LD) for the Google-posities article.
+googlePositiesFaqJsonLd :: Html
+googlePositiesFaqJsonLd =
+  H.script ! A.type_ "application/ld+json" $ H.preEscapedToHtml faqJson
+  where
+    faqJson :: Text
+    faqJson = T.concat
+      [ "{\"@context\":\"https://schema.org\""
+      , ",\"@type\":\"FAQPage\""
+      , ",\"mainEntity\":["
+      , faqEntry
+          "Verlies ik mijn Google-posities als ik van MijnWebwinkel migreer?"
+          "Niet als de migratie goed gebeurt. Het verlies ontstaat doordat oude URLs na de overstap niet meer bestaan en geen 301-redirect hebben. Wij genereren automatisch een redirect voor elke oude URL, zodat uw posities en backlinks behouden blijven."
+      , ","
+      , faqEntry
+          "Hoe weet u zeker dat alle URLs worden afgevangen?"
+          "Ons programma crawlt uw volledige webshop en legt elke URL vast, niet een steekproef. Elke vastgelegde URL krijgt een redirect, die we voor de overstap samen met u verifiëren."
+      , ","
+      , faqEntry
+          "De artikelcodes in MijnWebwinkel-URLs lijken te veranderen. Werkt dat dan wel?"
+          "Ja. We hebben die codes over meerdere weken geobserveerd en vastgesteld dat ze een vast, eenduidig patroon volgen. Daardoor kunnen we elke oude URL betrouwbaar naar de juiste nieuwe URL doorsturen."
+      , ","
+      , faqEntry
+          "Hoe lang duurt het voordat Google de nieuwe URLs oppikt?"
+          "Google volgt 301-redirects doorgaans binnen enkele weken. Doordat de redirects vanaf dag een actief zijn, verliest u in de tussentijd geen verkeer."
       , "]}"
       ]
 

--- a/shake/Shakefile.hs
+++ b/shake/Shakefile.hs
@@ -39,7 +39,7 @@ import WaiAppStatic.Types (ssIndices, unsafeToPiece, ssAddTrailingSlash)
 
 import Feed (generateAtomFeed)
 import Metadata (parseMarkdownMeta, parseOrgMeta, parseDateField, parseTags, isDraft)
-import PenguinTemplates (penguinIndexPage, penguinBlogIndexPage, penguinArticlePage, mijnwebwinkelMigrationPage, ccvshopMigrationPage, lightspeedMigrationPage, mijnwebwinkelWaaromPage, lightspeedWaaromPage)
+import PenguinTemplates (penguinIndexPage, penguinBlogIndexPage, penguinArticlePage, mijnwebwinkelMigrationPage, ccvshopMigrationPage, lightspeedMigrationPage, mijnwebwinkelWaaromPage, lightspeedWaaromPage, mijnwebwinkelGooglePositiesPage)
 import Slug (toSlug)
 import Templates
   ( renderArticlePage
@@ -579,6 +579,7 @@ generatePenguinSite config articles = do
   writeHtmlFile "_penguin-site/migrate-lightspeed.html" lightspeedMigrationPage
   writeHtmlFile "_penguin-site/waarom-mijnwebwinkel.html" mijnwebwinkelWaaromPage
   writeHtmlFile "_penguin-site/waarom-lightspeed.html" lightspeedWaaromPage
+  writeHtmlFile "_penguin-site/mijnwebwinkel-google-posities-behouden.html" mijnwebwinkelGooglePositiesPage
 
   -- Individual article pages
   mapM_ (\art ->
@@ -656,6 +657,7 @@ generatePenguinSitemap articles = T.unlines $
   , sitemapUrl "https://jappiesoftware.com/migrate-lightspeed.html"
   , sitemapUrl "https://jappiesoftware.com/waarom-mijnwebwinkel.html"
   , sitemapUrl "https://jappiesoftware.com/waarom-lightspeed.html"
+  , sitemapUrl "https://jappiesoftware.com/mijnwebwinkel-google-posities-behouden.html"
   , sitemapUrl "https://jappiesoftware.com/blog/"
   ]
   ++ map (\art -> sitemapUrl ("https://jappiesoftware.com/blog/" <> articleUrl art)) articles


### PR DESCRIPTION
New Dutch landing page for jappiesoftware.com targeting **webshop owners**: why most MijnWebwinkel migrations lose their Google rankings (old URLs 404 with no redirect), and how the automated redirect tooling prevents it.

## Why
Builds topical authority for the migration funnel. Links up to `waarom-mijnwebwinkel` and across to `migrate-mijnwebwinkel` (the cluster hubs), so it concentrates authority onto the money pages. First post from the [SEO content plan](https://github.com/jappeace-sloth/jappie-software/pull/94).

## Details
- Benefit-led for a non-technical audience; technical URL/redirect detail tucked into an optional `<details>` section ("voor de techneuten").
- `lang="nl"`, canonical set, FAQPage JSON-LD for rich results, added to `sitemap.xml`.
- Mentions we capture every URL via a program, and that the MijnWebwinkel a-codes (which appear to change) follow a stable, definitive pattern confirmed over several weeks of observation.
- URL: `/mijnwebwinkel-google-posities-behouden.html`.

## Verification
`nix-build nix/ci.nix` passes (exit 0): compiles, `seo-analyzer` reports no defects, `xmllint` validates the sitemap. Confirmed in generated HTML: `lang=nl`, canonical, title 74 chars, FAQ JSON-LD, both internal links, sitemap entry.

Branches off master independently of #64 (the structured-data PR); once #64 merges, this page also inherits the site-wide Organization schema via the shared base template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
