### PR TITLE
Fix Service schema price to match visible €999

### DIFF
--- a/shake/PenguinTemplates.hs
+++ b/shake/PenguinTemplates.hs
@@ -251,7 +251,7 @@ serviceJsonLd serviceName serviceDescription pageUrl =
       , ",\"url\":\"https://jappiesoftware.com/\"}"
       , ",\"offers\":{\"@type\":\"Offer\""
       , ",\"priceCurrency\":\"EUR\""
-      , ",\"price\":\"750\""
+      , ",\"price\":\"999\""
       , ",\"url\":" <> jsonLdString pageUrl <> "}"
       , "}"
       ]


### PR DESCRIPTION
The migration landing pages show "Vanaf €999", but the Service/Offer JSON-LD (merged in #64) hardcodes `price: 750`, a stale figure. Mismatched structured data is incorrect and search engines distrust it.

This aligns the Offer price with the visible price across all three migration pages (they share the `serviceJsonLd` helper).

Context: this fix was committed onto the #64 branch but landed after #64 was already merged, so it missed the merge. This PR brings it onto current master.

Verified: `nix-build nix/ci.nix` exit 0; deployed JSON-LD now shows `"price":"999"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
