### PR TITLE
Move webshop-migration funnel to webwinkelverhuis.nl brand domain

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -54,16 +54,26 @@ pkgs.stdenv.mkDerivation {
          metaBaseRule \
          metaSocialRule='{"properties":["og:title","og:description","og:type","og:locale","og:url"]}'
 
+    seo-analyzer \
+      -f $(find _webwinkelverhuis-site -name '*.html' \
+           -not -name 'google4043c908cce5ef76.html' \
+         ) \
+      -r titleLengthRule='{"min":10,"max":120}' \
+         metaBaseRule \
+         metaSocialRule='{"properties":["og:title","og:description","og:type","og:locale","og:url"]}'
+
     xmllint --noout _site/sitemap.xml
     xmllint --noout _penguin-site/sitemap.xml
+    xmllint --noout _webwinkelverhuis-site/sitemap.xml
 
     # Optimize images
     find _site -name '*.png' -exec optipng -quiet {} \;
     find _site \( -name '*.jpg' -o -name '*.jpeg' \) -exec jpegtran -copy none -optimize -progressive -outfile {} {} \;
   '';
   installPhase = ''
-    mkdir -p $out/jappieklooster.nl $out/jappiesoftware.com
+    mkdir -p $out/jappieklooster.nl $out/jappiesoftware.com $out/webwinkelverhuis.nl
     cp -r _site/* $out/jappieklooster.nl/
     cp -r _penguin-site/* $out/jappiesoftware.com/
+    cp -r _webwinkelverhuis-site/* $out/webwinkelverhuis.nl/
   '';
 }

--- a/shake/PenguinTemplates.hs
+++ b/shake/PenguinTemplates.hs
@@ -288,15 +288,15 @@ penguinIndexPage = penguinBaseTemplate indexMeta $
         H.li ! A.class_ "card" $ do
           H.h3 "MijnWebwinkel Migration Tool"
           H.p $ H.preEscapedToHtml ("Migrate your webshop from MijnWebwinkel to Shopify, WooCommerce or another platform &mdash; products, categories, translations, images, SEO redirects and bulk data modifications. Fully automated." :: Text)
-          H.a ! A.href "/migrate-mijnwebwinkel.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Learn more &rarr;" :: Text)
+          H.a ! A.href "https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Learn more &rarr;" :: Text)
         H.li ! A.class_ "card" $ do
           H.h3 "CCV Shop Migration Tool"
           H.p $ H.preEscapedToHtml ("Migrate your webshop from CCV Shop to Shopify &mdash; products, categories, translations, images, inventory and SEO redirects. Fully automated." :: Text)
-          H.a ! A.href "/migrate-ccvshop.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Learn more &rarr;" :: Text)
+          H.a ! A.href "https://webwinkelverhuis.nl/migrate-ccvshop.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Learn more &rarr;" :: Text)
         H.li ! A.class_ "card" $ do
           H.h3 "Lightspeed Migration Tool"
           H.p $ H.preEscapedToHtml ("Migrate your webshop from Lightspeed to Shopify &mdash; products, categories, translations, images, inventory and SEO redirects. No traffic loss." :: Text)
-          H.a ! A.href "/migrate-lightspeed.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Learn more &rarr;" :: Text)
+          H.a ! A.href "https://webwinkelverhuis.nl/migrate-lightspeed.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Learn more &rarr;" :: Text)
         H.li ! A.class_ "card" $ do
           H.h3 "Massapp"
           H.p "Bulk WhatsApp messaging for businesses. Reach your customers at scale through the official WhatsApp Business API."
@@ -493,12 +493,12 @@ mijnwebwinkelMigrationPage = penguinBaseTemplate migrationMeta $
       { pageMetaTitle       = "Ontsnap MijnWebwinkel \8212 Migratie naar Shopify \8212 Jappie Software B.V."
       , pageMetaDescription = "Geautomatiseerde migratie van MijnWebwinkel naar Shopify, WooCommerce of een ander platform. Producten, vertalingen, afbeeldingen en SEO-redirects. Vanaf \8364\&999."
       , pageMetaLang        = "nl"
-      , pageMetaCanonical   = Just "https://jappiesoftware.com/migrate-mijnwebwinkel.html"
+      , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html"
       , pageMetaOgImage     = Nothing
       , pageMetaExtraHead   = migrationFaqJsonLd <> serviceJsonLd
           "MijnWebwinkel naar Shopify migratie"
           "Geautomatiseerde migratie van MijnWebwinkel naar Shopify, WooCommerce of een ander platform: producten, vertalingen, afbeeldingen, categorieboom en SEO-redirects."
-          "https://jappiesoftware.com/migrate-mijnwebwinkel.html"
+          "https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html"
       }
 
 -- | FAQ structured data (JSON-LD) for the migration page.
@@ -701,12 +701,12 @@ ccvshopMigrationPage = penguinBaseTemplate ccvMeta $
       { pageMetaTitle       = "Ontsnap CCV Shop \8212 Migratie naar Shopify \8212 Jappie Software B.V."
       , pageMetaDescription = "Geautomatiseerde migratie van CCV Shop naar Shopify. Producten, vertalingen, afbeeldingen, voorraad en SEO-redirects. Vanaf \8364\&999."
       , pageMetaLang        = "nl"
-      , pageMetaCanonical   = Just "https://jappiesoftware.com/migrate-ccvshop.html"
+      , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/migrate-ccvshop.html"
       , pageMetaOgImage     = Nothing
       , pageMetaExtraHead   = ccvFaqJsonLd <> serviceJsonLd
           "CCV Shop naar Shopify migratie"
           "Geautomatiseerde migratie van CCV Shop naar Shopify: producten, vertalingen, afbeeldingen, voorraad, klantdata en SEO-redirects."
-          "https://jappiesoftware.com/migrate-ccvshop.html"
+          "https://webwinkelverhuis.nl/migrate-ccvshop.html"
       }
 
 -- | FAQ structured data (JSON-LD) for the CCV migration page.
@@ -902,12 +902,12 @@ lightspeedMigrationPage = penguinBaseTemplate lightspeedMeta $
       { pageMetaTitle       = "Ontsnap Lightspeed \8212 Migratie naar Shopify \8212 Jappie Software B.V."
       , pageMetaDescription = "Geautomatiseerde migratie van Lightspeed naar Shopify. Producten, vertalingen, afbeeldingen, voorraad en SEO-redirects. Geen verkeersverlies. Vanaf \8364\&999."
       , pageMetaLang        = "nl"
-      , pageMetaCanonical   = Just "https://jappiesoftware.com/migrate-lightspeed.html"
+      , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/migrate-lightspeed.html"
       , pageMetaOgImage     = Nothing
       , pageMetaExtraHead   = lightspeedFaqJsonLd <> serviceJsonLd
           "Lightspeed naar Shopify migratie"
           "Geautomatiseerde migratie van Lightspeed naar Shopify: producten, vertalingen, afbeeldingen, voorraad en SEO-redirects, zonder verkeersverlies."
-          "https://jappiesoftware.com/migrate-lightspeed.html"
+          "https://webwinkelverhuis.nl/migrate-lightspeed.html"
       }
 
 -- | FAQ structured data (JSON-LD) for the Lightspeed migration page.
@@ -1079,7 +1079,7 @@ mijnwebwinkelWaaromPage = penguinBaseTemplate waaromMeta $
       { pageMetaTitle       = "Waarom wordt MijnWebwinkel niet meer doorontwikkeld? \8212 Jappie Software B.V."
       , pageMetaDescription = "MijnWebwinkel is in 2021 overgenomen door Visma/Hg Capital en wordt sindsdien niet meer doorontwikkeld. De code is bevroren, prijzen zijn verdubbeld, en het platform wordt afgebouwd. Dit is waarom."
       , pageMetaLang        = "nl"
-      , pageMetaCanonical   = Just "https://jappiesoftware.com/waarom-mijnwebwinkel.html"
+      , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/waarom-mijnwebwinkel.html"
       , pageMetaOgImage     = Nothing
       , pageMetaExtraHead   = mempty
       }
@@ -1213,7 +1213,7 @@ lightspeedWaaromPage = penguinBaseTemplate waaromLsMeta $
       { pageMetaTitle       = "Waarom verlaten steeds meer webshops Lightspeed? \8212 Jappie Software B.V."
       , pageMetaDescription = "Lightspeed is beursgenoteerd en verschuift richting enterprise-klanten. Prijzen stijgen, kleine shops worden eruit gedrukt. 22% minder webshops in drie jaar. Dit is waarom."
       , pageMetaLang        = "nl"
-      , pageMetaCanonical   = Just "https://jappiesoftware.com/waarom-lightspeed.html"
+      , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/waarom-lightspeed.html"
       , pageMetaOgImage     = Nothing
       , pageMetaExtraHead   = lightspeedWaaromFaqJsonLd
       }

--- a/shake/Shakefile.hs
+++ b/shake/Shakefile.hs
@@ -132,6 +132,10 @@ shakeRules = do
       liftIO $ generatePenguinSite penguinSiteConfig penguinArticles
       copyPenguinStaticAssets
 
+      -- Build webwinkelverhuis.nl (the webshop-migration brand domain)
+      liftIO generateWebwinkelverhuisSite
+      copyPenguinStaticAssetsTo "_webwinkelverhuis-site"
+
     phony "serve" $ do
       need ["clean"]
 
@@ -186,9 +190,10 @@ shakeRules = do
             }
 
     phony "clean" $ do
-      putInfo "Cleaning _site, _penguin-site, and _build"
+      putInfo "Cleaning _site, _penguin-site, _webwinkelverhuis-site, and _build"
       removeFilesAfter "_site" ["//*"]
       removeFilesAfter "_penguin-site" ["//*"]
+      removeFilesAfter "_webwinkelverhuis-site" ["//*"]
       removeFilesAfter "_build" ["//*"]
 
 -- | Generate a full site for one language.
@@ -574,13 +579,6 @@ generatePenguinSite config articles = do
   -- Landing page
   writeHtmlFile "_penguin-site/index.html" penguinIndexPage
 
-  -- Product pages
-  writeHtmlFile "_penguin-site/migrate-mijnwebwinkel.html" mijnwebwinkelMigrationPage
-  writeHtmlFile "_penguin-site/migrate-ccvshop.html" ccvshopMigrationPage
-  writeHtmlFile "_penguin-site/migrate-lightspeed.html" lightspeedMigrationPage
-  writeHtmlFile "_penguin-site/waarom-mijnwebwinkel.html" mijnwebwinkelWaaromPage
-  writeHtmlFile "_penguin-site/waarom-lightspeed.html" lightspeedWaaromPage
-
   -- Individual article pages
   mapM_ (\art ->
     writeHtmlFile ("_penguin-site/blog" </> T.unpack (articleUrl art))
@@ -614,6 +612,25 @@ generatePenguinSite config articles = do
   -- Robots.txt
   T.writeFile "_penguin-site/robots.txt" penguinRobotsTxt
 
+-- | Generate the webwinkelverhuis.nl site into _webwinkelverhuis-site/.
+-- This is the dedicated cold-outreach brand domain for the webshop-migration
+-- funnel. The migration and "waarom" pages live here with their canonical URLs
+-- on this domain; jappiesoftware.com 302-redirects their old URLs here (in the
+-- megavid nginx config), and the bare domain is redirected to the MijnWebwinkel
+-- migration page there as well. Static assets are shared with the penguin theme.
+generateWebwinkelverhuisSite :: IO ()
+generateWebwinkelverhuisSite = do
+  Dir.createDirectoryIfMissing True "_webwinkelverhuis-site"
+
+  writeHtmlFile "_webwinkelverhuis-site/migrate-mijnwebwinkel.html" mijnwebwinkelMigrationPage
+  writeHtmlFile "_webwinkelverhuis-site/migrate-ccvshop.html" ccvshopMigrationPage
+  writeHtmlFile "_webwinkelverhuis-site/migrate-lightspeed.html" lightspeedMigrationPage
+  writeHtmlFile "_webwinkelverhuis-site/waarom-mijnwebwinkel.html" mijnwebwinkelWaaromPage
+  writeHtmlFile "_webwinkelverhuis-site/waarom-lightspeed.html" lightspeedWaaromPage
+
+  T.writeFile "_webwinkelverhuis-site/sitemap.xml" generateWebwinkelverhuisSitemap
+  T.writeFile "_webwinkelverhuis-site/robots.txt" webwinkelverhuisRobotsTxt
+
 -- | File name for penguin paginated blog index
 penguinIndexFileName :: Int -> Text
 penguinIndexFileName 1 = "index.html"
@@ -621,11 +638,16 @@ penguinIndexFileName n = "index" <> T.pack (show n) <> ".html"
 
 -- | Copy static assets for the penguin site
 copyPenguinStaticAssets :: Action ()
-copyPenguinStaticAssets = do
-  -- Copy all non-content, non-HTML files from penguin/ to _penguin-site/
+copyPenguinStaticAssets = copyPenguinStaticAssetsTo "_penguin-site"
+
+-- | Copy the penguin theme's static assets (css, images, favicon, og image,
+-- logo) into the given output directory. Shared by the jappiesoftware.com and
+-- webwinkelverhuis.nl sites, which render with the same theme.
+copyPenguinStaticAssetsTo :: FilePath -> Action ()
+copyPenguinStaticAssetsTo outDir = do
   penguinFiles <- getDirectoryFiles "penguin" ["//*"]
   let staticFiles = filter isPenguinStatic penguinFiles
-  liftIO $ mapM_ (\f -> copyBinaryFile ("penguin" </> f) ("_penguin-site" </> f)) staticFiles
+  liftIO $ mapM_ (\f -> copyBinaryFile ("penguin" </> f) (outDir </> f)) staticFiles
   where
     isPenguinStatic :: FilePath -> Bool
     isPenguinStatic f =
@@ -652,11 +674,6 @@ generatePenguinSitemap articles = T.unlines $
   [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
   , "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
   , sitemapUrl "https://jappiesoftware.com/"
-  , sitemapUrl "https://jappiesoftware.com/migrate-mijnwebwinkel.html"
-  , sitemapUrl "https://jappiesoftware.com/migrate-ccvshop.html"
-  , sitemapUrl "https://jappiesoftware.com/migrate-lightspeed.html"
-  , sitemapUrl "https://jappiesoftware.com/waarom-mijnwebwinkel.html"
-  , sitemapUrl "https://jappiesoftware.com/waarom-lightspeed.html"
   , sitemapUrl "https://jappiesoftware.com/blog/"
   ]
   ++ map (\art -> sitemapUrlDated ("https://jappiesoftware.com/blog/" <> articleUrl art) (articleLastmod art)) articles
@@ -689,6 +706,29 @@ penguinRobotsTxt = T.unlines
   , "Disallow:"
   , ""
   , "Sitemap: https://jappiesoftware.com/sitemap.xml"
+  ]
+
+-- | Sitemap for the webwinkelverhuis.nl migration funnel. Static pages only, so
+-- no lastmod (we don't fabricate dates for hand-written pages).
+generateWebwinkelverhuisSitemap :: Text
+generateWebwinkelverhuisSitemap = T.unlines
+  [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+  , "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
+  , sitemapUrl "https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html"
+  , sitemapUrl "https://webwinkelverhuis.nl/migrate-ccvshop.html"
+  , sitemapUrl "https://webwinkelverhuis.nl/migrate-lightspeed.html"
+  , sitemapUrl "https://webwinkelverhuis.nl/waarom-mijnwebwinkel.html"
+  , sitemapUrl "https://webwinkelverhuis.nl/waarom-lightspeed.html"
+  , "</urlset>"
+  ]
+
+-- | robots.txt for the webwinkelverhuis.nl site.
+webwinkelverhuisRobotsTxt :: Text
+webwinkelverhuisRobotsTxt = T.unlines
+  [ "User-agent: *"
+  , "Disallow:"
+  , ""
+  , "Sitemap: https://webwinkelverhuis.nl/sitemap.xml"
   ]
 
 -- =============================================================================


### PR DESCRIPTION
## Summary
Moves the webshop-migration funnel (`migrate-mijnwebwinkel`, `migrate-ccvshop`, `migrate-lightspeed`, `waarom-mijnwebwinkel`, `waarom-lightspeed`) from `jappiesoftware.com` onto its own brand domain **`webwinkelverhuis.nl`**.

Why: that domain is the sending/landing domain for the MijnWebwinkel cold-outreach campaign. A descriptive brand reads as "this is for me" to a webshop owner, and it acts as a **reputation firewall** so cold-mail fallout (spam complaints, bounces) never touches `jappiesoftware.com`, which carries invoices and client mail.

## Changes
- New `_webwinkelverhuis-site` output (`generateWebwinkelverhuisSite`) builds the five funnel pages with **canonical URLs on `webwinkelverhuis.nl`**, plus its own `sitemap.xml` and `robots.txt`. Theme assets shared via the new `copyPenguinStaticAssetsTo`.
- Those pages are **removed** from the `jappiesoftware.com` (`_penguin-site`) output and its sitemap; jappiesoftware.com keeps its index + blog. The index product-card CTAs now link to the `webwinkelverhuis.nl` pages.
- `default.nix` installs `$out/webwinkelverhuis.nl` and runs the same `seo-analyzer` + `xmllint` checks on it (Google verification stub excluded, matching the penguin site).

The old `jappiesoftware.com/migrate-*` and `/waarom-*` URLs are 302-redirected to `webwinkelverhuis.nl` in the **megavid** nginx config (separate PR, must merge + bump this pin to deploy).

## Test plan
- [x] `nix-build` (full site) passes, incl. `seo-analyzer` + `xmllint` on the new output
- [x] `nix-build shake` (executable) compiles clean
- [x] Output check: `webwinkelverhuis.nl/` has the 5 pages + assets + sitemap + robots; canonical = `https://webwinkelverhuis.nl/...`; `jappiesoftware.com/` no longer serves them
- [ ] After merge: bump the `jappeaceApplication` npins pin in megavid so `${blog}/webwinkelverhuis.nl` exists before deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)