### PR TITLE
Restore the customer-accounts fact on the MWW page

### DIFF
--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -389,8 +389,8 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $ do
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-spaarpunten.svg"
                 ! A.alt "Munt met ster" ! A.width "56" ! A.height "56"
-          H.h3 "Spaarpunten"
-          H.p "Spaarpuntensaldi van uw klanten worden overgezet naar het loyaliteitsprogramma van uw nieuwe platform."
+          H.h3 "Klanten & spaarpunten"
+          H.p "Klantaccounts, bestelgeschiedenis en spaarpuntensaldi verhuizen mee. Uw klanten kunnen direct inloggen, met hun spaarpunten in het loyaliteitsprogramma van uw nieuwe platform."
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-redirects.svg"
                 ! A.alt "Pijl die een nieuwe route neemt" ! A.width "56" ! A.height "56"


### PR DESCRIPTION
## Summary

Follow-up to #81 (merged while the fix was in flight). An adversarial review caught that deleting the Technische details section dropped one unique fact: customer accounts and order history migrate, so customers can keep logging in. The Spaarpunten card is now **Klanten & spaarpunten** and carries the whole customer story, matching the CCV and Lightspeed pages.

## Test plan

- [x] `nix-build shake` passes, all 10 template tests OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)