### PR TITLE
Cross-link footers between brand sites

### DIFF
--- a/shake/PenguinTemplates.hs
+++ b/shake/PenguinTemplates.hs
@@ -108,6 +108,8 @@ penguinBaseWith ogType includeFeed meta content =
           H.a ! A.href "tel:+31644237437" $ "+31 6 4423 7437"
           H.preEscapedToHtml (" &middot; " :: Text)
           H.a ! A.href "/blog/" $ "Blog"
+          H.preEscapedToHtml (" &middot; " :: Text)
+          H.a ! A.href "https://jappie.me/" $ "jappie.me"
         H.p $ H.small $ H.preEscapedToHtml ("Jappie Software B.V. &middot; KVK: 95097872" :: Text)
       H.preEscapedToHtml ("<svg class=\"voronoi\"></svg>" :: Text)
       H.script $ H.preEscapedToHtml voronoiScript

--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -121,7 +121,10 @@ webwinkelBaseWith ogType includeFeed meta content =
           H.a ! A.href "tel:+31644237437" $ "+31 6 4423 7437"
           H.preEscapedToHtml (" &middot; " :: Text)
           H.a ! A.href "/blog/" $ "Blog"
-        H.p $ H.small $ H.preEscapedToHtml ("Webwinkelverhuis is een dienst van Jappie Software B.V. &middot; KVK: 95097872" :: Text)
+        H.p $ H.small $ do
+          "Webwinkelverhuis is een dienst van "
+          H.a ! A.href "https://jappiesoftware.com/" $ "Jappie Software B.V."
+          H.preEscapedToHtml (" &middot; KVK: 95097872" :: Text)
 
 -- | Landing / migration page skeleton (Open Graph type "website").
 webwinkelBaseTemplate :: PageMeta -> Html -> Html


### PR DESCRIPTION
## Summary
Follow-up to #69. These two footer links were pushed after #69 had already merged, so they did not make it into master — this PR brings them in.

- **webwinkelverhuis.nl**: the "Webwinkelverhuis is een dienst van Jappie Software B.V." footer line now links the company name to https://jappiesoftware.com/.
- **jappiesoftware.com**: the footer now links to the founder's personal blog https://jappie.me/.

Together this makes the brand relationship explicit in both directions (personal site ← company ← service brand), matching the Organization `sameAs` structured data Google already uses. Both changes apply site-wide via the shared base templates.

## Test plan
- [x] `nix-build nix/ci.nix` passes (SEO analyzer clean on all three sites, sitemaps validate, `-Wall -Werror` clean)
- [x] Verified both footer links render in the built output

🤖 Generated with [Claude Code](https://claude.com/claude-code)