### PR TITLE
Marketing pass on the webwinkelverhuis.nl landing page

### DIFF
--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -63,6 +63,13 @@ offerteMailto = toValue ("mailto:" <> companyEmail <> "?subject=Migratie%20offer
 uitbreidingMailto :: H.AttributeValue
 uitbreidingMailto = toValue ("mailto:" <> companyEmail <> "?subject=Uitbreiding%20webshop")
 
+-- | Branded scheduling link used by every "plan een gesprek" button. It is a
+-- 302 redirect on our own infrastructure (megavid blog/vhost.nix) to the
+-- current Google Calendar booking page, so the underlying calendar can change
+-- without touching built pages or already-sent outreach mails.
+meetLink :: H.AttributeValue
+meetLink = "https://meet.jappiesoftware.com"
+
 -- =============================================================================
 -- Base template
 -- =============================================================================
@@ -151,27 +158,16 @@ webwinkelIndexPage :: Html
 webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
   H.main $ do
     -- Hero
-    H.section ! A.class_ "hero" $ do
-      H.h1 "Verhuis uw webshop. Zonder dataverlies, zonder SEO-verlies."
-      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Vastgelopen op MijnWebwinkel, CCV Shop of Lightspeed? Wij verhuizen uw complete webshop geautomatiseerd naar Shopify of een ander platform &mdash; producten, vertalingen, afbeeldingen, klantdata en SEO-redirects. U betaalt pas na een succesvolle migratie." :: Text)
-      H.a ! A.href offerteMailto ! A.class_ "cta-button" $ "Vraag een offerte aan"
-
-    -- Platform cards
-    H.section ! A.class_ "for-who" ! A.id "platforms" $ do
-      H.h2 "Vanaf welk platform verhuist u?"
-      H.ul ! A.class_ "card-grid" $ do
-        H.li ! A.class_ "card" $ do
-          H.h3 "MijnWebwinkel"
-          H.p $ H.preEscapedToHtml ("Bevroren platform, verdubbelde prijzen, gesloten community. Wij zetten alles over &mdash; inclusief de automatisch gegenereerde 301-redirects voor uw artikel-URLs." :: Text)
-          H.a ! A.href "/migrate-mijnwebwinkel.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Bekijk migratie &rarr;" :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "Lightspeed"
-          H.p $ H.preEscapedToHtml ("Beursgenoteerd en steeds duurder voor kleine shops. Wij verhuizen u veilig, met behoud van uw Google-posities &mdash; geen 70% verkeersverlies." :: Text)
-          H.a ! A.href "/migrate-lightspeed.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Bekijk migratie &rarr;" :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "CCV Shop"
-          H.p $ H.preEscapedToHtml ("Beperkte features en achterblijvende ontwikkeling. Wij zetten uw producten, talen, klantaccounts en voorraad volledig geautomatiseerd over." :: Text)
-          H.a ! A.href "/migrate-ccvshop.html" ! A.class_ "cta-button" $ H.preEscapedToHtml ("Bekijk migratie &rarr;" :: Text)
+    H.section ! A.class_ "hero" $
+      H.div ! A.class_ "hero-grid" $ do
+        H.div $ do
+          H.h1 "Verhuis uw webshop. Zonder dataverlies, zonder SEO-verlies."
+          H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Vastgelopen op MijnWebwinkel, CCV Shop of Lightspeed? Wij verhuizen uw complete webshop geautomatiseerd naar Shopify of een ander platform &mdash; producten, vertalingen, afbeeldingen, klantdata en SEO-redirects. U betaalt pas na een succesvolle migratie." :: Text)
+          H.a ! A.href offerteMailto ! A.class_ "cta-button" $ "Vraag een offerte aan"
+        H.img ! A.class_ "hero-image"
+              ! A.src "/illustratie-verhuizen.svg"
+              ! A.alt "Illustratie van dozen die van een oude webshop naar een nieuwe verhuizen"
+              ! A.width "400" ! A.height "300"
 
     -- How it works
     H.section ! A.class_ "audit" $ do
@@ -214,11 +210,40 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
         H.a ! A.href "/blog/" $ "blog"
         "."
 
+    -- Platform cards: the routing step, at the bottom so the visitor first
+    -- reads the promise, the process and the proof before picking a platform.
+    -- Secondary buttons: the orange primary is reserved for the offerte and
+    -- plan-een-gesprek actions.
+    H.section ! A.class_ "for-who" ! A.id "platforms" $ do
+      H.h2 "Vanaf welk platform verhuist u?"
+      H.ul ! A.class_ "card-grid" $ do
+        H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-bevroren.svg"
+                ! A.alt "Sneeuwvlok: het platform is bevroren"
+                ! A.width "56" ! A.height "56"
+          H.h3 "MijnWebwinkel"
+          H.p $ H.preEscapedToHtml ("Bevroren platform, verdubbelde prijzen, gesloten community. Wij zetten alles over &mdash; inclusief de automatisch gegenereerde 301-redirects voor uw artikel-URLs." :: Text)
+          H.a ! A.href "/migrate-mijnwebwinkel.html" ! A.class_ "cta-button-secondary" $ H.preEscapedToHtml ("Bekijk migratie &rarr;" :: Text)
+        H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-prijsstijging.svg"
+                ! A.alt "Grafiek met stijgende prijzen"
+                ! A.width "56" ! A.height "56"
+          H.h3 "Lightspeed"
+          H.p $ H.preEscapedToHtml ("Beursgenoteerd en steeds duurder voor kleine shops. Wij verhuizen u veilig, met behoud van uw Google-posities &mdash; geen 70% verkeersverlies." :: Text)
+          H.a ! A.href "/migrate-lightspeed.html" ! A.class_ "cta-button-secondary" $ H.preEscapedToHtml ("Bekijk migratie &rarr;" :: Text)
+        H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-beperkt.svg"
+                ! A.alt "Hangslot: beperkte mogelijkheden"
+                ! A.width "56" ! A.height "56"
+          H.h3 "CCV Shop"
+          H.p $ H.preEscapedToHtml ("Beperkte features en achterblijvende ontwikkeling. Wij zetten uw producten, talen, klantaccounts en voorraad volledig geautomatiseerd over." :: Text)
+          H.a ! A.href "/migrate-ccvshop.html" ! A.class_ "cta-button-secondary" $ H.preEscapedToHtml ("Bekijk migratie &rarr;" :: Text)
+
     -- Final CTA
     H.section ! A.class_ "final-cta" $ do
       H.h2 "Klaar om te verhuizen?"
       H.p "Plan een gratis, vrijblijvend gesprek. We bekijken samen uw webshop en geven direct een inschatting."
-      H.a ! A.href "https://calendar.app.google/9h9uTzsPQoryEc6S7" ! A.class_ "cta-button" $ "Plan een gesprek"
+      H.a ! A.href meetLink ! A.class_ "cta-button" $ "Plan een gesprek"
   where
     indexMeta :: PageMeta
     indexMeta = PageMeta
@@ -450,7 +475,7 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $ do
       H.h2 "Klaar om te ontsnappen?"
       H.p $ H.preEscapedToHtml ("U hoeft niet langer te wachten tot MijnWebwinkel beter wordt &mdash; dat gaat niet gebeuren. " :: Text)
       H.p "Plan een gratis, vrijblijvend gesprek. We bekijken samen uw webshop en geven direct een inschatting."
-      H.a ! A.href "https://calendar.app.google/9h9uTzsPQoryEc6S7" ! A.class_ "cta-button" $ "Ontsnap nu"
+      H.a ! A.href meetLink ! A.class_ "cta-button" $ "Ontsnap nu"
   where
     migrationMeta :: PageMeta
     migrationMeta = PageMeta
@@ -599,7 +624,7 @@ ccvshopMigrationPage = webwinkelBaseTemplate ccvMeta $
       H.h2 "Klaar om te ontsnappen?"
       H.p $ H.preEscapedToHtml ("U hoeft niet langer te wachten tot CCV Shop beter wordt. Neem de controle terug over uw webshop." :: Text)
       H.p "Plan een gratis, vrijblijvend gesprek. We bekijken samen uw webshop en geven direct een inschatting."
-      H.a ! A.href "https://calendar.app.google/9h9uTzsPQoryEc6S7" ! A.class_ "cta-button" $ "Ontsnap nu"
+      H.a ! A.href meetLink ! A.class_ "cta-button" $ "Ontsnap nu"
   where
     ccvMeta :: PageMeta
     ccvMeta = PageMeta
@@ -747,7 +772,7 @@ lightspeedMigrationPage = webwinkelBaseTemplate lightspeedMeta $
       H.h2 "Klaar om te ontsnappen?"
       H.p $ H.preEscapedToHtml ("Lightspeed gaat u niet helpen met deze overstap. Wij wel." :: Text)
       H.p "Plan een gratis, vrijblijvend gesprek. We bekijken samen uw webshop en geven direct een inschatting."
-      H.a ! A.href "https://calendar.app.google/9h9uTzsPQoryEc6S7" ! A.class_ "cta-button" $ "Ontsnap nu"
+      H.a ! A.href meetLink ! A.class_ "cta-button" $ "Ontsnap nu"
   where
     lightspeedMeta :: PageMeta
     lightspeedMeta = PageMeta
@@ -882,7 +907,7 @@ mijnwebwinkelWaaromPage = webwinkelBaseTemplate waaromMeta $
       H.p $ do
         H.a ! A.href "/migrate-mijnwebwinkel.html" $ "Bekijk onze migratieservice"
         H.preEscapedToHtml (" &mdash; volledig geautomatiseerd, vaste prijs, betaling na succes." :: Text)
-      H.a ! A.href "https://calendar.app.google/9h9uTzsPQoryEc6S7" ! A.class_ "cta-button" $ "Ontsnap nu"
+      H.a ! A.href meetLink ! A.class_ "cta-button" $ "Ontsnap nu"
   where
     waaromMeta :: PageMeta
     waaromMeta = PageMeta
@@ -1017,7 +1042,7 @@ lightspeedWaaromPage = webwinkelBaseTemplate waaromLsMeta $
       H.p $ do
         H.a ! A.href "/migrate-lightspeed.html" $ "Bekijk onze migratieservice"
         H.preEscapedToHtml (" &mdash; volledig geautomatiseerd, vaste prijs, betaling na succes." :: Text)
-      H.a ! A.href "https://calendar.app.google/9h9uTzsPQoryEc6S7" ! A.class_ "cta-button" $ "Ontsnap nu"
+      H.a ! A.href meetLink ! A.class_ "cta-button" $ "Ontsnap nu"
   where
     waaromLsMeta :: PageMeta
     waaromLsMeta = PageMeta

--- a/shake/shake.cabal
+++ b/shake/shake.cabal
@@ -46,6 +46,7 @@ test-suite unit
     PageChrome
     PenguinTemplates
     Types
+    WebwinkelTemplates
   hs-source-dirs:   test .
   default-language: Haskell2010
   ghc-options:      -Wall -Werror

--- a/shake/test/Test.hs
+++ b/shake/test/Test.hs
@@ -30,6 +30,14 @@ import PenguinTemplates
   , penguinWordpressPage
   , penguinWordpressPageNl
   )
+import WebwinkelTemplates
+  ( webwinkelIndexPage
+  , mijnwebwinkelMigrationPage
+  , ccvshopMigrationPage
+  , lightspeedMigrationPage
+  , mijnwebwinkelWaaromPage
+  , lightspeedWaaromPage
+  )
 
 -- | A recognisable fake origin: it can only appear in the output when the
 -- page honours the parameter instead of a hardcoded domain.
@@ -57,7 +65,34 @@ linksFollowOriginCase (pageName, page) = testCase pageName $ do
   assertBool "links the hardcoded live domain instead of the passed origin"
     (not ("href=\"https://webwinkelverhuis.nl" `T.isInfixOf` rendered))
 
+-- | Every webwinkelverhuis.nl page with a "plan een gesprek" button, named
+-- for test output.
+meetLinkPages :: [(String, Html)]
+meetLinkPages =
+  [ ("webwinkelIndexPage", webwinkelIndexPage)
+  , ("mijnwebwinkelMigrationPage", mijnwebwinkelMigrationPage)
+  , ("ccvshopMigrationPage", ccvshopMigrationPage)
+  , ("lightspeedMigrationPage", lightspeedMigrationPage)
+  , ("mijnwebwinkelWaaromPage", mijnwebwinkelWaaromPage)
+  , ("lightspeedWaaromPage", lightspeedWaaromPage)
+  ]
+
+-- | Scheduling buttons must use the branded meet.jappiesoftware.com redirect,
+-- never a raw calendar.app.google URL: the raw link routed to the wrong
+-- calendar once, and the redirect is the single place the target may change.
+usesMeetLinkCase :: (String, Html) -> TestTree
+usesMeetLinkCase (pageName, page) = testCase pageName $ do
+  let rendered = TL.toStrict (renderHtml page)
+  assertBool "expected a link to https://meet.jappiesoftware.com but found none"
+    ("href=\"https://meet.jappiesoftware.com\"" `T.isInfixOf` rendered)
+  assertBool "links a raw calendar.app.google URL instead of the meet redirect"
+    (not ("calendar.app.google" `T.isInfixOf` rendered))
+
 main :: IO ()
 main = defaultMain $
-  testGroup "webwinkel links follow WebwinkelverhuisUrl"
-    (map linksFollowOriginCase pagesUnderTest)
+  testGroup "shake-blog templates"
+    [ testGroup "webwinkel links follow WebwinkelverhuisUrl"
+        (map linksFollowOriginCase pagesUnderTest)
+    , testGroup "scheduling buttons use meet.jappiesoftware.com"
+        (map usesMeetLinkCase meetLinkPages)
+    ]

--- a/webwinkel/icoon-beperkt.svg
+++ b/webwinkel/icoon-beperkt.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- CCV Shop platform card icon: a padlocked box, "limited features". -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="30" fill="#eaf1f8"/>
+  <rect x="18" y="28" width="28" height="20" rx="3" fill="#ffffff" stroke="#10456b" stroke-width="3"/>
+  <path d="M24 28 v-5 a8 8 0 0 1 16 0 v5" fill="none" stroke="#10456b" stroke-width="3"/>
+  <circle cx="32" cy="37" r="3" fill="#e8590c"/>
+  <path d="M32 39 v4" stroke="#e8590c" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/webwinkel/icoon-bevroren.svg
+++ b/webwinkel/icoon-bevroren.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- MijnWebwinkel platform card icon: a snowflake, "the platform is frozen". -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="30" fill="#eaf1f8"/>
+  <g stroke="#10456b" stroke-width="3.5" stroke-linecap="round">
+    <path d="M32 12 v40"/>
+    <path d="M14.7 22 l34.6 20"/>
+    <path d="M14.7 42 l34.6 -20"/>
+    <path d="M32 12 l-5 6 M32 12 l5 6"/>
+    <path d="M32 52 l-5 -6 M32 52 l5 -6"/>
+    <path d="M14.7 22 l7.7 1.2 M14.7 22 l1 7.8"/>
+    <path d="M49.3 42 l-7.7 -1.2 M49.3 42 l-1 -7.8"/>
+    <path d="M14.7 42 l1 -7.8 M14.7 42 l7.7 -1.2"/>
+    <path d="M49.3 22 l-1 7.8 M49.3 22 l-7.7 1.2"/>
+  </g>
+</svg>

--- a/webwinkel/icoon-prijsstijging.svg
+++ b/webwinkel/icoon-prijsstijging.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Lightspeed platform card icon: a climbing price chart, "keeps getting
+     more expensive". -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="30" fill="#eaf1f8"/>
+  <path d="M16 46 h32" stroke="#10456b" stroke-width="3" stroke-linecap="round"/>
+  <path d="M16 46 v-28" stroke="#10456b" stroke-width="3" stroke-linecap="round"/>
+  <path d="M20 42 l9 -9 l6 5 l12 -14" fill="none" stroke="#e8590c" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M40 22 l7 2 l-2 7 z" fill="#e8590c"/>
+  <text x="24" y="26" font-family="sans-serif" font-size="13" font-weight="bold" fill="#10456b">&#8364;</text>
+</svg>

--- a/webwinkel/illustratie-verhuizen.svg
+++ b/webwinkel/illustratie-verhuizen.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Hero illustration for webwinkelverhuis.nl: boxes moving from a faded old
+     shop to a bright new one. Same composition as the penguin site's
+     illustratie-verhuizen.svg but in this theme's navy/orange palette. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" role="img">
+  <!-- soft backdrop -->
+  <circle cx="200" cy="150" r="130" fill="#eaf1f8"/>
+  <!-- old shop, faded -->
+  <g opacity="0.45">
+    <rect x="48" y="130" width="90" height="80" fill="#ffffff" stroke="#0c2f47" stroke-width="3"/>
+    <path d="M40 130 l8 -26 h74 l8 26 z" fill="#dbe5ef" stroke="#0c2f47" stroke-width="3" stroke-linejoin="round"/>
+    <path d="M40 130 h90" stroke="#0c2f47" stroke-width="3"/>
+    <rect x="62" y="152" width="26" height="26" fill="#dbe5ef" stroke="#0c2f47" stroke-width="3"/>
+    <rect x="98" y="152" width="26" height="58" fill="#dbe5ef" stroke="#0c2f47" stroke-width="3"/>
+  </g>
+  <!-- arrow of travel -->
+  <path d="M150 176 C 185 120, 225 120, 258 168" fill="none" stroke="#e8590c" stroke-width="6" stroke-linecap="round" stroke-dasharray="2 14"/>
+  <path d="M250 148 l10 22 l-24 -4 z" fill="#e8590c"/>
+  <!-- moving boxes -->
+  <g transform="rotate(-8 196 132)">
+    <rect x="172" y="112" width="48" height="40" rx="4" fill="#f6c89f" stroke="#0c2f47" stroke-width="3"/>
+    <path d="M172 128 h48" stroke="#0c2f47" stroke-width="3"/>
+    <path d="M196 112 v16" stroke="#0c2f47" stroke-width="3"/>
+  </g>
+  <!-- new shop, bright -->
+  <g>
+    <rect x="252" y="118" width="110" height="98" fill="#ffffff" stroke="#0c2f47" stroke-width="3"/>
+    <path d="M242 118 l10 -30 h90 l10 30 z" fill="#10456b" stroke="#0c2f47" stroke-width="3" stroke-linejoin="round"/>
+    <path d="M242 118 h130" stroke="#0c2f47" stroke-width="3"/>
+    <rect x="266" y="142" width="30" height="30" fill="#dbe5ef" stroke="#0c2f47" stroke-width="3"/>
+    <rect x="310" y="142" width="30" height="74" fill="#e8590c" stroke="#0c2f47" stroke-width="3"/>
+    <circle cx="316" cy="180" r="2.5" fill="#0c2f47"/>
+    <!-- awning scallops -->
+    <path d="M246 118 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 14 0" fill="#e8590c" stroke="#0c2f47" stroke-width="3"/>
+  </g>
+  <!-- delivered box at the door -->
+  <rect x="270" y="196" width="22" height="20" rx="3" fill="#f6c89f" stroke="#0c2f47" stroke-width="3"/>
+  <path d="M270 204 h22" stroke="#0c2f47" stroke-width="3"/>
+</svg>

--- a/webwinkel/style.css
+++ b/webwinkel/style.css
@@ -100,6 +100,48 @@ main section {
   background: #c44d06;
 }
 
+/* Secondary button: navy outline for routing links such as the platform
+   cards, so the one orange primary action per screen keeps its weight. */
+.cta-button-secondary {
+  display: inline-block;
+  padding: 0.75em 2em;
+  background: transparent;
+  color: #10456b;
+  text-decoration: none;
+  border: 2px solid #10456b;
+  border-radius: 4px;
+  font-weight: 600;
+  font-size: 1em;
+  transition: background 0.2s, color 0.2s;
+}
+.cta-button-secondary:hover {
+  background: #10456b;
+  color: #fff;
+}
+.card .cta-button-secondary {
+  margin-top: 1em;
+  padding: 0.5em 1.2em;
+}
+
+/* Hero with an illustration beside the text */
+.hero-grid {
+  display: grid;
+  grid-template-columns: 3fr 2fr;
+  gap: 2em;
+  align-items: center;
+}
+.hero-image {
+  width: 100%;
+  height: auto;
+}
+
+/* Small pictogram at the top of a platform card */
+.card-icon {
+  width: 56px;
+  height: 56px;
+  margin-bottom: 0.75em;
+}
+
 /* Card grid */
 .card-grid {
   list-style: none;
@@ -281,6 +323,9 @@ footer small {
     padding: 2em 1.2em;
   }
   .card-grid {
+    grid-template-columns: 1fr;
+  }
+  .hero-grid {
     grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary

Full marketing review of the webwinkelverhuis.nl index, addressing the feedback on the "Vanaf welk platform verhuist u?" section:

- **Reading line**: platform cards moved from directly under the hero to the bottom. The page now reads promise (hero) → process (hoe het werkt) → proof (recent werk) → reasons (waarom via ons) → platform choice → action. The cards are a routing step, not a sales pitch, so they belong after the persuasion, right above the final CTA.
- **Button hierarchy**: platform cards now use a navy outline `cta-button-secondary`. Orange is reserved for the two primary actions (offerte in the hero, plan-een-gesprek at the bottom) instead of five orange buttons shouting over each other.
- **Images**: hero illustration (boxes moving from a faded old shop to a bright new one, navy/orange palette matching the theme) plus a pictogram per platform card: snowflake (MijnWebwinkel, frozen), climbing price chart (Lightspeed, ever pricier), padlock (CCV Shop, feature-limited).
- **Scheduling links**: all six raw `calendar.app.google/9h9uTzsPQoryEc6S7` hrefs replaced with the branded `https://meet.jappiesoftware.com` redirect via a single `meetLink` constant. The raw link pointed at the wrong calendar; the confirmed booking link lives behind the redirect (megavid `blog/vhost.nix`, already on megavid master). Site content and redirect ship on the same megavid deploy, so ordering is automatic.

## Test plan

- [x] `nix-build shake` passes; suite extended with 6 new cases: every webwinkel page must link `meet.jappiesoftware.com` and may never contain a raw `calendar.app.google` URL (all 10 cases OK)
- [x] Built the site and reviewed the full page with Playwright: section order, secondary buttons, icons and hero illustration render as intended
- [x] Platform anchor id `platforms` unchanged, existing deep links keep working

## Note

The 404 you saw on `http://localhost:8002/migrate-mijnwebwinkel.html` was a stale python server of mine serving a deleted directory, not a missing page; after `pkill -x shake-blog` and rerunning `serve` the page is there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)