### PR TITLE
Give webwinkelverhuis.nl its own Google Analytics property

### DIFF
--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -106,8 +106,8 @@ webwinkelBaseWith ogType includeFeed meta content =
                     ! A.rel "alternate"
                     ! A.title "Webwinkelverhuis blog"
         else mempty
-      H.script ! A.async "" ! A.src "https://www.googletagmanager.com/gtag/js?id=G-FMYV1PLWZ6" $ mempty
-      H.script $ H.preEscapedToHtml ("window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'G-FMYV1PLWZ6');" :: Text)
+      H.script ! A.async "" ! A.src "https://www.googletagmanager.com/gtag/js?id=G-GD4S885G6F" $ mempty
+      H.script $ H.preEscapedToHtml ("window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'G-GD4S885G6F');" :: Text)
       H.title (toHtml (pageMetaTitle meta))
       organizationJsonLd
       pageMetaExtraHead meta


### PR DESCRIPTION
## Summary
- The webwinkel page template reused the jappiesoftware.com measurement ID (G-FMYV1PLWZ6), copied over when the template was created, so traffic from both sites landed in the same Analytics property.
- Replace the ID in `shake/WebwinkelTemplates.hs` with the dedicated webwinkelverhuis.nl property G-GD4S885G6F.
- `PenguinTemplates.hs` is untouched: jappiesoftware.com keeps G-FMYV1PLWZ6, and jappieklooster.nl keeps G-SJ36NEDJPD.

## Test plan
- [x] `nix-build nix/ci.nix` passes
- [x] Grep of the generated output shows exactly one distinct measurement ID per site (webwinkelverhuis.nl: G-GD4S885G6F, jappiesoftware.com: G-FMYV1PLWZ6, jappieklooster.nl: G-SJ36NEDJPD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)