### PR TITLE
Marketing pass on the MijnWebwinkel migration page

### DIFF
--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -356,32 +356,54 @@ mijnwebwinkelMigrationPage :: Html
 mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $ do
   whatsappFloatingButton mijnwebwinkelWhatsappLabel mijnwebwinkelWhatsappMessage
   H.main $ do
-    -- Hero
-    H.section ! A.class_ "hero" $ do
-      H.h1 "Ontsnap MijnWebwinkel"
-      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Uw webshop is uw broodwinning. MijnWebwinkel wordt al jaren niet meer doorontwikkeld, de community is gesloten, en support reageert niet. Hoelang blijft u nog wachten? Wij verhuizen uw complete shop naar Shopify &mdash; geautomatiseerd, zonder dataverlies, zonder downtime." :: Text)
-      H.a ! A.href offerteMailto ! A.class_ "cta-button" $ "Vraag een offerte aan"
+    -- Hero: friendly reassurance rather than pressure, with the escape
+    -- illustration. The visitor already knows the platform is stuck; this
+    -- page's job is making the move feel safe.
+    H.section ! A.class_ "hero" $
+      H.div ! A.class_ "hero-grid" $ do
+        H.div $ do
+          H.h1 "Ontsnap MijnWebwinkel"
+          H.p ! A.class_ "subtitle" $ "Uw webshop is uw broodwinning, en MijnWebwinkel staat al jaren stil. Verhuizen voelt als een grote stap, maar het hoeft geen sprong in het diepe te zijn: wij zetten uw complete shop geautomatiseerd over, zonder dataverlies en zonder downtime. U betaalt pas na een succesvolle migratie."
+          H.a ! A.href offerteMailto ! A.class_ "cta-button" $ "Vraag een offerte aan"
+        H.img ! A.class_ "hero-image"
+              ! A.src "/illustratie-ontsnappen.svg"
+              ! A.alt "Illustratie van dozen die een bevroren webshop verlaten richting een zonnige nieuwe winkel"
+              ! A.width "400" ! A.height "300"
 
-    -- What we migrate
+    -- What we migrate. One card per data type, each with a pictogram; the
+    -- technical depth (redirect internals, platform choice) lives in the FAQ
+    -- instead of a second near-duplicate card grid.
     H.section ! A.class_ "for-who" ! A.id "what" $ do
       H.h2 "Wat we migreren"
       H.ul ! A.class_ "card-grid" $ do
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-producten.svg"
+                ! A.alt "Doos met producten" ! A.width "56" ! A.height "56"
           H.h3 "Producten & varianten"
           H.p "Alle producten inclusief titels, beschrijvingen, prijzen, afbeeldingen, SKU's en varianten. Automatisch overgezet naar het formaat van uw doelplatform."
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-talen.svg"
+                ! A.alt "Twee tekstballonnen" ! A.width "56" ! A.height "56"
           H.h3 "Meerdere talen"
           H.p $ H.preEscapedToHtml ("Vertalingen worden correct gekoppeld. Uw klanten blijven uw shop in hun eigen taal zien &mdash; ook de URL-slugs." :: Text)
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-spaarpunten.svg"
+                ! A.alt "Munt met ster" ! A.width "56" ! A.height "56"
           H.h3 "Spaarpunten"
           H.p "Spaarpuntensaldi van uw klanten worden overgezet naar het loyaliteitsprogramma van uw nieuwe platform."
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-redirects.svg"
+                ! A.alt "Pijl die een nieuwe route neemt" ! A.width "56" ! A.height "56"
           H.h3 "SEO-redirects"
-          H.p $ H.preEscapedToHtml ("301-redirects van elke oude URL naar de nieuwe URL. We hebben de onderliggende logica van MijnWebwinkel-artikel-ID&rsquo;s in URLs achterhaald, waardoor we alle redirects volledig automatisch kunnen genereren. Uw Google-posities en backlinks blijven behouden." :: Text)
+          H.p "301-redirects van elke oude URL naar de nieuwe, volledig automatisch gegenereerd. Uw Google-posities en backlinks blijven behouden."
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-categorieen.svg"
+                ! A.alt "Categorieboom" ! A.width "56" ! A.height "56"
           H.h3 $ H.preEscapedToHtml ("Categorie&euml;n" :: Text)
           H.p $ H.preEscapedToHtml ("De volledige categorieboom wordt overgezet naar Collections met vertaalde titels en het navigatiemenu." :: Text)
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-bulk.svg"
+                ! A.alt "Toverstaf met sterretjes" ! A.width "56" ! A.height "56"
           H.h3 "Bulk-aanpassingen aan data"
           H.p $ H.preEscapedToHtml ("Grootschalige wijzigingen aan uw productdata tijdens de migratie &mdash; bijvoorbeeld alt-teksten voor alle afbeeldingen, prijsaanpassingen of het opschonen van beschrijvingen." :: Text)
 
@@ -394,13 +416,23 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $ do
           " \8212 Ons programma crawlt uw MijnWebwinkel-shop en slaat alle data op."
         H.li $ do
           H.strong "Controle"
-          " \8212 U krijgt een werkende testshop die u zelf kunt controleren voordat we live gaan."
+          " \8212 U krijgt een werkende testshop die u op uw gemak kunt bekijken voordat we live gaan."
         H.li $ do
           H.strong "Import"
           " \8212 We importeren alles in uw nieuwe shop: producten, vertalingen, collections, redirects."
         H.li $ do
           H.strong "Verificatie"
           " \8212 Samen controleren we steekproefsgewijs of alles klopt."
+
+    -- Recent werk: proof before price, so the number lands on trust.
+    H.section ! A.class_ "results" $ do
+      H.h2 "Recent werk"
+      H.div ! A.class_ "testimonials" $ do
+        H.blockquote $
+          H.p $ do
+            H.strong "Panzer-ShopNL"
+            H.preEscapedToHtml (": een modeltreinwinkel met 2.400+ producten over drie domeinen en drie talen, verhuisd van MijnWebwinkel naar Shopify. Inclusief vertalingen, de volledige categorieboom en automatisch gegenereerde 301-redirects, zodat de Google-posities behouden bleven. " :: Text)
+            H.a ! A.href "https://panzer-shop.nl/" $ H.preEscapedToHtml ("panzer-shop.nl &rarr;" :: Text)
 
     -- Pricing
     H.section ! A.class_ "engagement" ! A.id "pricing" $ do
@@ -413,33 +445,21 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $ do
           H.a ! A.href offerteMailto ! A.class_ "cta-button" $ "Vraag een offerte aan"
       H.p ! A.class_ "engagement-note" $ H.preEscapedToHtml ("Vaste prijs, vooraf afgesproken. Geen verrassingen. Betaling na succesvolle migratie." :: Text)
 
-    -- Recent werk
-    H.section ! A.class_ "results" $ do
-      H.h2 "Recent werk"
-      H.div ! A.class_ "testimonials" $ do
-        H.blockquote $
-          H.p $ do
-            H.strong "Panzer-ShopNL"
-            H.preEscapedToHtml (": een modeltreinwinkel met 2.400+ producten over drie domeinen en drie talen, verhuisd van MijnWebwinkel naar Shopify. Inclusief vertalingen, de volledige categorieboom en automatisch gegenereerde 301-redirects, zodat de Google-posities behouden bleven. " :: Text)
-            H.a ! A.href "https://panzer-shop.nl/" $ H.preEscapedToHtml ("panzer-shop.nl &rarr;" :: Text)
-
     -- Why us
     H.section ! A.class_ "results" $ do
       H.h2 "Waarom via ons?"
       H.div ! A.class_ "testimonials" $ do
         H.blockquote $ do
-          H.p $ H.preEscapedToHtml ("U weet het al: MijnWebwinkel gaat nergens meer heen. Geen nieuwe features, geen community, trage support. Elke dag dat u wacht is een dag dat uw concurrent op Shopify u inhaalt. Het werkt, want het is al gedaan." :: Text)
+          H.p "U weet het al: MijnWebwinkel gaat nergens meer heen. Geen nieuwe features, geen community, trage support. Gelukkig hoeft u daar niet op te wachten: verhuizen is inmiddels een gebaande weg."
           H.p $ do
             H.a ! A.href "/waarom-mijnwebwinkel.html" $ "Waarom wordt MijnWebwinkel niet meer doorontwikkeld?"
             H.preEscapedToHtml (" &rarr;" :: Text)
       H.p $ H.preEscapedToHtml ("Wij zijn geen Shopify-partner die commissie verdient op uw overstap. Wij zijn migratie-specialisten. U kiest het platform &mdash; Shopify, WooCommerce, of iets anders &mdash; wij regelen de techniek." :: Text)
       H.ul $ do
         H.li $ H.strong "Geen risico" >> H.preEscapedToHtml (" &mdash; u betaalt pas na succesvolle migratie" :: Text)
-        H.li $ H.strong "Platformonafhankelijk" >> H.preEscapedToHtml (" &mdash; u kiest de bestemming, wij migreren naar elk platform" :: Text)
         H.li $ H.strong "Geautomatiseerd" >> H.preEscapedToHtml (" &mdash; geen handmatig overtypen, geen kopieerfouten" :: Text)
         H.li $ H.strong "SEO-behoud" >> H.preEscapedToHtml (" &mdash; 301-redirects zodat uw Google-posities niet verloren gaan" :: Text)
         H.li $ H.strong "Meertalig" >> H.preEscapedToHtml (" &mdash; vertalingen correct gekoppeld via offici&euml;le APIs" :: Text)
-        H.li $ H.strong "Controleerbaar" >> H.preEscapedToHtml (" &mdash; u krijgt een testshop en kunt alles verifi&euml;ren voor de overstap" :: Text)
         H.li $ H.strong "Vaste prijs" >> H.preEscapedToHtml (" &mdash; geen uurtarief, u weet vooraf wat het kost" :: Text)
 
     -- FAQ
@@ -447,35 +467,11 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $ do
       H.h2 "Veelgestelde vragen"
       H.dl $ mapM_ renderFaqItem mijnwebwinkelFaq
 
-    -- Technical details
-    H.section ! A.class_ "for-who" $ do
-      H.h2 "Technische details"
-      H.ul ! A.class_ "card-grid" $ do
-        H.li ! A.class_ "card" $ do
-          H.h3 "SEO-redirects"
-          H.p $ H.preEscapedToHtml ("Volledige 301-redirect mapping van elke oude URL. We hebben de interne logica van MijnWebwinkel artikel-ID&rsquo;s in URLs achterhaald &mdash; alle redirects worden volledig automatisch gegenereerd, inclusief URLs met numerieke product-ID&rsquo;s." :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "Bulk-aanpassingen"
-          H.p $ H.preEscapedToHtml ("Grootschalige wijzigingen aan uw productdata tijdens de migratie: alt-teksten genereren voor alle afbeeldingen, prijzen aanpassen, beschrijvingen opschonen, HTML-tags verwijderen &mdash; alles in &eacute;&eacute;n keer." :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "Platformkeuze"
-          H.p $ H.preEscapedToHtml ("Shopify is het meest gekozen doelplatform, maar we ondersteunen ook WooCommerce of andere platformen. U kiest, wij regelen de techniek." :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "Vertalingen & URL-slugs"
-          H.p $ H.preEscapedToHtml ("Meertalige content wordt correct gekoppeld via offici&euml;le platform APIs. Inclusief vertaalde URL-slugs &mdash; niet alleen productteksten." :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "Klantdata & spaarpunten"
-          H.p "Klantaccounts, bestelgeschiedenis en spaarpuntensaldi worden overgezet naar het loyaliteitsprogramma van uw nieuwe platform."
-        H.li ! A.class_ "card" $ do
-          H.h3 "Testshop & verificatie"
-          H.p "U krijgt een volledige testshop om alles te controleren. Pas na uw goedkeuring gaan we live. Correcties zijn inbegrepen."
-
     -- CTA
     H.section ! A.class_ "final-cta" $ do
       H.h2 "Klaar om te ontsnappen?"
-      H.p $ H.preEscapedToHtml ("U hoeft niet langer te wachten tot MijnWebwinkel beter wordt &mdash; dat gaat niet gebeuren. " :: Text)
-      H.p "Plan een gratis, vrijblijvend gesprek. We bekijken samen uw webshop en geven direct een inschatting."
-      H.a ! A.href meetLink ! A.class_ "cta-button" $ "Ontsnap nu"
+      H.p "Plan een gratis, vrijblijvend gesprek. We bekijken samen uw webshop en geven een eerlijke inschatting."
+      H.a ! A.href meetLink ! A.class_ "cta-button" $ "Plan een gratis gesprek"
   where
     migrationMeta :: PageMeta
     migrationMeta = PageMeta

--- a/webwinkel/icoon-bulk.svg
+++ b/webwinkel/icoon-bulk.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- "Wat we migreren" card icon: a magic wand with sparkles, bulk edits
+     applied across the whole catalogue in one go. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="30" fill="#eaf1f8"/>
+  <path d="M20 44 L38 26" stroke="#10456b" stroke-width="4" stroke-linecap="round"/>
+  <path d="M38 26 L44 20" stroke="#e8590c" stroke-width="4" stroke-linecap="round"/>
+  <g stroke="#e8590c" stroke-width="2.5" stroke-linecap="round">
+    <path d="M46 32 v6 M43 35 h6"/>
+    <path d="M28 20 v5 M25.5 22.5 h5"/>
+    <path d="M48 44 v4 M46 46 h4"/>
+  </g>
+</svg>

--- a/webwinkel/icoon-categorieen.svg
+++ b/webwinkel/icoon-categorieen.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- "Wat we migreren" card icon: a category tree with nodes. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="30" fill="#eaf1f8"/>
+  <rect x="26" y="14" width="12" height="10" rx="2" fill="#10456b" stroke="#0c2f47" stroke-width="2.5"/>
+  <path d="M32 24 v8 M32 32 h-12 v6 M32 32 h12 v6" fill="none" stroke="#10456b" stroke-width="3"/>
+  <rect x="14" y="38" width="12" height="10" rx="2" fill="#ffffff" stroke="#10456b" stroke-width="2.5"/>
+  <rect x="38" y="38" width="12" height="10" rx="2" fill="#f6c89f" stroke="#10456b" stroke-width="2.5"/>
+</svg>

--- a/webwinkel/icoon-producten.svg
+++ b/webwinkel/icoon-producten.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- "Wat we migreren" card icon: an open box with items, products & variants. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="30" fill="#eaf1f8"/>
+  <rect x="18" y="28" width="28" height="18" rx="2" fill="#ffffff" stroke="#10456b" stroke-width="3"/>
+  <path d="M18 28 l-4 -7 h14 l4 7 M46 28 l4 -7 h-14 l-4 7" fill="#dbe5ef" stroke="#10456b" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M27 37 h10" stroke="#e8590c" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/webwinkel/icoon-redirects.svg
+++ b/webwinkel/icoon-redirects.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- "Wat we migreren" card icon: an arrow rerouting to a new destination,
+     301 redirects that keep Google rankings. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="30" fill="#eaf1f8"/>
+  <circle cx="20" cy="44" r="4" fill="#ffffff" stroke="#10456b" stroke-width="3"/>
+  <path d="M24 40 C 30 28, 38 26, 44 26" fill="none" stroke="#e8590c" stroke-width="3.5" stroke-linecap="round"/>
+  <path d="M40 20 l8 6 l-8 6 z" fill="#e8590c"/>
+  <path d="M28 46 h14 M30 51 h10" stroke="#10456b" stroke-width="2.5" stroke-linecap="round" opacity="0.5"/>
+</svg>

--- a/webwinkel/icoon-spaarpunten.svg
+++ b/webwinkel/icoon-spaarpunten.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- "Wat we migreren" card icon: a star coin, loyalty points. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="30" fill="#eaf1f8"/>
+  <circle cx="32" cy="32" r="16" fill="#f6c89f" stroke="#10456b" stroke-width="3"/>
+  <path d="M32 24 l2.4 5 5.6 0.7 -4 3.9 1 5.4 -5 -2.6 -5 2.6 1 -5.4 -4 -3.9 5.6 -0.7 z" fill="#e8590c" stroke="#0c2f47" stroke-width="1.5" stroke-linejoin="round"/>
+</svg>

--- a/webwinkel/icoon-talen.svg
+++ b/webwinkel/icoon-talen.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- "Wat we migreren" card icon: two speech bubbles, multiple languages. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="30" fill="#eaf1f8"/>
+  <path d="M16 20 h20 v14 h-12 l-6 6 v-6 h-2 z" fill="#ffffff" stroke="#10456b" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M48 30 h-16 v12 h10 l6 6 v-6 h0 z" fill="#f6c89f" stroke="#10456b" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M22 27 h8" stroke="#10456b" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M38 36 h6" stroke="#0c2f47" stroke-width="2.5" stroke-linecap="round"/>
+</svg>

--- a/webwinkel/illustratie-ontsnappen.svg
+++ b/webwinkel/illustratie-ontsnappen.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Hero illustration for the MijnWebwinkel migration page: boxes escaping a
+     frozen (snowflake) old shop toward a bright new one with the sun out.
+     Remix of illustratie-verhuizen.svg in the same navy/orange palette. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 300" role="img">
+  <!-- soft backdrop -->
+  <circle cx="200" cy="150" r="130" fill="#eaf1f8"/>
+  <!-- snowflake over the old shop -->
+  <g stroke="#7fa3c0" stroke-width="3" stroke-linecap="round" opacity="0.9">
+    <path d="M92 62 v36"/>
+    <path d="M76.5 71 l31 18"/>
+    <path d="M76.5 89 l31 -18"/>
+    <path d="M92 62 l-4 5 M92 62 l4 5"/>
+    <path d="M92 98 l-4 -5 M92 98 l4 -5"/>
+  </g>
+  <!-- old shop, faded -->
+  <g opacity="0.45">
+    <rect x="48" y="130" width="90" height="80" fill="#ffffff" stroke="#0c2f47" stroke-width="3"/>
+    <path d="M40 130 l8 -26 h74 l8 26 z" fill="#dbe5ef" stroke="#0c2f47" stroke-width="3" stroke-linejoin="round"/>
+    <path d="M40 130 h90" stroke="#0c2f47" stroke-width="3"/>
+    <rect x="62" y="152" width="26" height="26" fill="#dbe5ef" stroke="#0c2f47" stroke-width="3"/>
+    <rect x="98" y="152" width="26" height="58" fill="#dbe5ef" stroke="#0c2f47" stroke-width="3"/>
+  </g>
+  <!-- sun over the new shop -->
+  <g stroke="#e8590c" stroke-width="3" stroke-linecap="round">
+    <circle cx="330" cy="66" r="10" fill="#f6c89f"/>
+    <path d="M330 48 v-6 M330 84 v6 M312 66 h-6 M348 66 h6"/>
+    <path d="M317 53 l-4 -4 M343 53 l4 -4 M317 79 l-4 4 M343 79 l4 4"/>
+  </g>
+  <!-- arrow of travel -->
+  <path d="M150 176 C 185 120, 225 120, 258 168" fill="none" stroke="#e8590c" stroke-width="6" stroke-linecap="round" stroke-dasharray="2 14"/>
+  <path d="M250 148 l10 22 l-24 -4 z" fill="#e8590c"/>
+  <!-- moving boxes -->
+  <g transform="rotate(-8 196 132)">
+    <rect x="172" y="112" width="48" height="40" rx="4" fill="#f6c89f" stroke="#0c2f47" stroke-width="3"/>
+    <path d="M172 128 h48" stroke="#0c2f47" stroke-width="3"/>
+    <path d="M196 112 v16" stroke="#0c2f47" stroke-width="3"/>
+  </g>
+  <!-- new shop, bright -->
+  <g>
+    <rect x="252" y="118" width="110" height="98" fill="#ffffff" stroke="#0c2f47" stroke-width="3"/>
+    <path d="M242 118 l10 -30 h90 l10 30 z" fill="#10456b" stroke="#0c2f47" stroke-width="3" stroke-linejoin="round"/>
+    <path d="M242 118 h130" stroke="#0c2f47" stroke-width="3"/>
+    <rect x="266" y="142" width="30" height="30" fill="#dbe5ef" stroke="#0c2f47" stroke-width="3"/>
+    <rect x="310" y="142" width="30" height="74" fill="#e8590c" stroke="#0c2f47" stroke-width="3"/>
+    <circle cx="316" cy="180" r="2.5" fill="#0c2f47"/>
+    <path d="M246 118 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 16 0 a8 8 0 0 0 14 0" fill="#e8590c" stroke="#0c2f47" stroke-width="3"/>
+  </g>
+  <!-- delivered box at the door -->
+  <rect x="270" y="196" width="22" height="20" rx="3" fill="#f6c89f" stroke="#0c2f47" stroke-width="3"/>
+  <path d="M270 204 h22" stroke="#0c2f47" stroke-width="3"/>
+</svg>

--- a/webwinkel/style.css
+++ b/webwinkel/style.css
@@ -53,11 +53,12 @@ body {
   color: #c44d06 !important;
 }
 
-/* Shared section spacing */
+/* Shared section spacing. A touch more vertical air than the penguin theme:
+   these pages are text-dense sales pages and need the breathing room. */
 main section {
   max-width: 800px;
   margin: 0 auto;
-  padding: 3em 2em;
+  padding: 3.5em 2em;
 }
 
 /* Hero */


### PR DESCRIPTION
## Summary

Declutter and befriend `migrate-mijnwebwinkel.html`, keeping the substance:

- **Een lijn**: hero (promise) → wat we migreren → hoe het werkt → recent werk (proof) → prijzen → waarom via ons → FAQ → gesprek. Recent werk moved above Prijzen so the €999 lands on trust rather than cold.
- **Less crammed**: the "Technische details" section is deleted; its six cards duplicated the "Wat we migreren" cards and the FAQ almost point for point (redirect internals, bulk edits, platform choice, testshop are all still on the page, once each). Twelve cards saying six things became six. Sections also get a touch more vertical padding across the webwinkel theme.
- **Pictures**: a new escape hero illustration (boxes leaving a frozen shop, sun over the new one) plus a pictogram per migreren-card, all in the navy/orange palette.
- **Friendly**: the hero acknowledges that moving feels like a big step instead of "hoelang blijft u nog wachten?"; "elke dag dat u wacht haalt uw concurrent u in" became "verhuizen is inmiddels een gebaande weg"; the closing button is "Plan een gratis gesprek" instead of "Ontsnap nu". Why-us bullets trimmed 7 → 5 (the dropped two were already covered by the paragraph, the process steps and the FAQ).

## Test plan

- [x] `nix-build shake` passes, all 10 template tests OK (meet-link invariant still enforced on this page)
- [x] `nix-build nix/ci.nix` passes (site build runs the calendar-link guard over every page)
- [x] Full-page Playwright screenshot reviewed: icons, hero illustration and section order render as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)