### PR TITLE
webwinkelverhuis: add /app.html for the Shopify migration app

### DIFF
--- a/shake/Shakefile.hs
+++ b/shake/Shakefile.hs
@@ -45,6 +45,7 @@ import WebwinkelTemplates
   ( webwinkelIndexPage
   , webwinkelBlogIndexPage
   , webwinkelArticlePage
+  , appPage
   , mijnwebwinkelMigrationPage
   , ccvshopMigrationPage
   , lightspeedMigrationPage
@@ -650,6 +651,9 @@ generateWebwinkelverhuisSite config articles = do
 
   -- Landing page
   writeHtmlFile "_webwinkelverhuis-site/index.html" webwinkelIndexPage
+
+  -- Shopify migration app's App URL landing page
+  writeHtmlFile "_webwinkelverhuis-site/app.html" appPage
 
   -- Migration and explainer pages
   writeHtmlFile "_webwinkelverhuis-site/migrate-mijnwebwinkel.html" mijnwebwinkelMigrationPage

--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -10,6 +10,7 @@ module WebwinkelTemplates
   ( webwinkelIndexPage
   , webwinkelBlogIndexPage
   , webwinkelArticlePage
+  , appPage
   , mijnwebwinkelMigrationPage
   , ccvshopMigrationPage
   , lightspeedMigrationPage
@@ -236,6 +237,64 @@ mijnwebwinkelWhatsappLabel = "Open een WhatsApp-gesprek met ons"
 -- page. Dutch, matching the page's audience.
 mijnwebwinkelWhatsappMessage :: Text
 mijnwebwinkelWhatsappMessage = "Hallo, ik heb een vraag over de migratie van mijn MijnWebwinkel-shop."
+
+-- | The migration app's landing page (webwinkelverhuis.nl/app.html). This is
+-- the App URL of the custom Shopify app we install in a client's store to run
+-- the import; Shopify shows the merchant this page on install. It explains, in
+-- plain Dutch, what the app is and why it asks for access, so the install does
+-- not look like a black box. Marked noindex: it is a utility page, not part of
+-- the marketing funnel.
+appPage :: Html
+appPage = webwinkelBaseTemplate appMeta $ do
+  H.main $ do
+    H.section ! A.class_ "hero" $ do
+      H.h1 "De migratie-app"
+      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("U ziet deze pagina omdat de migratie-app van Webwinkelverhuis in uw Shopify-winkel is ge&iuml;nstalleerd. Dat is precies de bedoeling: de app is het gereedschap waarmee wij uw webshop naar Shopify overzetten." :: Text)
+      H.a ! A.href offerteMailto ! A.class_ "cta-button" $ "Vraag een offerte aan"
+
+    H.section ! A.class_ "for-who" ! A.id "what" $ do
+      H.h2 "Wat de app doet"
+      H.ul ! A.class_ "card-grid" $ do
+        H.li ! A.class_ "card" $ do
+          H.h3 "Producten plaatsen"
+          H.p "De app zet uw producten, varianten, afbeeldingen, prijzen en SKU's in uw nieuwe Shopify-winkel."
+        H.li ! A.class_ "card" $ do
+          H.h3 $ H.preEscapedToHtml ("Categorie&euml;n en pagina&rsquo;s" :: Text)
+          H.p $ H.preEscapedToHtml ("Uw categorie&euml;n worden Shopify-collections en uw informatiepagina&rsquo;s worden meegenomen, inclusief het navigatiemenu." :: Text)
+        H.li ! A.class_ "card" $ do
+          H.h3 "SEO-redirects"
+          H.p "De app legt 301-redirects aan van elke oude URL naar de juiste nieuwe pagina, zodat uw Google-posities behouden blijven."
+        H.li ! A.class_ "card" $ do
+          H.h3 "Thema"
+          H.p "De app bouwt en plaatst een Shopify-thema dat de uitstraling van uw huidige winkel volgt."
+
+    H.section ! A.class_ "audit" $ do
+      H.h2 "Waarom de app toegang vraagt"
+      H.p "Om dit werk te doen vraagt de app toegang tot precies de onderdelen die hij plaatst:"
+      H.ul $ do
+        H.li $ H.strong "Producten" >> ": om uw artikelen, varianten en collections aan te maken."
+        H.li $ H.strong "Content" >> ": om uw pagina's, navigatie en redirects over te zetten."
+        H.li $ H.strong "Klanten" >> ": om bestaande klantaccounts mee te nemen."
+        H.li $ H.preEscapedToHtml ("<strong>Thema&rsquo;s</strong>: om het nieuwe thema te plaatsen." :: Text)
+        H.li $ H.strong "Vertalingen" >> ": om meertalige content correct te koppelen."
+
+    H.section ! A.class_ "about" $ do
+      H.h2 "Veilig en tijdelijk"
+      H.p "De app is alleen nodig tijdens de migratie. Wij installeren hem in uw winkel om uw data te plaatsen, en daarna kan hij verwijderd worden. Hij maakt geen onderdeel uit van uw winkel voor uw bezoekers. U betaalt pas na een succesvolle migratie."
+      H.p $ do
+        H.a ! A.href "/migrate-mijnwebwinkel.html" $ "Lees hoe de migratie werkt"
+        H.preEscapedToHtml (" &rarr;" :: Text)
+  where
+    appMeta :: PageMeta
+    appMeta = PageMeta
+      { pageMetaTitle       = "De migratie-app van Webwinkelverhuis"
+      , pageMetaDescription = "Uitleg over de migratie-app van Webwinkelverhuis: het gereedschap waarmee wij uw webshop naar Shopify overzetten, en waarom de app toegang vraagt."
+      , pageMetaLang        = "nl"
+      , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/app.html"
+      , pageMetaOgImage     = Nothing
+      , pageMetaSwitchUrl   = Nothing
+      , pageMetaExtraHead   = H.meta ! A.name "robots" ! A.content "noindex"
+      }
 
 mijnwebwinkelMigrationPage :: Html
 mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $ do


### PR DESCRIPTION
## Why
The custom Shopify app we install in a client's store to run a migration needs an **App URL**. Shopify shows the merchant that page on install, so it should explain what the app is, not 404 or show a stray page.

## What
`appPage` → `webwinkelverhuis.nl/app.html`: a plain-Dutch explainer (what the app places, why it asks for the API scopes, that it's only needed during the migration). Reuses the existing webwinkelverhuis theme; `noindex` since it's a utility page. Wired into `generateWebwinkelverhuisSite`.

## Note
Being framed inside the Shopify admin also needs an `X-Frame-Options` exception for just `/app.html` in nginx (separate PR in the `megavid` repo). This PR is only the page.

## Test plan
- [ ] CI builds the site (local nix build unavailable: `max-jobs=0`, remote builder unreachable)
- [ ] SEO analyzer passes (title 10-120; og/meta via base template; canonical set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)