### PR TITLE
Serve webwinkelverhuis locally and cross-link it from penguin

### DIFF
--- a/shake/PenguinTemplates.hs
+++ b/shake/PenguinTemplates.hs
@@ -5,7 +5,8 @@
 -- green palette). Shared SEO/structured-data/blog markup lives in 'PageChrome';
 -- the webshop-migration brand site lives in 'WebwinkelTemplates'.
 module PenguinTemplates
-  ( penguinIndexPage
+  ( WebwinkelverhuisUrl(..)
+  , penguinIndexPage
   , penguinIndexPageNl
   , penguinWordpressPage
   , penguinWordpressPageNl
@@ -53,6 +54,12 @@ penguinOgImage = "https://jappiesoftware.com/og-default.png"
 -- | The "get in touch" mailto used across the company site.
 contactMailto :: H.AttributeValue
 contactMailto = toValue ("mailto:" <> companyEmail)
+
+-- | Origin (no trailing slash) of the webwinkelverhuis.nl site as linked from
+-- jappiesoftware.com pages. Production passes the real domain; the local
+-- serve mode passes http://localhost:8002 so both locally served sites
+-- cross-link to each other instead of jumping to the live site.
+newtype WebwinkelverhuisUrl = WebwinkelverhuisUrl Text
 
 -- Decision: the landing page shows exactly two service blocks (websites,
 -- webshop migration) instead of the previous six-card product grid. Client
@@ -105,13 +112,13 @@ wordpressServiceEn = ServiceBlock
 
 -- | English webshop-migration service block. This one leaves the site, so the
 -- note says so explicitly instead of surprising the visitor.
-migrationServiceEn :: ServiceBlock
-migrationServiceEn = ServiceBlock
+migrationServiceEn :: WebwinkelverhuisUrl -> ServiceBlock
+migrationServiceEn (WebwinkelverhuisUrl url) = ServiceBlock
   { serviceImageSource = "/illustratie-verhuizen.svg"
   , serviceImageAlt = "Illustration of boxes moving from an old webshop to a new one"
   , serviceTitle = "Move your webshop"
   , serviceBody = "Stuck on MijnWebwinkel, CCV Shop or Lightspeed? We move your complete webshop to Shopify or another platform: products, translations, images and the redirects that keep your Google rankings."
-  , serviceLinkHref = "https://webwinkelverhuis.nl/"
+  , serviceLinkHref = url <> "/"
   , serviceLinkLabel = "Visit Webwinkelverhuis"
   , serviceNote = Just "Opens webwinkelverhuis.nl, our dedicated migration site."
   }
@@ -130,13 +137,13 @@ wordpressServiceNl = ServiceBlock
 
 -- | Dutch webshop-migration service block. This one leaves the site, so the
 -- note says so explicitly instead of surprising the visitor.
-migrationServiceNl :: ServiceBlock
-migrationServiceNl = ServiceBlock
+migrationServiceNl :: WebwinkelverhuisUrl -> ServiceBlock
+migrationServiceNl (WebwinkelverhuisUrl url) = ServiceBlock
   { serviceImageSource = "/illustratie-verhuizen.svg"
   , serviceImageAlt = "Illustratie van dozen die van een oude webshop naar een nieuwe verhuizen"
   , serviceTitle = "Verhuis uw webshop"
   , serviceBody = "Vastgelopen op MijnWebwinkel, CCV Shop of Lightspeed? Wij verhuizen uw complete webshop naar Shopify of een ander platform: producten, vertalingen, afbeeldingen en de redirects die uw Google-posities behouden."
-  , serviceLinkHref = "https://webwinkelverhuis.nl/"
+  , serviceLinkHref = url <> "/"
   , serviceLinkLabel = "Naar Webwinkelverhuis"
   , serviceNote = Just "Opent webwinkelverhuis.nl, onze aparte migratie-site."
   }
@@ -285,8 +292,8 @@ penguinBlogBaseTemplate lang = penguinBaseWith lang "article" True
 -- Landing page (index.html)
 -- =============================================================================
 
-penguinIndexPage :: Html
-penguinIndexPage = penguinBaseTemplate En indexMeta $
+penguinIndexPage :: WebwinkelverhuisUrl -> Html
+penguinIndexPage webwinkelUrl = penguinBaseTemplate En indexMeta $
   H.main $ do
     -- Hero
     H.section ! A.class_ "hero" $ do
@@ -298,7 +305,7 @@ penguinIndexPage = penguinBaseTemplate En indexMeta $
     H.section ! A.class_ "for-who" ! A.id "products" $ do
       H.h2 "What we do"
       renderServiceBlock wordpressServiceEn
-      renderServiceBlock migrationServiceEn
+      renderServiceBlock (migrationServiceEn webwinkelUrl)
 
     -- How we work: the same three steps every subpage elaborates on
     H.section ! A.class_ "audit" $ do
@@ -378,8 +385,8 @@ penguinIndexPage = penguinBaseTemplate En indexMeta $
 -- | Dutch counterpart of 'penguinIndexPage'. Same structure and section ids (so
 -- the in-page anchors keep working), Dutch copy. The webshop-migration cards
 -- still point at webwinkelverhuis.nl, which is Dutch already.
-penguinIndexPageNl :: Html
-penguinIndexPageNl = penguinBaseTemplate Nl indexMetaNl $
+penguinIndexPageNl :: WebwinkelverhuisUrl -> Html
+penguinIndexPageNl webwinkelUrl = penguinBaseTemplate Nl indexMetaNl $
   H.main $ do
     -- Hero
     H.section ! A.class_ "hero" $ do
@@ -391,7 +398,7 @@ penguinIndexPageNl = penguinBaseTemplate Nl indexMetaNl $
     H.section ! A.class_ "for-who" ! A.id "products" $ do
       H.h2 "Wat we doen"
       renderServiceBlock wordpressServiceNl
-      renderServiceBlock migrationServiceNl
+      renderServiceBlock (migrationServiceNl webwinkelUrl)
 
     -- Hoe we werken: dezelfde drie stappen die elke subpagina uitwerkt
     H.section ! A.class_ "audit" $ do
@@ -474,8 +481,8 @@ penguinIndexPageNl = penguinBaseTemplate Nl indexMetaNl $
 -- gives that work a home and frames it as the natural first step before a
 -- webshop, linking onward to the migration service on webwinkelverhuis.nl. The
 -- two recent builds (Voedzame Kost, Het Waardegebaar) are the proof of work.
-penguinWordpressPage :: Html
-penguinWordpressPage = penguinBaseTemplate En wordpressMeta $
+penguinWordpressPage :: WebwinkelverhuisUrl -> Html
+penguinWordpressPage (WebwinkelverhuisUrl webwinkelUrl) = penguinBaseTemplate En wordpressMeta $
   H.main $ do
     -- Hero
     H.section ! A.class_ "hero" $
@@ -555,7 +562,7 @@ penguinWordpressPage = penguinBaseTemplate En wordpressMeta $
       H.p $ H.preEscapedToHtml ("Plenty of businesses start with a site to be found, and later want to sell online. When you are ready to open a webshop, or to move an existing one without losing your Google rankings, we build and migrate those too." :: Text)
       H.p $ do
         "See "
-        H.a ! A.href "https://webwinkelverhuis.nl/" $ "webwinkelverhuis.nl"
+        H.a ! A.href (toValue (webwinkelUrl <> "/")) $ "webwinkelverhuis.nl"
         " for the webshop side."
 
     -- Final CTA
@@ -580,8 +587,8 @@ penguinWordpressPage = penguinBaseTemplate En wordpressMeta $
 
 -- | Dutch counterpart of 'penguinWordpressPage'. This is the page the
 -- warm-intro SMB leads actually land on, so the Dutch copy is the important one.
-penguinWordpressPageNl :: Html
-penguinWordpressPageNl = penguinBaseTemplate Nl wordpressMetaNl $
+penguinWordpressPageNl :: WebwinkelverhuisUrl -> Html
+penguinWordpressPageNl (WebwinkelverhuisUrl webwinkelUrl) = penguinBaseTemplate Nl wordpressMetaNl $
   H.main $ do
     -- Hero
     H.section ! A.class_ "hero" $
@@ -661,7 +668,7 @@ penguinWordpressPageNl = penguinBaseTemplate Nl wordpressMetaNl $
       H.p $ H.preEscapedToHtml ("Veel bedrijven beginnen met een site om gevonden te worden, en willen later online verkopen. Als u klaar bent om een webshop te openen, of een bestaande te verhuizen zonder uw Google-posities te verliezen, bouwen en migreren we die ook." :: Text)
       H.p $ do
         "Zie "
-        H.a ! A.href "https://webwinkelverhuis.nl/" $ "webwinkelverhuis.nl"
+        H.a ! A.href (toValue (webwinkelUrl <> "/")) $ "webwinkelverhuis.nl"
         " voor de webshop-kant."
 
     -- Laatste CTA

--- a/shake/Shakefile.hs
+++ b/shake/Shakefile.hs
@@ -40,7 +40,7 @@ import WaiAppStatic.Types (ssIndices, unsafeToPiece, ssAddTrailingSlash)
 
 import Feed (generateAtomFeed)
 import Metadata (parseMarkdownMeta, parseOrgMeta, parseDateField, parseTags, isDraft)
-import PenguinTemplates (penguinIndexPage, penguinIndexPageNl, penguinWordpressPage, penguinWordpressPageNl, penguinBlogIndexPage, penguinArticlePage)
+import PenguinTemplates (WebwinkelverhuisUrl(..), penguinIndexPage, penguinIndexPageNl, penguinWordpressPage, penguinWordpressPageNl, penguinBlogIndexPage, penguinArticlePage)
 import WebwinkelTemplates
   ( webwinkelIndexPage
   , webwinkelBlogIndexPage
@@ -133,26 +133,8 @@ shakeRules = do
       -- Build penguin site
       need ["build-penguin"]
 
-    phony "build-penguin" $ do
-      -- Discover penguin blog content
-      penguinMds <- getDirectoryFiles "penguin/content" ["//*.md"]
-      penguinOrgs <- getDirectoryFiles "penguin/content" ["//*.org"]
-      let penguinFiles = [(f, "md") | f <- penguinMds]
-                      ++ [(f, "org") | f <- penguinOrgs]
-
-      (penguinArticles, _penguinPages) <- liftIO $ parseAllContent "penguin/content" penguinFiles
-      liftIO $ generatePenguinSite penguinSiteConfig penguinArticles
-      copyPenguinStaticAssets
-
-      -- Build webwinkelverhuis.nl (the webshop-migration brand domain), with its
-      -- own theme and blog.
-      webwinkelMds <- getDirectoryFiles "webwinkel/content" ["//*.md"]
-      webwinkelOrgs <- getDirectoryFiles "webwinkel/content" ["//*.org"]
-      let webwinkelFiles = [(f, "md") | f <- webwinkelMds]
-                        ++ [(f, "org") | f <- webwinkelOrgs]
-      (webwinkelArticles, _webwinkelPages) <- liftIO $ parseAllContent "webwinkel/content" webwinkelFiles
-      liftIO $ generateWebwinkelverhuisSite webwinkelSiteConfig webwinkelArticles
-      copyWebwinkelStaticAssets
+    phony "build-penguin" $
+      buildPenguinSites productionWebwinkelUrl
 
     phony "serve" $ do
       need ["clean"]
@@ -187,17 +169,25 @@ shakeRules = do
         generateSite localConfig Nl nlArticles nlPages enSlugs enPageSlugs
       copyStaticAssets
 
-      -- Build penguin site
-      need ["build-penguin"]
-
-      -- Serve both sites
+      -- Build penguin + webwinkel sites, with penguin's webwinkelverhuis.nl
+      -- links pointing at the locally served copy instead of the live site.
       let blogPort = 8000 :: Int
           penguinPort = 8001 :: Int
+          webwinkelPort = 8002 :: Int
+      buildPenguinSites (WebwinkelverhuisUrl (T.pack ("http://localhost:" ++ show webwinkelPort)))
+
+      -- Serve all three sites
       putInfo $ "Serving _site on http://localhost:" ++ show blogPort
       putInfo $ "Serving _penguin-site on http://localhost:" ++ show penguinPort
+      putInfo $ "Serving _webwinkelverhuis-site on http://localhost:" ++ show webwinkelPort
       liftIO $ do
         _ <- forkIO $ Warp.run penguinPort $ Static.staticApp
           (Static.defaultFileServerSettings "_penguin-site")
+            { ssIndices = [unsafeToPiece "index.html"]
+            , ssAddTrailingSlash = True
+            }
+        _ <- forkIO $ Warp.run webwinkelPort $ Static.staticApp
+          (Static.defaultFileServerSettings "_webwinkelverhuis-site")
             { ssIndices = [unsafeToPiece "index.html"]
             , ssAddTrailingSlash = True
             }
@@ -585,9 +575,38 @@ copyStaticAssets = do
 -- Penguin site generation
 -- =============================================================================
 
+-- | The real webwinkelverhuis.nl origin, used for links from jappiesoftware.com
+-- in production builds.
+productionWebwinkelUrl :: WebwinkelverhuisUrl
+productionWebwinkelUrl = WebwinkelverhuisUrl "https://webwinkelverhuis.nl"
+
+-- | Build jappiesoftware.com into _penguin-site and webwinkelverhuis.nl into
+-- _webwinkelverhuis-site. The penguin pages link to the webwinkel site at the
+-- given origin: production builds pass the real domain, serve mode passes the
+-- local port so the sites cross-link locally.
+buildPenguinSites :: WebwinkelverhuisUrl -> Action ()
+buildPenguinSites webwinkelUrl = do
+  penguinMds <- getDirectoryFiles "penguin/content" ["//*.md"]
+  penguinOrgs <- getDirectoryFiles "penguin/content" ["//*.org"]
+  let penguinFiles = map (\f -> (f, "md")) penguinMds
+                  ++ map (\f -> (f, "org")) penguinOrgs
+  (penguinArticles, _penguinPages) <- liftIO $ parseAllContent "penguin/content" penguinFiles
+  liftIO $ generatePenguinSite webwinkelUrl penguinSiteConfig penguinArticles
+  copyPenguinStaticAssets
+
+  -- webwinkelverhuis.nl (the webshop-migration brand domain), with its own
+  -- theme and blog.
+  webwinkelMds <- getDirectoryFiles "webwinkel/content" ["//*.md"]
+  webwinkelOrgs <- getDirectoryFiles "webwinkel/content" ["//*.org"]
+  let webwinkelFiles = map (\f -> (f, "md")) webwinkelMds
+                    ++ map (\f -> (f, "org")) webwinkelOrgs
+  (webwinkelArticles, _webwinkelPages) <- liftIO $ parseAllContent "webwinkel/content" webwinkelFiles
+  liftIO $ generateWebwinkelverhuisSite webwinkelSiteConfig webwinkelArticles
+  copyWebwinkelStaticAssets
+
 -- | Generate the jappiesoftware.com site into _penguin-site/
-generatePenguinSite :: SiteConfig -> [Article] -> IO ()
-generatePenguinSite config articles = do
+generatePenguinSite :: WebwinkelverhuisUrl -> SiteConfig -> [Article] -> IO ()
+generatePenguinSite webwinkelUrl config articles = do
   let sortedArticles = sortBy (\a b -> compare (Down (articleDate a)) (Down (articleDate b))) articles
 
   -- Create output directories
@@ -595,13 +614,13 @@ generatePenguinSite config articles = do
   Dir.createDirectoryIfMissing True "_penguin-site/blog"
 
   -- Landing page (English at /, Dutch at /nl/)
-  writeHtmlFile "_penguin-site/index.html" penguinIndexPage
+  writeHtmlFile "_penguin-site/index.html" (penguinIndexPage webwinkelUrl)
   Dir.createDirectoryIfMissing True "_penguin-site/nl"
-  writeHtmlFile "_penguin-site/nl/index.html" penguinIndexPageNl
+  writeHtmlFile "_penguin-site/nl/index.html" (penguinIndexPageNl webwinkelUrl)
 
   -- WordPress websites service page (English at /, Dutch at /nl/)
-  writeHtmlFile "_penguin-site/wordpress-websites.html" penguinWordpressPage
-  writeHtmlFile "_penguin-site/nl/wordpress-websites.html" penguinWordpressPageNl
+  writeHtmlFile "_penguin-site/wordpress-websites.html" (penguinWordpressPage webwinkelUrl)
+  writeHtmlFile "_penguin-site/nl/wordpress-websites.html" (penguinWordpressPageNl webwinkelUrl)
 
   -- Individual article pages
   mapM_ (\art ->

--- a/shake/shake.cabal
+++ b/shake/shake.cabal
@@ -55,5 +55,7 @@ test-suite unit
     , blaze-markup >=0.8 && <0.9
     , bytestring >=0.10 && <0.13
     , http-types >=0.12 && <0.13
+    , tasty >=1.4 && <1.6
+    , tasty-hunit >=0.10 && <0.11
     , text >=1.2 && <2.2
     , time >=1.9 && <1.15

--- a/shake/shake.cabal
+++ b/shake/shake.cabal
@@ -38,3 +38,22 @@ executable shake-blog
     , wai >=3.2 && <3.3
     , wai-app-static >=3.1 && <3.2
     , warp >=3.3 && <3.5
+
+test-suite unit
+  type:             exitcode-stdio-1.0
+  main-is:          Test.hs
+  other-modules:
+    PageChrome
+    PenguinTemplates
+    Types
+  hs-source-dirs:   test .
+  default-language: Haskell2010
+  ghc-options:      -Wall -Werror
+  build-depends:
+      base >=4.9 && <4.22
+    , blaze-html >=0.9 && <0.10
+    , blaze-markup >=0.8 && <0.9
+    , bytestring >=0.10 && <0.13
+    , http-types >=0.12 && <0.13
+    , text >=1.2 && <2.2
+    , time >=1.9 && <1.15

--- a/shake/test/Test.hs
+++ b/shake/test/Test.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Asserts that the webwinkelverhuis.nl links on the jappiesoftware.com
+-- pages follow the 'WebwinkelverhuisUrl' passed to the page functions: serve
+-- mode must cross-link to the locally hosted copy, production to the live
+-- domain. The test renders each page with a fake origin and fails if the
+-- fake origin is missing or the live domain is still hardcoded in a href.
+module Main (main) where
+
+import Control.Monad (unless, when)
+import Data.Text (Text)
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import System.Exit (exitFailure)
+import Text.Blaze.Html (Html)
+import Text.Blaze.Html.Renderer.Text (renderHtml)
+
+import PenguinTemplates
+  ( WebwinkelverhuisUrl(..)
+  , penguinIndexPage
+  , penguinIndexPageNl
+  , penguinWordpressPage
+  , penguinWordpressPageNl
+  )
+
+-- | A recognisable fake origin: it can only appear in the output when the
+-- page honours the parameter instead of a hardcoded domain.
+testOrigin :: Text
+testOrigin = "http://origin-under-test.example"
+
+-- | Every jappiesoftware.com page that links to the webwinkel site, named
+-- for error output.
+pagesUnderTest :: [(String, WebwinkelverhuisUrl -> Html)]
+pagesUnderTest =
+  [ ("penguinIndexPage", penguinIndexPage)
+  , ("penguinIndexPageNl", penguinIndexPageNl)
+  , ("penguinWordpressPage", penguinWordpressPage)
+  , ("penguinWordpressPageNl", penguinWordpressPageNl)
+  ]
+
+-- | Render the page with the fake origin and fail loudly unless the links
+-- follow it. The live domain may still appear as visible text (the brand
+-- name is spelled out on the pages), so only href occurrences count.
+assertLinksFollowOrigin :: (String, WebwinkelverhuisUrl -> Html) -> IO ()
+assertLinksFollowOrigin (pageName, page) = do
+  let rendered = TL.toStrict (renderHtml (page (WebwinkelverhuisUrl testOrigin)))
+  unless (("href=\"" <> testOrigin <> "/\"") `T.isInfixOf` rendered) $ do
+    putStrLn (pageName <> ": expected a link to " <> T.unpack testOrigin <> " but found none")
+    exitFailure
+  when ("href=\"https://webwinkelverhuis.nl" `T.isInfixOf` rendered) $ do
+    putStrLn (pageName <> ": links the hardcoded live domain instead of the passed origin")
+    exitFailure
+
+main :: IO ()
+main = do
+  mapM_ assertLinksFollowOrigin pagesUnderTest
+  putStrLn "webwinkel links follow WebwinkelverhuisUrl on all 4 pages"

--- a/shake/test/Test.hs
+++ b/shake/test/Test.hs
@@ -7,6 +7,14 @@
 -- origin is missing or the live domain is still hardcoded in a href.
 module Main (main) where
 
+-- Decision: tasty + tasty-hunit as the test framework, suite named "unit",
+-- following the haskell-template-project convention used across the other
+-- repositories (mijn-webwinkel-migraine's suite has the same shape).
+-- Alternatives considered: a hand-rolled exitcode-stdio main (zero extra
+-- dependencies, but no per-case output and off-convention; this suite's
+-- first version was written that way and ported) and hspec (no house
+-- precedent).
+
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL

--- a/shake/test/Test.hs
+++ b/shake/test/Test.hs
@@ -3,15 +3,15 @@
 -- | Asserts that the webwinkelverhuis.nl links on the jappiesoftware.com
 -- pages follow the 'WebwinkelverhuisUrl' passed to the page functions: serve
 -- mode must cross-link to the locally hosted copy, production to the live
--- domain. The test renders each page with a fake origin and fails if the
--- fake origin is missing or the live domain is still hardcoded in a href.
+-- domain. Each page is rendered with a fake origin and fails if the fake
+-- origin is missing or the live domain is still hardcoded in a href.
 module Main (main) where
 
-import Control.Monad (unless, when)
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
-import System.Exit (exitFailure)
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.HUnit (assertBool, testCase)
 import Text.Blaze.Html (Html)
 import Text.Blaze.Html.Renderer.Text (renderHtml)
 
@@ -29,7 +29,7 @@ testOrigin :: Text
 testOrigin = "http://origin-under-test.example"
 
 -- | Every jappiesoftware.com page that links to the webwinkel site, named
--- for error output.
+-- for test output.
 pagesUnderTest :: [(String, WebwinkelverhuisUrl -> Html)]
 pagesUnderTest =
   [ ("penguinIndexPage", penguinIndexPage)
@@ -38,20 +38,18 @@ pagesUnderTest =
   , ("penguinWordpressPageNl", penguinWordpressPageNl)
   ]
 
--- | Render the page with the fake origin and fail loudly unless the links
--- follow it. The live domain may still appear as visible text (the brand
--- name is spelled out on the pages), so only href occurrences count.
-assertLinksFollowOrigin :: (String, WebwinkelverhuisUrl -> Html) -> IO ()
-assertLinksFollowOrigin (pageName, page) = do
+-- | Render the page with the fake origin and assert the links follow it.
+-- The live domain may still appear as visible text (the brand name is
+-- spelled out on the pages), so only href occurrences count.
+linksFollowOriginCase :: (String, WebwinkelverhuisUrl -> Html) -> TestTree
+linksFollowOriginCase (pageName, page) = testCase pageName $ do
   let rendered = TL.toStrict (renderHtml (page (WebwinkelverhuisUrl testOrigin)))
-  unless (("href=\"" <> testOrigin <> "/\"") `T.isInfixOf` rendered) $ do
-    putStrLn (pageName <> ": expected a link to " <> T.unpack testOrigin <> " but found none")
-    exitFailure
-  when ("href=\"https://webwinkelverhuis.nl" `T.isInfixOf` rendered) $ do
-    putStrLn (pageName <> ": links the hardcoded live domain instead of the passed origin")
-    exitFailure
+  assertBool ("expected a link to " <> T.unpack testOrigin <> " but found none")
+    (("href=\"" <> testOrigin <> "/\"") `T.isInfixOf` rendered)
+  assertBool "links the hardcoded live domain instead of the passed origin"
+    (not ("href=\"https://webwinkelverhuis.nl" `T.isInfixOf` rendered))
 
 main :: IO ()
-main = do
-  mapM_ assertLinksFollowOrigin pagesUnderTest
-  putStrLn "webwinkel links follow WebwinkelverhuisUrl on all 4 pages"
+main = defaultMain $
+  testGroup "webwinkel links follow WebwinkelverhuisUrl"
+    (map linksFollowOriginCase pagesUnderTest)


### PR DESCRIPTION
## Summary

Follow-up to #77 (the first commit was originally pushed to that branch minutes after it merged, so it needed a new PR).

- `shake-blog serve` now hosts all three sites instead of two: blog on 8000, jappiesoftware.com on 8001, **webwinkelverhuis.nl on 8002** (new). Previously the webwinkel site was built but not served locally.
- The locally served jappiesoftware.com cross-links to the local webwinkel copy instead of jumping to the live site: a new `WebwinkelverhuisUrl` newtype threads the origin through the penguin pages (production builds pass `https://webwinkelverhuis.nl`, serve mode passes `http://localhost:8002`).
- The `build-penguin` body moved to `buildPenguinSites` so serve can call it with the local origin while the build phony keeps the real domain.
- New `unit` test suite (tasty + tasty-hunit, runs inside `nix-build shake`): renders all four penguin pages with a fake origin and fails if a page drops the passed origin or hardcodes the live domain in a href.

## Test plan

- [x] `nix-build shake` passes, test suite output: all 4 pages OK
- [x] `nix-build nix/ci.nix` passes
- [x] Negative control: hardcoding the domain back into `migrationServiceNl` fails the suite ("expected a link to http://origin-under-test.example but found none"); naive hardcode is already a compile error via -Werror unused-matches
- [x] Ran serve locally; Playwright click on "Naar Webwinkelverhuis" from the local homepage lands on http://localhost:8002/ (local copy, correct title)
- [x] Production origin unchanged for `build`: `_penguin-site` from `build-penguin` still links `https://webwinkelverhuis.nl/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)