### PR TITLE
Rework jappiesoftware.com around a clear reading line

### DIFF
--- a/penguin/illustratie-verhuizen.svg
+++ b/penguin/illustratie-verhuizen.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Webshop-migration illustration: boxes moving from a faded old shop to a
+     bright new one. Same palette and stroke style as illustratie-website.svg. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" role="img">
+  <!-- soft backdrop -->
+  <circle cx="200" cy="150" r="130" fill="#f0f5f1"/>
+  <!-- old shop, faded -->
+  <g opacity="0.45">
+    <rect x="48" y="130" width="90" height="80" fill="#ffffff" stroke="#0d1f12" stroke-width="3"/>
+    <path d="M40 130 l8 -26 h74 l8 26 z" fill="#cfe3d5" stroke="#0d1f12" stroke-width="3" stroke-linejoin="round"/>
+    <path d="M40 130 h90" stroke="#0d1f12" stroke-width="3"/>
+    <rect x="62" y="152" width="26" height="26" fill="#cfe3d5" stroke="#0d1f12" stroke-width="3"/>
+    <rect x="98" y="152" width="26" height="58" fill="#cfe3d5" stroke="#0d1f12" stroke-width="3"/>
+  </g>
+  <!-- arrow of travel -->
+  <path d="M150 176 C 185 120, 225 120, 258 168" fill="none" stroke="#2a5a3a" stroke-width="6" stroke-linecap="round" stroke-dasharray="2 14"/>
+  <path d="M250 148 l10 22 l-24 -4 z" fill="#2a5a3a"/>
+  <!-- moving boxes -->
+  <g transform="rotate(-8 196 132)">
+    <rect x="172" y="112" width="48" height="40" rx="4" fill="#f6d9a0" stroke="#0d1f12" stroke-width="3"/>
+    <path d="M172 128 h48" stroke="#0d1f12" stroke-width="3"/>
+    <path d="M196 112 v16" stroke="#0d1f12" stroke-width="3"/>
+  </g>
+  <!-- new shop, bright -->
+  <g>
+    <rect x="252" y="118" width="110" height="98" fill="#ffffff" stroke="#0d1f12" stroke-width="3"/>
+    <path d="M242 118 l10 -30 h90 l10 30 z" fill="#2a5a3a" stroke="#0d1f12" stroke-width="3" stroke-linejoin="round"/>
+    <path d="M242 118 h130" stroke="#0d1f12" stroke-width="3"/>
+    <path d="M252 88 q5 14 15 14 q10 0 10 -14 M277 88 q5 14 15 14 q10 0 10 -14 M302 88 q5 14 15 14 q10 0 10 -14" fill="none" stroke="#ffffff" stroke-width="0" opacity="0"/>
+    <rect x="266" y="142" width="30" height="30" fill="#cfe3d5" stroke="#0d1f12" stroke-width="3"/>
+    <rect x="310" y="142" width="30" height="74" fill="#7fb08f" stroke="#0d1f12" stroke-width="3"/>
+    <circle cx="316" cy="180" r="2.5" fill="#0d1f12"/>
+    <!-- awning scallops -->
+    <path d="M246 118 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 14 0" fill="#7fb08f" stroke="#0d1f12" stroke-width="3"/>
+  </g>
+  <!-- delivered box at the door -->
+  <rect x="270" y="196" width="22" height="20" rx="3" fill="#f6d9a0" stroke="#0d1f12" stroke-width="3"/>
+  <path d="M270 204 h22" stroke="#0d1f12" stroke-width="3"/>
+</svg>

--- a/penguin/illustratie-website.svg
+++ b/penguin/illustratie-website.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Decision: homepage service-block illustrations are hand-drawn inline SVGs
+     in the site palette (#2a5a3a greens) instead of stock photos, so the site
+     stays self-hosted, fast, and visually consistent with the voronoi theme.
+     Alternatives considered: stock photography (generic, off-palette) and
+     client screenshots (not yet live, permission needed). -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" role="img">
+  <!-- soft backdrop -->
+  <circle cx="200" cy="150" r="130" fill="#f0f5f1"/>
+  <!-- browser window -->
+  <g>
+    <rect x="70" y="60" width="260" height="180" rx="10" fill="#ffffff" stroke="#0d1f12" stroke-width="3"/>
+    <path d="M70 90 h260" stroke="#0d1f12" stroke-width="3"/>
+    <circle cx="88" cy="75" r="4" fill="#2a5a3a"/>
+    <circle cx="102" cy="75" r="4" fill="#7fb08f"/>
+    <circle cx="116" cy="75" r="4" fill="#cfe3d5"/>
+    <!-- hero banner inside the page -->
+    <rect x="86" y="104" width="152" height="52" rx="6" fill="#2a5a3a"/>
+    <rect x="96" y="118" width="90" height="8" rx="4" fill="#ffffff" opacity="0.9"/>
+    <rect x="96" y="132" width="60" height="8" rx="4" fill="#ffffff" opacity="0.6"/>
+    <!-- image placeholder with mountain icon -->
+    <rect x="250" y="104" width="64" height="52" rx="6" fill="#cfe3d5"/>
+    <path d="M256 148 l16 -20 l10 12 l8 -9 l14 17 z" fill="#2a5a3a"/>
+    <circle cx="268" cy="116" r="5" fill="#ffffff"/>
+    <!-- text lines -->
+    <rect x="86" y="172" width="228" height="8" rx="4" fill="#cfe3d5"/>
+    <rect x="86" y="188" width="200" height="8" rx="4" fill="#cfe3d5"/>
+    <rect x="86" y="204" width="214" height="8" rx="4" fill="#cfe3d5"/>
+  </g>
+  <!-- pencil, editing the page yourself -->
+  <g transform="rotate(40 318 218)">
+    <rect x="304" y="150" width="28" height="96" rx="4" fill="#7fb08f" stroke="#0d1f12" stroke-width="3"/>
+    <path d="M304 246 h28 l-14 26 z" fill="#f6d9a0" stroke="#0d1f12" stroke-width="3" stroke-linejoin="round"/>
+    <path d="M311 258 l7 14 l7 -14 z" fill="#0d1f12"/>
+    <rect x="304" y="140" width="28" height="12" rx="3" fill="#2a5a3a" stroke="#0d1f12" stroke-width="3"/>
+  </g>
+</svg>

--- a/penguin/style.css
+++ b/penguin/style.css
@@ -90,6 +90,82 @@ main section {
   background: #1e4029;
 }
 
+/* Service blocks: one illustration + pitch per service, stacked. They replace
+   the old six-card product grid so the homepage reads top to bottom as a
+   single line: what we do, how we work, who we are, contact. */
+.service-block {
+  display: grid;
+  grid-template-columns: 2fr 3fr;
+  gap: 2em;
+  align-items: center;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  padding: 2em;
+  margin-top: 1.5em;
+}
+.service-block img {
+  width: 100%;
+  height: auto;
+}
+.service-block h3 {
+  font-size: 1.3em;
+  margin-bottom: 0.4em;
+  color: #0d1f12;
+}
+.service-block p {
+  color: #444;
+  margin-bottom: 1em;
+}
+.service-block .service-note {
+  font-size: 0.85em;
+  color: #777;
+  margin-top: 0.8em;
+  margin-bottom: 0;
+}
+
+/* About section portrait */
+.about-grid {
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  gap: 2em;
+  align-items: center;
+}
+.about-portrait {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 1 / 1;
+  object-fit: cover;
+  border-radius: 50%;
+  background: #f0f5f1;
+  border: 1px solid #e0e0e0;
+}
+
+/* Hero with an image beside the text (WordPress page) */
+.hero-grid {
+  display: grid;
+  grid-template-columns: 3fr 2fr;
+  gap: 2em;
+  align-items: center;
+}
+.hero-image {
+  width: 100%;
+  height: auto;
+  border-radius: 6px;
+}
+
+@media (max-width: 700px) {
+  .service-block,
+  .about-grid,
+  .hero-grid {
+    grid-template-columns: 1fr;
+  }
+  .about-portrait {
+    max-width: 180px;
+    margin: 0 auto;
+  }
+}
+
 /* Card grid */
 .card-grid {
   list-style: none;

--- a/shake/PenguinTemplates.hs
+++ b/shake/PenguinTemplates.hs
@@ -54,6 +54,93 @@ penguinOgImage = "https://jappiesoftware.com/og-default.png"
 contactMailto :: H.AttributeValue
 contactMailto = toValue ("mailto:" <> companyEmail)
 
+-- Decision: the landing page shows exactly two service blocks (websites,
+-- webshop migration) instead of the previous six-card product grid. Client
+-- feedback: the cards were confusing, three of them jumped straight to
+-- webwinkelverhuis.nl, and the page had no pictures and no reading line.
+-- Alternatives considered: keeping all six cards with images (still noisy),
+-- or one combined block (hides that these are two distinct services).
+-- Massapp and IoT were dropped from the landing page; they were "coming
+-- soon" filler without a next step for the visitor.
+
+-- | One service on the landing page: an illustration next to a short pitch
+-- with a single call to action, rendered as a wide block.
+data ServiceBlock = ServiceBlock
+  { serviceImageSource :: Text
+  , serviceImageAlt :: Text
+  , serviceTitle :: Text
+  , serviceBody :: Html
+  , serviceLinkHref :: Text
+  , serviceLinkLabel :: Text
+  , serviceNote :: Maybe Html
+  }
+
+-- | Render a 'ServiceBlock' as an image-plus-text block with one button.
+renderServiceBlock :: ServiceBlock -> Html
+renderServiceBlock block =
+  H.div ! A.class_ "service-block" $ do
+    H.img ! A.src (toValue (serviceImageSource block))
+          ! A.alt (toValue (serviceImageAlt block))
+          ! A.width "400" ! A.height "300"
+    H.div $ do
+      H.h3 (toHtml (serviceTitle block))
+      H.p (serviceBody block)
+      H.a ! A.href (toValue (serviceLinkHref block)) ! A.class_ "cta-button" $
+        toHtml (serviceLinkLabel block)
+      case serviceNote block of
+        Just note -> H.p ! A.class_ "service-note" $ note
+        Nothing -> mempty
+
+-- | English "have a website built" service block, linking within this site.
+wordpressServiceEn :: ServiceBlock
+wordpressServiceEn = ServiceBlock
+  { serviceImageSource = "/illustratie-website.svg"
+  , serviceImageAlt = "Illustration of a website being built, with a pencil editing the page"
+  , serviceTitle = "Have a website built"
+  , serviceBody = "A clean, fast WordPress website for your business, for one fixed price. You see a sketch before we build, and after delivery you can update everything yourself."
+  , serviceLinkHref = "/wordpress-websites.html"
+  , serviceLinkLabel = "What you can expect"
+  , serviceNote = Nothing
+  }
+
+-- | English webshop-migration service block. This one leaves the site, so the
+-- note says so explicitly instead of surprising the visitor.
+migrationServiceEn :: ServiceBlock
+migrationServiceEn = ServiceBlock
+  { serviceImageSource = "/illustratie-verhuizen.svg"
+  , serviceImageAlt = "Illustration of boxes moving from an old webshop to a new one"
+  , serviceTitle = "Move your webshop"
+  , serviceBody = "Stuck on MijnWebwinkel, CCV Shop or Lightspeed? We move your complete webshop to Shopify or another platform: products, translations, images and the redirects that keep your Google rankings."
+  , serviceLinkHref = "https://webwinkelverhuis.nl/"
+  , serviceLinkLabel = "Visit Webwinkelverhuis"
+  , serviceNote = Just "Opens webwinkelverhuis.nl, our dedicated migration site."
+  }
+
+-- | Dutch "laat een website bouwen" service block, linking within this site.
+wordpressServiceNl :: ServiceBlock
+wordpressServiceNl = ServiceBlock
+  { serviceImageSource = "/illustratie-website.svg"
+  , serviceImageAlt = "Illustratie van een website in aanbouw, met een potlood dat de pagina bewerkt"
+  , serviceTitle = "Laat een website bouwen"
+  , serviceBody = "Een verzorgde, snelle WordPress-website voor uw bedrijf, voor \233\233n vaste prijs. U ziet eerst een schets, en na oplevering kunt u alles zelf aanpassen."
+  , serviceLinkHref = "/nl/wordpress-websites.html"
+  , serviceLinkLabel = "Wat u kunt verwachten"
+  , serviceNote = Nothing
+  }
+
+-- | Dutch webshop-migration service block. This one leaves the site, so the
+-- note says so explicitly instead of surprising the visitor.
+migrationServiceNl :: ServiceBlock
+migrationServiceNl = ServiceBlock
+  { serviceImageSource = "/illustratie-verhuizen.svg"
+  , serviceImageAlt = "Illustratie van dozen die van een oude webshop naar een nieuwe verhuizen"
+  , serviceTitle = "Verhuis uw webshop"
+  , serviceBody = "Vastgelopen op MijnWebwinkel, CCV Shop of Lightspeed? Wij verhuizen uw complete webshop naar Shopify of een ander platform: producten, vertalingen, afbeeldingen en de redirects die uw Google-posities behouden."
+  , serviceLinkHref = "https://webwinkelverhuis.nl/"
+  , serviceLinkLabel = "Naar Webwinkelverhuis"
+  , serviceNote = Just "Opent webwinkelverhuis.nl, onze aparte migratie-site."
+  }
+
 -- =============================================================================
 -- Base templates
 -- =============================================================================
@@ -160,10 +247,11 @@ penguinAnchor :: Lang -> Text -> H.AttributeValue
 penguinAnchor En section = toValue ("/#" <> section)
 penguinAnchor Nl section = toValue ("/nl/#" <> section)
 
--- | Navigation label for the products section.
+-- | Navigation label for the services section (anchor id stays "products" so
+-- old links keep working).
 navProducts :: Lang -> Text
-navProducts En = "Products"
-navProducts Nl = "Producten"
+navProducts En = "Services"
+navProducts Nl = "Diensten"
 
 -- | Navigation label for the consulting section.
 navConsulting :: Lang -> Text
@@ -202,37 +290,29 @@ penguinIndexPage = penguinBaseTemplate En indexMeta $
   H.main $ do
     -- Hero
     H.section ! A.class_ "hero" $ do
-      H.h1 "We build software that solves real problems."
-      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Software products and expert consulting from a team that ships reliable systems. We build tools we believe in &mdash; and help others do the same." :: Text)
+      H.h1 "A website or webshop that works for your business."
+      H.p ! A.class_ "subtitle" $ "We build websites for small businesses and move webshops to a better platform. Fixed price, plain language, and you pay on delivery."
+      H.a ! A.href contactMailto ! A.class_ "cta-button" $ "Get in touch"
 
-    -- Products
+    -- What we do: the two services
     H.section ! A.class_ "for-who" ! A.id "products" $ do
-      H.h2 "Products"
-      H.ul ! A.class_ "card-grid" $ do
-        H.li ! A.class_ "card" $ do
-          H.h3 "MijnWebwinkel Migration Tool"
-          H.p $ H.preEscapedToHtml ("Migrate your webshop from MijnWebwinkel to Shopify, WooCommerce or another platform &mdash; products, categories, translations, images, SEO redirects and bulk data modifications. Fully automated." :: Text)
-          H.a ! A.href "https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Learn more &rarr;" :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "CCV Shop Migration Tool"
-          H.p $ H.preEscapedToHtml ("Migrate your webshop from CCV Shop to Shopify &mdash; products, categories, translations, images, inventory and SEO redirects. Fully automated." :: Text)
-          H.a ! A.href "https://webwinkelverhuis.nl/migrate-ccvshop.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Learn more &rarr;" :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "Lightspeed Migration Tool"
-          H.p $ H.preEscapedToHtml ("Migrate your webshop from Lightspeed to Shopify &mdash; products, categories, translations, images, inventory and SEO redirects. No traffic loss." :: Text)
-          H.a ! A.href "https://webwinkelverhuis.nl/migrate-lightspeed.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Learn more &rarr;" :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "WordPress Websites"
-          H.p $ H.preEscapedToHtml ("A professional website for your business, built for a fixed price and ready to manage yourself. Often the first step before selling online." :: Text)
-          H.a ! A.href "/wordpress-websites.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Learn more &rarr;" :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "Massapp"
-          H.p "Bulk WhatsApp messaging for businesses. Reach your customers at scale through the official WhatsApp Business API."
-          H.p ! A.class_ "coming-soon" $ "Rebuilding on official API. Contact us for early access."
-        H.li ! A.class_ "card" $ do
-          H.h3 "IoT & Sensor Solutions"
-          H.p $ H.preEscapedToHtml ("Custom software for sensor data collection, monitoring, and dashboards. We have deep experience with IoT systems &mdash; from firmware to cloud." :: Text)
-          H.p ! A.class_ "coming-soon" $ "Looking for partners with domain expertise."
+      H.h2 "What we do"
+      renderServiceBlock wordpressServiceEn
+      renderServiceBlock migrationServiceEn
+
+    -- How we work: the same three steps every subpage elaborates on
+    H.section ! A.class_ "audit" $ do
+      H.h2 "How we work"
+      H.ol $ do
+        H.li $ do
+          H.strong "Meet"
+          ": a free conversation about what you need. No obligations."
+        H.li $ do
+          H.strong "Fixed proposal"
+          ": one fixed price, agreed up front. No hourly billing, no surprises."
+        H.li $ do
+          H.strong "Build and deliver"
+          ": you check everything before it goes live, and you pay on delivery."
 
     -- Consulting
     H.section ! A.class_ "results" ! A.id "consulting" $ do
@@ -262,25 +342,32 @@ penguinIndexPage = penguinBaseTemplate En indexMeta $
     -- About
     H.section ! A.class_ "about" $ do
       H.h2 "About"
-      H.p $ H.preEscapedToHtml ("I&rsquo;m Jappie Klooster. I build software products and help companies that need serious technical expertise. I use technologies chosen for reliability &mdash; Haskell, Nix, and whatever else gets the job done right." :: Text)
-      H.p $ H.preEscapedToHtml ("Based in the Netherlands. Available for product partnerships, consulting engagements, and co-founder conversations." :: Text)
-      H.p $ do
-        "For more writing and case studies, visit the "
-        H.a ! A.href "/blog/" $ "blog"
-        "."
+      H.div ! A.class_ "about-grid" $ do
+        H.div $ do
+          H.p $ H.preEscapedToHtml ("I&rsquo;m Jappie Klooster. I build websites, webshops and software products, and I help companies that need serious technical expertise. I use technology chosen for reliability, and I explain what I do in plain language." :: Text)
+          H.p "Based in the Netherlands. Available for product partnerships, consulting engagements, and co-founder conversations."
+          H.p $ do
+            "For more writing and case studies, visit the "
+            H.a ! A.href "/blog/" $ "blog"
+            "."
+        H.img ! A.class_ "about-portrait"
+              ! A.src "/selfie.png"
+              ! A.alt "Jappie Klooster"
+              ! A.width "300" ! A.height "259"
 
     -- Final CTA
     H.section ! A.class_ "final-cta" $ do
       H.h2 "Have a problem that needs solving?"
       H.p $ do
-        H.preEscapedToHtml ("Whether you need a product, a technical partner, or expert consulting &mdash; " :: Text)
+        "Whether you need a website, a webshop migration, or expert consulting: "
         H.a ! A.href contactMailto $ "get in touch"
         "."
       H.a ! A.href contactMailto ! A.class_ "cta-button" $ "Get in touch"
   where
     indexMeta :: PageMeta
-    indexMeta = (defaultPageMeta "Jappie Software B.V. \8212 Software Products & Expert Consulting")
-      { pageMetaCanonical = Just "https://jappiesoftware.com/"
+    indexMeta = (defaultPageMeta "Jappie Software B.V. \8212 Websites, Webshop Migrations & Consulting")
+      { pageMetaDescription = "We build websites for small businesses and move webshops to a better platform. Fixed price, plain language, and you pay on delivery."
+      , pageMetaCanonical = Just "https://jappiesoftware.com/"
       , pageMetaSwitchUrl = Just "/nl/"
       }
 
@@ -296,37 +383,29 @@ penguinIndexPageNl = penguinBaseTemplate Nl indexMetaNl $
   H.main $ do
     -- Hero
     H.section ! A.class_ "hero" $ do
-      H.h1 "Wij bouwen software die echte problemen oplost."
-      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Softwareproducten en deskundig advies van een team dat betrouwbare systemen oplevert. We bouwen tools waar we zelf in geloven, en helpen anderen hetzelfde te doen." :: Text)
+      H.h1 "Een website of webshop die voor uw bedrijf werkt."
+      H.p ! A.class_ "subtitle" $ "Wij bouwen websites voor ondernemers en verhuizen webshops naar een beter platform. Vaste prijs, gewone taal, en u betaalt na oplevering."
+      H.a ! A.href contactMailto ! A.class_ "cta-button" $ "Neem contact op"
 
-    -- Producten
+    -- Wat we doen: de twee diensten
     H.section ! A.class_ "for-who" ! A.id "products" $ do
-      H.h2 "Producten"
-      H.ul ! A.class_ "card-grid" $ do
-        H.li ! A.class_ "card" $ do
-          H.h3 "MijnWebwinkel-migratie"
-          H.p $ H.preEscapedToHtml ("Verhuis uw webshop van MijnWebwinkel naar Shopify, WooCommerce of een ander platform: producten, categorie\235n, vertalingen, afbeeldingen, SEO-redirects en bulk-aanpassingen. Volledig geautomatiseerd." :: Text)
-          H.a ! A.href "https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Lees meer &rarr;" :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "CCV Shop-migratie"
-          H.p $ H.preEscapedToHtml ("Verhuis uw webshop van CCV Shop naar Shopify: producten, categorie\235n, vertalingen, afbeeldingen, voorraad en SEO-redirects. Volledig geautomatiseerd." :: Text)
-          H.a ! A.href "https://webwinkelverhuis.nl/migrate-ccvshop.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Lees meer &rarr;" :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "Lightspeed-migratie"
-          H.p $ H.preEscapedToHtml ("Verhuis uw webshop van Lightspeed naar Shopify: producten, categorie\235n, vertalingen, afbeeldingen, voorraad en SEO-redirects. Zonder verkeersverlies." :: Text)
-          H.a ! A.href "https://webwinkelverhuis.nl/migrate-lightspeed.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Lees meer &rarr;" :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "WordPress-websites"
-          H.p $ H.preEscapedToHtml ("Een professionele website voor uw bedrijf, voor een vaste prijs en zelf te beheren. Vaak de eerste stap voordat u online gaat verkopen." :: Text)
-          H.a ! A.href "/nl/wordpress-websites.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Lees meer &rarr;" :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "Massapp"
-          H.p "Bulk-WhatsApp-berichten voor bedrijven. Bereik uw klanten op grote schaal via de offici\235le WhatsApp Business API."
-          H.p ! A.class_ "coming-soon" $ "Wordt herbouwd op de offici\235le API. Neem contact op voor vroege toegang."
-        H.li ! A.class_ "card" $ do
-          H.h3 "IoT & sensoroplossingen"
-          H.p $ H.preEscapedToHtml ("Software op maat voor sensordata, monitoring en dashboards. We hebben diepgaande ervaring met IoT-systemen, van firmware tot cloud." :: Text)
-          H.p ! A.class_ "coming-soon" $ "Op zoek naar partners met domeinkennis."
+      H.h2 "Wat we doen"
+      renderServiceBlock wordpressServiceNl
+      renderServiceBlock migrationServiceNl
+
+    -- Hoe we werken: dezelfde drie stappen die elke subpagina uitwerkt
+    H.section ! A.class_ "audit" $ do
+      H.h2 "Hoe we werken"
+      H.ol $ do
+        H.li $ do
+          H.strong "Kennismaken"
+          ": een gratis gesprek over wat u nodig hebt. Vrijblijvend."
+        H.li $ do
+          H.strong "Vast voorstel"
+          ": \233\233n vaste prijs, vooraf afgesproken. Geen uurtarief, geen verrassingen."
+        H.li $ do
+          H.strong "Bouwen en opleveren"
+          ": u controleert alles voordat het live gaat, en u betaalt na oplevering."
 
     -- Consultancy
     H.section ! A.class_ "results" ! A.id "consulting" $ do
@@ -356,25 +435,31 @@ penguinIndexPageNl = penguinBaseTemplate Nl indexMetaNl $
     -- Over
     H.section ! A.class_ "about" $ do
       H.h2 "Over ons"
-      H.p $ H.preEscapedToHtml ("Ik ben Jappie Klooster. Ik bouw softwareproducten en help bedrijven die serieuze technische expertise nodig hebben. Ik kies technologie op betrouwbaarheid: Haskell, Nix, en wat het werk verder goed doet." :: Text)
-      H.p $ H.preEscapedToHtml ("Gevestigd in Nederland. Beschikbaar voor productpartnerschappen, adviesopdrachten en gesprekken over medeoprichterschap." :: Text)
-      H.p $ do
-        "Meer schrijfsels en cases vindt u op de "
-        H.a ! A.href "/blog/" $ "blog"
-        "."
+      H.div ! A.class_ "about-grid" $ do
+        H.div $ do
+          H.p "Ik ben Jappie Klooster. Ik bouw websites, webshops en softwareproducten, en help bedrijven die serieuze technische expertise nodig hebben. Ik kies technologie op betrouwbaarheid, en leg in gewone taal uit wat ik doe."
+          H.p "Gevestigd in Nederland. Beschikbaar voor productpartnerschappen, adviesopdrachten en gesprekken over medeoprichterschap."
+          H.p $ do
+            "Meer schrijfsels en cases vindt u op de "
+            H.a ! A.href "/blog/" $ "blog"
+            "."
+        H.img ! A.class_ "about-portrait"
+              ! A.src "/selfie.png"
+              ! A.alt "Jappie Klooster"
+              ! A.width "300" ! A.height "259"
 
     -- Laatste CTA
     H.section ! A.class_ "final-cta" $ do
       H.h2 "Een probleem dat opgelost moet worden?"
       H.p $ do
-        "Of u nu een product, een technische partner of deskundig advies nodig hebt, "
+        "Of u nu een website, een webshopverhuizing of deskundig advies nodig hebt, "
         H.a ! A.href contactMailto $ "neem contact op"
         "."
       H.a ! A.href contactMailto ! A.class_ "cta-button" $ "Neem contact op"
   where
     indexMetaNl :: PageMeta
-    indexMetaNl = (defaultPageMeta "Jappie Software B.V. \8212 Softwareproducten & deskundig advies")
-      { pageMetaDescription = "Softwareproducten en deskundig advies. We bouwen betrouwbare systemen die echte problemen oplossen."
+    indexMetaNl = (defaultPageMeta "Jappie Software B.V. \8212 Websites, webshopverhuizingen & advies")
+      { pageMetaDescription = "Wij bouwen websites voor ondernemers en verhuizen webshops naar een beter platform. Vaste prijs, gewone taal, en u betaalt na oplevering."
       , pageMetaLang        = "nl"
       , pageMetaCanonical   = Just "https://jappiesoftware.com/nl/"
       , pageMetaSwitchUrl   = Just "/"
@@ -393,33 +478,39 @@ penguinWordpressPage :: Html
 penguinWordpressPage = penguinBaseTemplate En wordpressMeta $
   H.main $ do
     -- Hero
-    H.section ! A.class_ "hero" $ do
-      H.h1 "A website that works for your business."
-      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("A clean, fast WordPress site, built for one fixed price and handed over so you can manage it yourself. No hourly billing, no surprises, and you pay on delivery." :: Text)
-      H.a ! A.href contactMailto ! A.class_ "cta-button" $ "Get in touch"
+    H.section ! A.class_ "hero" $
+      H.div ! A.class_ "hero-grid" $ do
+        H.div $ do
+          H.h1 "Have a website built that works for your business."
+          H.p ! A.class_ "subtitle" $ "A clean, fast WordPress site for practices, coaches and other small businesses. One fixed price, you see a sketch up front, and after delivery you update everything yourself."
+          H.a ! A.href contactMailto ! A.class_ "cta-button" $ "Get in touch"
+        H.img ! A.class_ "hero-image"
+              ! A.src "/huiskamer.jpg"
+              ! A.alt "Watercolour of a warm living room: the feeling your website should have"
+              ! A.width "350" ! A.height "451"
 
-    -- What you get
+    -- What you can expect
     H.section ! A.class_ "for-who" ! A.id "what" $ do
-      H.h2 "What you get"
+      H.h2 "What you can expect"
       H.ul ! A.class_ "card-grid" $ do
         H.li ! A.class_ "card" $ do
-          H.h3 "A theme built around your brand"
-          H.p $ H.preEscapedToHtml ("We set up a premium-looking theme in your own colours and lay out the pages you need. You approve the look up front: two candidates with dummy content, you pick." :: Text)
+          H.h3 "A design in your own style"
+          H.p "We set up the site in your colours and logo, and lay out the pages you need. You pick from two proposals with sample content up front, so you know what you are getting."
         H.li ! A.class_ "card" $ do
-          H.h3 "Mobile-first and responsive"
-          H.p $ H.preEscapedToHtml ("Built mobile-first and tested on phone, laptop and desktop, so it looks right everywhere: consistent margins, sensible proportions, a layout that works on a small screen." :: Text)
+          H.h3 "Looks right on phone and computer"
+          H.p "Built and tested on phone, laptop and desktop, so it looks right everywhere: consistent margins, sensible proportions, a layout that works on a small screen."
         H.li ! A.class_ "card" $ do
           H.h3 "Contact, WhatsApp and bookings"
-          H.p $ H.preEscapedToHtml ("A contact form, your email and phone in plain sight, and a WhatsApp button. Optionally a booking tool (Calendly, Google Appointments) so clients can plan an appointment themselves." :: Text)
+          H.p "A contact form, your email and phone in plain sight, and a WhatsApp button. Optionally a booking tool so clients can plan an appointment themselves."
         H.li ! A.class_ "card" $ do
-          H.h3 "Basic SEO"
-          H.p $ H.preEscapedToHtml ("Meta titles and descriptions, image alt text and a clean heading structure so Google understands the page. You supply the keywords, we build them in correctly." :: Text)
+          H.h3 "Being found on Google"
+          H.p "Clean page titles, descriptions and headings so Google understands your site. You tell us what you want to be found for, we build it in correctly."
         H.li ! A.class_ "card" $ do
-          H.h3 "HTTPS, speed and security"
-          H.p $ H.preEscapedToHtml ("SSL (the padlock) switched on, images sized right and a page cache as the final step. On managed hosting this is part of a tidy build, not a separate expensive package." :: Text)
+          H.h3 "Safe and fast"
+          H.p "The padlock in the browser (SSL), images sized right and a site that loads quickly. That is part of a tidy build, not a separate expensive package."
         H.li ! A.class_ "card" $ do
-          H.h3 "A handover, so it stays yours"
-          H.p $ H.preEscapedToHtml ("A personal video walkthrough plus a short written manual: edit text, update a page, replace a photo, manage the bookings. You are not tied to us for day-to-day changes." :: Text)
+          H.h3 "Update it yourself, no need to call us"
+          H.p "A personal video walkthrough plus a short written manual: edit text, replace a photo, update a page. After that you can do it yourself, and we stay available for bigger jobs."
 
     -- Recent work: hidden until these projects are actually delivered and live.
     {-
@@ -440,20 +531,23 @@ penguinWordpressPage = penguinBaseTemplate En wordpressMeta $
 
     -- How it works
     H.section ! A.class_ "audit" $ do
-      H.h2 "How it works"
+      H.h2 "How does it work?"
       H.ol $ do
         H.li $ do
-          H.strong "Intake"
-          ": we talk through your goals, the pages you need and the style you want."
+          H.strong "Meet"
+          ": we talk through your goals, the pages you need and the style you want. Free, no obligations."
         H.li $ do
-          H.strong "Theme proposal"
-          ": you pick from two candidates with dummy content, so you see the look before we build."
+          H.strong "Sketch (wireframe)"
+          ": you get a simple sketch of the layout first, so you see where everything goes before anything is built."
+        H.li $ do
+          H.strong "Design proposal"
+          ": you pick from two worked-out proposals with sample content, in your own colours."
         H.li $ do
           H.strong "Build"
-          ": we set up the pages and place your texts, images and brand colours."
+          ": we set up the pages and place your texts, photos and brand colours."
         H.li $ do
           H.strong "Handover"
-          ": the site goes live and you get a walkthrough plus a manual to manage it yourself."
+          ": the site goes live and you get a video walkthrough plus a short manual, so you can update everything yourself."
 
     -- The webshop angle
     H.section ! A.class_ "about" $ do
@@ -474,8 +568,8 @@ penguinWordpressPage = penguinBaseTemplate En wordpressMeta $
       H.a ! A.href contactMailto ! A.class_ "cta-button" $ "Get in touch"
   where
     wordpressMeta :: PageMeta
-    wordpressMeta = (defaultPageMeta "WordPress Websites \8212 Jappie Software B.V.")
-      { pageMetaDescription = "Fixed-price WordPress websites for small businesses: a clean, fast site in your own brand, handed over so you can manage it yourself. Often the first step before a webshop."
+    wordpressMeta = (defaultPageMeta "Have a Website Built \8212 Fixed-Price WordPress \8212 Jappie Software B.V.")
+      { pageMetaDescription = "Have a website built for one fixed price: a clean, fast WordPress site. You see a sketch (wireframe) up front and can update everything yourself after delivery."
       , pageMetaCanonical   = Just "https://jappiesoftware.com/wordpress-websites.html"
       , pageMetaSwitchUrl   = Just "/nl/wordpress-websites.html"
       }
@@ -490,33 +584,39 @@ penguinWordpressPageNl :: Html
 penguinWordpressPageNl = penguinBaseTemplate Nl wordpressMetaNl $
   H.main $ do
     -- Hero
-    H.section ! A.class_ "hero" $ do
-      H.h1 "Een website die voor uw bedrijf werkt."
-      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Een verzorgde, snelle WordPress-site, gebouwd voor \233\233n vaste prijs en zo opgeleverd dat u hem zelf kunt beheren. Geen uurtarief, geen verrassingen, en u betaalt na oplevering." :: Text)
-      H.a ! A.href contactMailto ! A.class_ "cta-button" $ "Neem contact op"
+    H.section ! A.class_ "hero" $
+      H.div ! A.class_ "hero-grid" $ do
+        H.div $ do
+          H.h1 "Laat een website bouwen die voor uw bedrijf werkt."
+          H.p ! A.class_ "subtitle" $ "Een verzorgde, snelle WordPress-site voor praktijken, coaches en andere kleine ondernemers. E\233n vaste prijs, u ziet vooraf een schets, en na oplevering past u alles zelf aan."
+          H.a ! A.href contactMailto ! A.class_ "cta-button" $ "Neem contact op"
+        H.img ! A.class_ "hero-image"
+              ! A.src "/huiskamer.jpg"
+              ! A.alt "Aquarel van een warme huiskamer: de sfeer die uw website mag hebben"
+              ! A.width "350" ! A.height "451"
 
-    -- Wat u krijgt
+    -- Wat u kunt verwachten
     H.section ! A.class_ "for-who" ! A.id "what" $ do
-      H.h2 "Wat u krijgt"
+      H.h2 "Wat u kunt verwachten"
       H.ul ! A.class_ "card-grid" $ do
         H.li ! A.class_ "card" $ do
-          H.h3 "Een thema rond uw merk"
-          H.p $ H.preEscapedToHtml ("We richten een premium-ogend thema in uw eigen kleuren in en zetten de pagina's op die u nodig hebt. U keurt de look vooraf goed: twee kandidaten met voorbeeldinhoud, u kiest." :: Text)
+          H.h3 "Een ontwerp in uw eigen stijl"
+          H.p "We richten de site in met uw kleuren en logo, en zetten de pagina's op die u nodig hebt. U kiest vooraf uit twee voorstellen met voorbeeldinhoud, zodat u weet wat u krijgt."
         H.li ! A.class_ "card" $ do
-          H.h3 "Mobile-first en responsive"
-          H.p $ H.preEscapedToHtml ("Mobile-first gebouwd en getest op telefoon, laptop en desktop, zodat het overal klopt: nette marges, kloppende verhoudingen en een indeling die op een klein scherm werkt." :: Text)
+          H.h3 "Mooi op telefoon en computer"
+          H.p "Gebouwd en getest op telefoon, laptop en desktop, zodat het overal klopt: nette marges, kloppende verhoudingen en een indeling die op een klein scherm werkt."
         H.li ! A.class_ "card" $ do
           H.h3 "Contact, WhatsApp en afspraken"
-          H.p $ H.preEscapedToHtml ("Een contactformulier, uw e-mail en telefoon goed zichtbaar, en een WhatsApp-knop. Optioneel een afsprakentool (Calendly, Google Afspraken) zodat klanten zelf een afspraak inplannen." :: Text)
+          H.p "Een contactformulier, uw e-mail en telefoon goed zichtbaar, en een WhatsApp-knop. Optioneel een afsprakentool zodat klanten zelf een afspraak inplannen."
         H.li ! A.class_ "card" $ do
-          H.h3 "Basis-SEO"
-          H.p $ H.preEscapedToHtml ("Meta-titels en -beschrijvingen, alt-teksten bij afbeeldingen en een nette koppenstructuur zodat Google de pagina begrijpt. U levert de zoekwoorden, wij bouwen ze correct in." :: Text)
+          H.h3 "Gevonden worden in Google"
+          H.p "Nette paginatitels, beschrijvingen en koppen zodat Google uw site begrijpt. U vertelt waarop u gevonden wilt worden, wij bouwen het correct in."
         H.li ! A.class_ "card" $ do
-          H.h3 "HTTPS, snelheid en beveiliging"
-          H.p $ H.preEscapedToHtml ("SSL (het slotje) aangezet, afbeeldingen in de juiste maat en een page cache als laatste stap. Op managed hosting hoort dit bij een nette bouw, niet bij een apart duur pakket." :: Text)
+          H.h3 "Veilig en snel"
+          H.p "Het slotje in de browser (SSL), afbeeldingen in de juiste maat en een site die vlot laadt. Dat hoort bij een nette bouw, niet bij een apart duur pakket."
         H.li ! A.class_ "card" $ do
-          H.h3 "Een overdracht, zodat het van u blijft"
-          H.p $ H.preEscapedToHtml ("Een persoonlijke videorondleiding plus een korte handleiding: tekst aanpassen, een pagina bijwerken, een foto vervangen, de afspraken beheren. U bent voor dagelijkse aanpassingen niet afhankelijk van ons." :: Text)
+          H.h3 "Zelf aanpassen zonder ons te bellen"
+          H.p "Een persoonlijke videorondleiding plus een korte handleiding: tekst aanpassen, een foto vervangen, een pagina bijwerken. U kunt het daarna zelf, en voor grotere klussen blijven we bereikbaar."
 
     -- Recent werk: verborgen tot deze projecten daadwerkelijk opgeleverd en live zijn.
     {-
@@ -537,20 +637,23 @@ penguinWordpressPageNl = penguinBaseTemplate Nl wordpressMetaNl $
 
     -- Hoe het werkt
     H.section ! A.class_ "audit" $ do
-      H.h2 "Hoe het werkt"
+      H.h2 "Hoe gaat het in zijn werk?"
       H.ol $ do
         H.li $ do
-          H.strong "Intake"
-          ": we bespreken uw doelen, de pagina's die u nodig hebt en de stijl die u wilt."
+          H.strong "Kennismaken"
+          ": we bespreken uw doelen, de pagina's die u nodig hebt en de stijl die u wilt. Gratis en vrijblijvend."
         H.li $ do
-          H.strong "Themavoorstel"
-          ": u kiest uit twee kandidaten met voorbeeldinhoud, zodat u de look ziet voordat we bouwen."
+          H.strong "Schets (wireframe)"
+          ": u krijgt eerst een eenvoudige schets van de indeling, zodat u ziet waar alles komt te staan voordat er iets gebouwd wordt."
+        H.li $ do
+          H.strong "Ontwerpvoorstel"
+          ": u kiest uit twee uitgewerkte voorstellen met voorbeeldinhoud, in uw eigen kleuren."
         H.li $ do
           H.strong "Bouw"
-          ": we zetten de pagina's op en verwerken uw teksten, afbeeldingen en merkkleuren."
+          ": we zetten de pagina's op en verwerken uw teksten, foto's en merkkleuren."
         H.li $ do
           H.strong "Overdracht"
-          ": de site gaat live en u krijgt een rondleiding plus een handleiding om hem zelf te beheren."
+          ": de site gaat live en u krijgt een videorondleiding plus een korte handleiding, zodat u alles zelf kunt aanpassen."
 
     -- De webshop-stap
     H.section ! A.class_ "about" $ do
@@ -571,8 +674,8 @@ penguinWordpressPageNl = penguinBaseTemplate Nl wordpressMetaNl $
       H.a ! A.href contactMailto ! A.class_ "cta-button" $ "Neem contact op"
   where
     wordpressMetaNl :: PageMeta
-    wordpressMetaNl = (defaultPageMeta "WordPress-websites \8212 Jappie Software B.V.")
-      { pageMetaDescription = "WordPress-websites met vaste prijs voor het mkb: een verzorgde, snelle site in uw eigen merk, opgeleverd zodat u hem zelf kunt beheren. Vaak de eerste stap voor een webshop."
+    wordpressMetaNl = (defaultPageMeta "Laat een website bouwen \8212 WordPress met vaste prijs \8212 Jappie Software B.V.")
+      { pageMetaDescription = "Laat een website bouwen voor \233\233n vaste prijs: een verzorgde, snelle WordPress-site. U ziet vooraf een schets (wireframe) en kunt na oplevering alles zelf aanpassen."
       , pageMetaLang        = "nl"
       , pageMetaCanonical   = Just "https://jappiesoftware.com/nl/wordpress-websites.html"
       , pageMetaSwitchUrl   = Just "/wordpress-websites.html"

--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -385,6 +385,7 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $ do
           H.h3 "Volledige migratie"
           H.p ! A.class_ "price" $ H.preEscapedToHtml ("Vanaf &euro;999" :: Text)
           H.p $ H.preEscapedToHtml ("Producten, afbeeldingen, vertalingen, categorie&euml;n, klantdata, SEO-redirects en eventuele bulk-aanpassingen. Prijs afhankelijk van de omvang van uw webshop." :: Text)
+          H.a ! A.href offerteMailto ! A.class_ "cta-button" $ "Vraag een offerte aan"
       H.p ! A.class_ "engagement-note" $ H.preEscapedToHtml ("Vaste prijs, vooraf afgesproken. Geen verrassingen. Betaling na succesvolle migratie." :: Text)
 
     -- Recent werk
@@ -468,13 +469,13 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $ do
 mijnwebwinkelFaq :: [(Text, Text)]
 mijnwebwinkelFaq =
   [ ( "Hoe lang duurt een migratie?"
-    , "De technische migratie duurt meestal 1-2 werkdagen. De voorbereiding en controle erbij: reken op een week totaal." )
+    , "Het technische overzetten van uw producten duurt maar enkele uren. Maar er komt bij een verhuizing meestal meer kijken: het thema, apps en plugins, betaalmethoden, en de controle van de testshop op uw tempo. Reken daarom op ongeveer een maand van start tot livegang." )
   , ( "Kan ik mijn domeinnaam behouden?"
     , "Ja. Na de migratie wijst u uw domein naar Shopify. Alle oude URLs worden automatisch doorgestuurd." )
   , ( "Wat als er iets niet klopt na de migratie?"
     , "We controleren samen steekproefsgewijs. Eventuele correcties zijn inbegrepen in de vaste prijs." )
-  , ( "Werkt het ook voor andere talen dan NL/DE/EN?"
-    , "Ja. Het programma ondersteunt elke taalcombinatie die MijnWebwinkel en uw doelplatform beide ondersteunen." )
+  , ( "Werkt het ook voor meertalige webshops?"
+    , "Ja. Nederlands, Duits, Engels, Frans of een andere taal: het programma ondersteunt elke taalcombinatie die MijnWebwinkel en uw doelplatform beide ondersteunen. Ook de vertaalde URL's verhuizen mee." )
   , ( "Kan ik ook naar een ander platform dan Shopify migreren?"
     , "Ja. Shopify is het meest gekozen doelplatform, maar we kunnen ook migreren naar WooCommerce of andere platformen." )
   , ( "Worden spaarpunten ook overgezet?"
@@ -546,6 +547,7 @@ ccvshopMigrationPage = webwinkelBaseTemplate ccvMeta $
           H.h3 "Volledige migratie"
           H.p ! A.class_ "price" $ H.preEscapedToHtml ("Vanaf &euro;999" :: Text)
           H.p $ H.preEscapedToHtml ("Producten, afbeeldingen, vertalingen, categorie&euml;n, klantdata, SEO-redirects en voorraad. Prijs afhankelijk van de omvang van uw webshop." :: Text)
+          H.a ! A.href offerteMailto ! A.class_ "cta-button" $ "Vraag een offerte aan"
       H.p ! A.class_ "engagement-note" $ H.preEscapedToHtml ("Vaste prijs, vooraf afgesproken. Geen verrassingen. Betaling na succesvolle migratie." :: Text)
 
     -- Why us
@@ -616,13 +618,13 @@ ccvshopMigrationPage = webwinkelBaseTemplate ccvMeta $
 ccvshopFaq :: [(Text, Text)]
 ccvshopFaq =
   [ ( "Hoe lang duurt een migratie?"
-    , "De technische migratie duurt meestal 1-2 werkdagen. De voorbereiding en controle erbij: reken op een week totaal." )
+    , "Het technische overzetten van uw producten duurt maar enkele uren. Maar er komt bij een verhuizing meestal meer kijken: het thema, apps en plugins, betaalmethoden, en de controle van de testshop op uw tempo. Reken daarom op ongeveer een maand van start tot livegang." )
   , ( "Kan ik mijn domeinnaam behouden?"
     , "Ja. Na de migratie wijst u uw domein naar Shopify. Alle oude URLs worden automatisch doorgestuurd." )
   , ( "Wat als er iets niet klopt na de migratie?"
     , "We controleren samen steekproefsgewijs. Eventuele correcties zijn inbegrepen in de vaste prijs." )
-  , ( "Werkt het ook voor meerdere talen?"
-    , "Ja. Het programma ondersteunt elke taalcombinatie die CCV Shop en Shopify beide ondersteunen." )
+  , ( "Werkt het ook voor meertalige webshops?"
+    , "Ja. Nederlands, Duits, Engels, Frans of een andere taal: het programma ondersteunt elke taalcombinatie die CCV Shop en Shopify beide ondersteunen." )
   , ( "Worden mijn klantaccounts overgezet?"
     , "Ja. Klantgegevens en bestelgeschiedenis worden meegenomen zodat uw klanten direct verder kunnen." )
   , ( "Hoe werken de SEO-redirects precies?"
@@ -690,6 +692,7 @@ lightspeedMigrationPage = webwinkelBaseTemplate lightspeedMeta $
           H.h3 "Volledige migratie"
           H.p ! A.class_ "price" $ H.preEscapedToHtml ("Vanaf &euro;999" :: Text)
           H.p $ H.preEscapedToHtml ("Producten, afbeeldingen, vertalingen, categorie&euml;n, klantdata, SEO-redirects en voorraad. Prijs afhankelijk van de omvang van uw webshop." :: Text)
+          H.a ! A.href offerteMailto ! A.class_ "cta-button" $ "Vraag een offerte aan"
       H.p ! A.class_ "engagement-note" $ H.preEscapedToHtml ("Vaste prijs, vooraf afgesproken. Geen verrassingen. Betaling na succesvolle migratie." :: Text)
 
     -- Why us
@@ -763,15 +766,15 @@ lightspeedMigrationPage = webwinkelBaseTemplate lightspeedMeta $
 lightspeedFaq :: [(Text, Text)]
 lightspeedFaq =
   [ ( "Hoe lang duurt een migratie?"
-    , "De technische migratie duurt meestal 1-2 werkdagen. De voorbereiding en controle erbij: reken op een week totaal." )
+    , "Het technische overzetten van uw producten duurt maar enkele uren. Maar er komt bij een verhuizing meestal meer kijken: het thema, apps en plugins, betaalmethoden, en de controle van de testshop op uw tempo. Reken daarom op ongeveer een maand van start tot livegang." )
   , ( "Kan ik mijn domeinnaam behouden?"
     , "Ja. Na de migratie wijst u uw domein naar Shopify. Alle oude URLs worden automatisch doorgestuurd." )
   , ( "Wat als er iets niet klopt na de migratie?"
     , "We controleren samen steekproefsgewijs. Eventuele correcties zijn inbegrepen in de vaste prijs." )
   , ( "Verlies ik mijn Google-posities?"
     , "Nee. Wij genereren automatisch 301-redirects voor elke URL. Dit is het belangrijkste onderdeel van een veilige migratie en de reden dat u dit niet zelf wilt doen." )
-  , ( "Werkt het ook voor meerdere talen?"
-    , "Ja. Het programma ondersteunt elke taalcombinatie die Lightspeed en Shopify beide ondersteunen." )
+  , ( "Werkt het ook voor meertalige webshops?"
+    , "Ja. Nederlands, Duits, Engels, Frans of een andere taal: het programma ondersteunt elke taalcombinatie die Lightspeed en Shopify beide ondersteunen." )
   , ( "Worden mijn klantaccounts overgezet?"
     , "Ja. Klantgegevens en bestelgeschiedenis worden meegenomen zodat uw klanten direct verder kunnen." )
   ]


### PR DESCRIPTION
## What

Processes the advertising feedback for jappiesoftware.com and webwinkelverhuis.nl.

### jappiesoftware.com
- **Leeslijn**: the landing page now reads top to bottom as one line: hero with CTA → two service blocks → how we work → consulting → about → contact. The "how we work" three-step structure recurs on the subpages, so the same line comes back everywhere.
- **Blocks**: the six product cards (three of which jumped straight to webwinkelverhuis.nl) are replaced by exactly two service blocks with illustrations: *Laat een website bouwen* (stays on site) and *Verhuis uw webshop* (labelled explicitly as opening webwinkelverhuis.nl, our dedicated migration site). Massapp and IoT "coming soon" filler dropped.
- **Plaatjes**: two hand-drawn SVG illustrations in the site palette, the watercolour living room on the WordPress hero, and the portrait photo in the about sections.
- **WordPress voor een Ellen en Laura**: page retitled "Laat een website bouwen", cards de-jargoned (*Gevonden worden in Google*, *Zelf aanpassen zonder ons te bellen*), and the process now shows five steps including the wireframe sketch and the self-managed handover.

### webwinkelverhuis.nl
- **Klikbare prijzen**: every pricing card now has a "Vraag een offerte aan" button.
- **Timeline**: duration FAQ now says the technical transfer takes hours but theme/plugins/checks mean about a month start to live (was "a week total").
- **Talen**: language FAQ spells out Nederlands, Duits, Engels, Frans instead of "NL/DE/EN".

## Screenshots

Verified locally with Playwright on ports 8001/8002, both languages checked.

## Verification

- `nix-build shake` (typechecker) passes
- `nix-build nix/ci.nix` passes
- Playwright full-page screenshots of /, /nl/, /wordpress-websites.html (EN+NL) and the migration pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)