### PR TITLE
Fix seventh calendar link, guard the build, v-align card buttons

### DIFF
--- a/shake/Shakefile.hs
+++ b/shake/Shakefile.hs
@@ -517,6 +517,21 @@ writeHtmlFile path html = do
   Dir.createDirectoryIfMissing True (takeDirectory path)
   TLIO.writeFile path (renderHtml html)
 
+-- | Write a webwinkelverhuis.nl page, refusing to emit one that links a raw
+-- calendar.app.google URL. Scheduling links must use the
+-- https://meet.jappiesoftware.com redirect ('meetLink' in
+-- 'WebwinkelTemplates'): a raw link in blog content once routed visitors to
+-- the wrong calendar, and the template test suite cannot see rendered
+-- content. Crashing the build here beats publishing the bad link silently.
+writeWebwinkelHtmlFile :: FilePath -> Html -> IO ()
+writeWebwinkelHtmlFile path html = do
+  let rendered = renderHtml html
+  if TL.pack "calendar.app.google" `TL.isInfixOf` rendered
+    then error (path <> " links a raw calendar.app.google URL; use https://meet.jappiesoftware.com instead")
+    else do
+      Dir.createDirectoryIfMissing True (takeDirectory path)
+      TLIO.writeFile path rendered
+
 tagSlugLocal :: Text -> Text
 tagSlugLocal = T.intercalate "-" . T.words . T.toLower
 
@@ -669,21 +684,21 @@ generateWebwinkelverhuisSite config articles = do
   Dir.createDirectoryIfMissing True "_webwinkelverhuis-site/blog"
 
   -- Landing page
-  writeHtmlFile "_webwinkelverhuis-site/index.html" webwinkelIndexPage
+  writeWebwinkelHtmlFile "_webwinkelverhuis-site/index.html" webwinkelIndexPage
 
   -- Shopify migration app's App URL landing page
-  writeHtmlFile "_webwinkelverhuis-site/app.html" appPage
+  writeWebwinkelHtmlFile "_webwinkelverhuis-site/app.html" appPage
 
   -- Migration and explainer pages
-  writeHtmlFile "_webwinkelverhuis-site/migrate-mijnwebwinkel.html" mijnwebwinkelMigrationPage
-  writeHtmlFile "_webwinkelverhuis-site/migrate-ccvshop.html" ccvshopMigrationPage
-  writeHtmlFile "_webwinkelverhuis-site/migrate-lightspeed.html" lightspeedMigrationPage
-  writeHtmlFile "_webwinkelverhuis-site/waarom-mijnwebwinkel.html" mijnwebwinkelWaaromPage
-  writeHtmlFile "_webwinkelverhuis-site/waarom-lightspeed.html" lightspeedWaaromPage
+  writeWebwinkelHtmlFile "_webwinkelverhuis-site/migrate-mijnwebwinkel.html" mijnwebwinkelMigrationPage
+  writeWebwinkelHtmlFile "_webwinkelverhuis-site/migrate-ccvshop.html" ccvshopMigrationPage
+  writeWebwinkelHtmlFile "_webwinkelverhuis-site/migrate-lightspeed.html" lightspeedMigrationPage
+  writeWebwinkelHtmlFile "_webwinkelverhuis-site/waarom-mijnwebwinkel.html" mijnwebwinkelWaaromPage
+  writeWebwinkelHtmlFile "_webwinkelverhuis-site/waarom-lightspeed.html" lightspeedWaaromPage
 
   -- Individual blog article pages
   mapM_ (\art ->
-    writeHtmlFile ("_webwinkelverhuis-site/blog" </> T.unpack (articleUrl art))
+    writeWebwinkelHtmlFile ("_webwinkelverhuis-site/blog" </> T.unpack (articleUrl art))
       (webwinkelArticlePage config art))
     sortedArticles
 
@@ -701,7 +716,7 @@ generateWebwinkelverhuisSite config articles = do
               then Just ("/blog/" <> penguinIndexFileName (pageNum + 1))
               else Nothing
           }
-    in writeHtmlFile ("_webwinkelverhuis-site/blog" </> T.unpack (penguinIndexFileName pageNum))
+    in writeWebwinkelHtmlFile ("_webwinkelverhuis-site/blog" </> T.unpack (penguinIndexFileName pageNum))
          (webwinkelBlogIndexPage config arts pagination)
     ) (zip [1..] articlePages)
 

--- a/webwinkel/content/mijnwebwinkel-google-posities-behouden.org
+++ b/webwinkel/content/mijnwebwinkel-google-posities-behouden.org
@@ -76,7 +76,7 @@ Wilt u eerst lezen [[https://webwinkelverhuis.nl/waarom-mijnwebwinkel.html][waar
 MijnWebwinkel niet meer wordt doorontwikkeld]], of meteen weten hoe
 [[https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html][onze migratieservice]]
 werkt? Beide leggen we graag uit. En als u liever direct spart over uw eigen
-winkel: [[https://calendar.app.google/9h9uTzsPQoryEc6S7][plan een vrijblijvend
+winkel: [[https://meet.jappiesoftware.com][plan een vrijblijvend
 gesprek]]. We kijken samen naar uw shop en geven een eerlijke inschatting van de
 migratie en de redirects.
 

--- a/webwinkel/style.css
+++ b/webwinkel/style.css
@@ -119,7 +119,7 @@ main section {
   color: #fff;
 }
 .card .cta-button-secondary {
-  margin-top: 1em;
+  margin-top: auto;
   padding: 0.5em 1.2em;
 }
 
@@ -155,6 +155,11 @@ main section {
   border: 1px solid #dbe5ef;
   border-radius: 6px;
   padding: 1.5em;
+  /* Flex column so buttons in a card row line up on one baseline,
+     whatever the text length above them. */
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 .card h3 {
   font-size: 1.1em;
@@ -168,9 +173,13 @@ main section {
 .card p {
   color: #41505f;
   font-size: 0.95em;
+  margin-bottom: 1em;
+}
+.card > :last-child {
+  margin-bottom: 0;
 }
 .card .cta-button {
-  margin-top: 1em;
+  margin-top: auto;
   padding: 0.5em 1.2em;
 }
 .card .price {


### PR DESCRIPTION
## Summary

Follow-up to #79 (which merged while this was in flight):

- **Seventh calendar link**: an adversarial review found one more raw `calendar.app.google` link in the Google-posities blog article (org content), invisible to the template sweep and template tests. Now uses `https://meet.jappiesoftware.com` like the other six.
- **Build guard**: new `writeWebwinkelHtmlFile` checks every emitted webwinkelverhuis.nl page and crashes the build loudly if any page (templates *or* rendered content) links a raw `calendar.app.google` URL. Content can no longer smuggle the wrong calendar past the tests.
- **Button v-align**: platform cards are flex columns with the button pinned to the bottom, so the three "Bekijk migratie" buttons sit on one line regardless of text length (also bottom-aligns the pricing button on the migration pages).

## Test plan

- [x] `nix-build shake` passes (10 test cases OK)
- [x] `nix-build nix/ci.nix` passes (site build runs the new guard over every page)
- [x] Guard failure path verified: restoring the raw link in the org file fails `build-penguin` with the offending output file named
- [x] Fresh-browser Playwright screenshot: all three platform buttons on one baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)