### PR TITLE
Refocus jappiesoftware.com: drop consulting, polish WordPress page

### DIFF
--- a/penguin/icoon-apparaten.svg
+++ b/penguin/icoon-apparaten.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- WordPress-page card icon: laptop and phone, looks right on every screen. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="30" fill="#f0f5f1"/>
+  <rect x="14" y="20" width="30" height="20" rx="2" fill="#ffffff" stroke="#2a5a3a" stroke-width="3"/>
+  <path d="M11 44 h36 l-3 -4 h-30 z" fill="#cfe3d5" stroke="#2a5a3a" stroke-width="3" stroke-linejoin="round"/>
+  <rect x="40" y="26" width="12" height="20" rx="3" fill="#ffffff" stroke="#2a5a3a" stroke-width="3"/>
+  <circle cx="46" cy="42" r="1.5" fill="#2a5a3a"/>
+  <rect x="19" y="25" width="14" height="3" rx="1.5" fill="#7fb08f"/>
+  <rect x="19" y="31" width="10" height="3" rx="1.5" fill="#cfe3d5"/>
+</svg>

--- a/penguin/icoon-contact.svg
+++ b/penguin/icoon-contact.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- WordPress-page card icon: chat bubble with a calendar check, contact,
+     WhatsApp and bookings. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="30" fill="#f0f5f1"/>
+  <path d="M15 18 h26 v18 h-16 l-7 7 v-7 h-3 z" fill="#ffffff" stroke="#2a5a3a" stroke-width="3" stroke-linejoin="round"/>
+  <circle cx="23" cy="27" r="2" fill="#2a5a3a"/>
+  <circle cx="30" cy="27" r="2" fill="#2a5a3a"/>
+  <circle cx="37" cy="27" r="2" fill="#2a5a3a"/>
+  <rect x="36" y="34" width="16" height="14" rx="2" fill="#cfe3d5" stroke="#2a5a3a" stroke-width="3"/>
+  <path d="M36 39 h16" stroke="#2a5a3a" stroke-width="2"/>
+  <path d="M40 43.5 l2.5 2.5 l5 -5" fill="none" stroke="#2a5a3a" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/penguin/icoon-ontwerp.svg
+++ b/penguin/icoon-ontwerp.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- WordPress-page card icon: paint palette, a design in your own style.
+     Penguin palette (greens), matching the webwinkel icon style. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="30" fill="#f0f5f1"/>
+  <path d="M32 14 a18 18 0 1 0 0 36 c4 0 4 -3 2.5 -5 c-2 -2.5 -0.5 -6 3.5 -6 h5 a7 7 0 0 0 7 -7 a18 18 0 0 0 -18 -18 z" fill="#ffffff" stroke="#2a5a3a" stroke-width="3"/>
+  <circle cx="24" cy="26" r="3" fill="#7fb08f"/>
+  <circle cx="34" cy="22" r="3" fill="#2a5a3a"/>
+  <circle cx="43" cy="28" r="3" fill="#f6d9a0"/>
+  <circle cx="22" cy="37" r="3" fill="#cfe3d5"/>
+</svg>

--- a/penguin/icoon-veilig.svg
+++ b/penguin/icoon-veilig.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- WordPress-page card icon: shield with a lightning bolt, safe and fast. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="30" fill="#f0f5f1"/>
+  <path d="M32 14 l14 5 v12 c0 10 -6 16 -14 19 c-8 -3 -14 -9 -14 -19 v-12 z" fill="#ffffff" stroke="#2a5a3a" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M34 22 l-7 11 h5 l-2 9 l8 -12 h-5 z" fill="#7fb08f" stroke="#2a5a3a" stroke-width="2" stroke-linejoin="round"/>
+</svg>

--- a/penguin/icoon-vindbaar.svg
+++ b/penguin/icoon-vindbaar.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- WordPress-page card icon: magnifying glass over a page, being found on
+     Google. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="30" fill="#f0f5f1"/>
+  <rect x="17" y="16" width="22" height="28" rx="2" fill="#ffffff" stroke="#2a5a3a" stroke-width="3"/>
+  <path d="M22 23 h12 M22 29 h12 M22 35 h8" stroke="#cfe3d5" stroke-width="3" stroke-linecap="round"/>
+  <circle cx="39" cy="36" r="8" fill="#f0f5f1" fill-opacity="0.7" stroke="#2a5a3a" stroke-width="3"/>
+  <path d="M45 42 l6 6" stroke="#2a5a3a" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/penguin/icoon-zelf-aanpassen.svg
+++ b/penguin/icoon-zelf-aanpassen.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- WordPress-page card icon: pencil writing on a page, update it yourself. -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img">
+  <circle cx="32" cy="32" r="30" fill="#f0f5f1"/>
+  <rect x="16" y="18" width="24" height="28" rx="2" fill="#ffffff" stroke="#2a5a3a" stroke-width="3"/>
+  <path d="M21 26 h14 M21 32 h14 M21 38 h9" stroke="#cfe3d5" stroke-width="3" stroke-linecap="round"/>
+  <g transform="rotate(45 44 32)">
+    <rect x="41" y="18" width="7" height="20" rx="1.5" fill="#7fb08f" stroke="#2a5a3a" stroke-width="2.5"/>
+    <path d="M41 38 h7 l-3.5 7 z" fill="#f6d9a0" stroke="#2a5a3a" stroke-width="2.5" stroke-linejoin="round"/>
+  </g>
+</svg>

--- a/penguin/style.css
+++ b/penguin/style.css
@@ -141,6 +141,13 @@ main section {
   border: 1px solid #e0e0e0;
 }
 
+/* Small pictogram at the top of a card */
+.card-icon {
+  width: 56px;
+  height: 56px;
+  margin-bottom: 0.75em;
+}
+
 /* Hero with an image beside the text (WordPress page) */
 .hero-grid {
   display: grid;

--- a/shake/PageChrome.hs
+++ b/shake/PageChrome.hs
@@ -14,6 +14,7 @@ module PageChrome
   , ogLocale
   , resolveOgImage
   , companyEmail
+  , meetLink
   , companyWhatsappNumber
   , whatsappFloatingButton
   , organizationJsonLd
@@ -99,6 +100,14 @@ resolveOgImage siteDefault = fromMaybe siteDefault . pageMetaOgImage
 -- sites and the Organization structured data.
 companyEmail :: Text
 companyEmail = "hallo@jappiesoftware.com"
+
+-- | Branded scheduling link used by every "plan een gesprek" button across
+-- the sites and the outreach mails. It is a 302 redirect on our own
+-- infrastructure (megavid blog/vhost.nix) to the current Google Calendar
+-- booking page, so the underlying calendar can change without touching
+-- built pages or already-sent mails.
+meetLink :: H.AttributeValue
+meetLink = "https://meet.jappiesoftware.com"
 
 -- =============================================================================
 -- Floating WhatsApp contact button ("bolletje")

--- a/shake/PenguinTemplates.hs
+++ b/shake/PenguinTemplates.hs
@@ -40,6 +40,7 @@ import PageChrome
   , ogLocale
   , resolveOgImage
   , companyEmail
+  , meetLink
   , whatsappFloatingButton
   , organizationJsonLd
   , formatIsoDate
@@ -457,21 +458,33 @@ penguinWordpressPage (WebwinkelverhuisUrl webwinkelUrl) = penguinBaseTemplate En
       H.h2 "What you can expect"
       H.ul ! A.class_ "card-grid" $ do
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-ontwerp.svg"
+                ! A.alt "Verfpalet" ! A.width "56" ! A.height "56"
           H.h3 "A design in your own style"
           H.p "We set up the site in your colours and logo, and lay out the pages you need. You pick from two proposals with sample content up front, so you know what you are getting."
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-apparaten.svg"
+                ! A.alt "Laptop en telefoon" ! A.width "56" ! A.height "56"
           H.h3 "Looks right on phone and computer"
           H.p "Built and tested on phone, laptop and desktop, so it looks right everywhere: consistent margins, sensible proportions, a layout that works on a small screen."
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-contact.svg"
+                ! A.alt "Tekstballon en kalender" ! A.width "56" ! A.height "56"
           H.h3 "Contact, WhatsApp and bookings"
           H.p "A contact form, your email and phone in plain sight, and a WhatsApp button. Optionally a booking tool so clients can plan an appointment themselves."
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-vindbaar.svg"
+                ! A.alt "Vergrootglas boven een pagina" ! A.width "56" ! A.height "56"
           H.h3 "Being found on Google"
           H.p "Clean page titles, descriptions and headings so Google understands your site. You tell us what you want to be found for, we build it in correctly."
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-veilig.svg"
+                ! A.alt "Schild met bliksem" ! A.width "56" ! A.height "56"
           H.h3 "Safe and fast"
           H.p "The padlock in the browser (SSL), images sized right and a site that loads quickly. That is part of a tidy build, not a separate expensive package."
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-zelf-aanpassen.svg"
+                ! A.alt "Potlood op een pagina" ! A.width "56" ! A.height "56"
           H.h3 "Update it yourself, no need to call us"
           H.p "A personal video walkthrough plus a short written manual: edit text, replace a photo, update a page. After that you can do it yourself, and we stay available for bigger jobs."
 
@@ -521,14 +534,15 @@ penguinWordpressPage (WebwinkelverhuisUrl webwinkelUrl) = penguinBaseTemplate En
         H.a ! A.href (toValue (webwinkelUrl <> "/")) $ "webwinkelverhuis.nl"
         " for the webshop side."
 
-    -- Final CTA
+    -- Final CTA: direct booking is the lowest-friction step for this
+    -- audience; email stays available as the text link.
     H.section ! A.class_ "final-cta" $ do
       H.h2 "Thinking about a new website?"
       H.p $ do
-        H.preEscapedToHtml ("Tell us what your business does and we will sketch what a fixed-price site would look like. " :: Text)
+        "Tell us what your business does and we will sketch what a fixed-price site would look like. Prefer email? "
         H.a ! A.href contactMailto $ "Get in touch"
         "."
-      H.a ! A.href contactMailto ! A.class_ "cta-button" $ "Get in touch"
+      H.a ! A.href meetLink ! A.class_ "cta-button" $ "Book a free chat"
   where
     wordpressMeta :: PageMeta
     wordpressMeta = (defaultPageMeta "Have a Website Built \8212 Fixed-Price WordPress \8212 Jappie Software B.V.")
@@ -563,21 +577,33 @@ penguinWordpressPageNl (WebwinkelverhuisUrl webwinkelUrl) = penguinBaseTemplate 
       H.h2 "Wat u kunt verwachten"
       H.ul ! A.class_ "card-grid" $ do
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-ontwerp.svg"
+                ! A.alt "Verfpalet" ! A.width "56" ! A.height "56"
           H.h3 "Een ontwerp in uw eigen stijl"
           H.p "We richten de site in met uw kleuren en logo, en zetten de pagina's op die u nodig hebt. U kiest vooraf uit twee voorstellen met voorbeeldinhoud, zodat u weet wat u krijgt."
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-apparaten.svg"
+                ! A.alt "Laptop en telefoon" ! A.width "56" ! A.height "56"
           H.h3 "Mooi op telefoon en computer"
           H.p "Gebouwd en getest op telefoon, laptop en desktop, zodat het overal klopt: nette marges, kloppende verhoudingen en een indeling die op een klein scherm werkt."
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-contact.svg"
+                ! A.alt "Tekstballon en kalender" ! A.width "56" ! A.height "56"
           H.h3 "Contact, WhatsApp en afspraken"
           H.p "Een contactformulier, uw e-mail en telefoon goed zichtbaar, en een WhatsApp-knop. Optioneel een afsprakentool zodat klanten zelf een afspraak inplannen."
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-vindbaar.svg"
+                ! A.alt "Vergrootglas boven een pagina" ! A.width "56" ! A.height "56"
           H.h3 "Gevonden worden in Google"
           H.p "Nette paginatitels, beschrijvingen en koppen zodat Google uw site begrijpt. U vertelt waarop u gevonden wilt worden, wij bouwen het correct in."
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-veilig.svg"
+                ! A.alt "Schild met bliksem" ! A.width "56" ! A.height "56"
           H.h3 "Veilig en snel"
           H.p "Het slotje in de browser (SSL), afbeeldingen in de juiste maat en een site die vlot laadt. Dat hoort bij een nette bouw, niet bij een apart duur pakket."
         H.li ! A.class_ "card" $ do
+          H.img ! A.class_ "card-icon" ! A.src "/icoon-zelf-aanpassen.svg"
+                ! A.alt "Potlood op een pagina" ! A.width "56" ! A.height "56"
           H.h3 "Zelf aanpassen zonder ons te bellen"
           H.p "Een persoonlijke videorondleiding plus een korte handleiding: tekst aanpassen, een foto vervangen, een pagina bijwerken. U kunt het daarna zelf, en voor grotere klussen blijven we bereikbaar."
 
@@ -627,14 +653,15 @@ penguinWordpressPageNl (WebwinkelverhuisUrl webwinkelUrl) = penguinBaseTemplate 
         H.a ! A.href (toValue (webwinkelUrl <> "/")) $ "webwinkelverhuis.nl"
         " voor de webshop-kant."
 
-    -- Laatste CTA
+    -- Laatste CTA: direct een gesprek inplannen is voor deze doelgroep de
+    -- laagste drempel; mailen kan via de tekstlink.
     H.section ! A.class_ "final-cta" $ do
       H.h2 "Denkt u na over een nieuwe website?"
       H.p $ do
-        "Vertel ons wat uw bedrijf doet, dan schetsen we hoe een site met vaste prijs eruit zou zien. "
+        "Vertel ons wat uw bedrijf doet, dan schetsen we hoe een site met vaste prijs eruit zou zien. Liever mailen? "
         H.a ! A.href contactMailto $ "Neem contact op"
         "."
-      H.a ! A.href contactMailto ! A.class_ "cta-button" $ "Neem contact op"
+      H.a ! A.href meetLink ! A.class_ "cta-button" $ "Plan een gratis kennismaking"
   where
     wordpressMetaNl :: PageMeta
     wordpressMetaNl = (defaultPageMeta "Laat een website bouwen \8212 WordPress met vaste prijs \8212 Jappie Software B.V.")

--- a/shake/PenguinTemplates.hs
+++ b/shake/PenguinTemplates.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Templates for jappiesoftware.com: the company's products-and-consulting
--- site and its technical blog. Carries the penguin theme (voronoi background,
--- green palette). Shared SEO/structured-data/blog markup lives in 'PageChrome';
--- the webshop-migration brand site lives in 'WebwinkelTemplates'.
+-- | Templates for jappiesoftware.com: the company's site for fixed-price,
+-- transactional services (WordPress websites, webshop migrations). Carries
+-- the penguin theme (voronoi background, green palette). The technical blog
+-- remains reachable but unpromoted; consulting lives on jappie.me. Shared
+-- SEO/structured-data/blog markup lives in 'PageChrome'; the
+-- webshop-migration brand site lives in 'WebwinkelTemplates'.
 module PenguinTemplates
   ( WebwinkelverhuisUrl(..)
   , penguinIndexPage
@@ -222,10 +224,11 @@ penguinNav lang switchUrl =
   H.nav ! A.class_ "top-nav" $ do
     H.span ! A.class_ "logo" $
       H.a ! A.href (penguinHome lang) $ "Jappie Software B.V."
+    -- No Blog entry: the technical blog stays reachable (footer link, old
+    -- URLs live) but is not maintained or promoted; the menu sells only the
+    -- transactional services.
     H.ul $ do
       H.li $ H.a ! A.href (penguinAnchor lang "products") $ toHtml (navProducts lang)
-      H.li $ H.a ! A.href (penguinAnchor lang "consulting") $ toHtml (navConsulting lang)
-      H.li $ H.a ! A.href "/blog/" $ "Blog"
       H.li $ H.a ! A.href contactMailto ! A.class_ "cta-link" $ toHtml (navContact lang)
       penguinLangToggle lang switchUrl
 
@@ -259,11 +262,6 @@ penguinAnchor Nl section = toValue ("/nl/#" <> section)
 navProducts :: Lang -> Text
 navProducts En = "Services"
 navProducts Nl = "Diensten"
-
--- | Navigation label for the consulting section.
-navConsulting :: Lang -> Text
-navConsulting En = "Consulting"
-navConsulting Nl = "Consultancy"
 
 -- | Navigation label for the "get in touch" call to action.
 navContact :: Lang -> Text
@@ -321,41 +319,23 @@ penguinIndexPage webwinkelUrl = penguinBaseTemplate En indexMeta $
           H.strong "Build and deliver"
           ": you check everything before it goes live, and you pay on delivery."
 
-    -- Consulting
-    H.section ! A.class_ "results" ! A.id "consulting" $ do
-      H.h2 "Expert Consulting"
-      H.p $ H.preEscapedToHtml ("We also take on consulting engagements where our expertise makes a difference. 10+ years building production systems &mdash; we make technical decisions and then build them." :: Text)
-      H.div ! A.class_ "testimonials" $ do
-        H.blockquote $
-          H.p $ do
-            "Built the core platform for a "
-            H.strong "reinsurance technology startup"
-            H.preEscapedToHtml (" &mdash; from early architecture to handling live deals in production. " :: Text)
-            H.a ! A.href "https://jappie.me/the-peculiar-event-sourced-deadlock.html" $ H.preEscapedToHtml ("Read about solving a production issue &rarr;" :: Text)
-        H.blockquote $
-          H.p $ do
-            "Technical lead for a "
-            H.strong "construction IoT startup"
-            H.preEscapedToHtml (". Architecture decisions that scaled from pilot to production. 7x device performance improvement. " :: Text)
-            H.a ! A.href "https://jappie.me/stacked-against-us.html" $ H.preEscapedToHtml ("Read the full story &rarr;" :: Text)
-            H.preEscapedToHtml (" &middot; " :: Text)
-            H.a ! A.href "https://jappie.me/firmware-lemons.html" $ H.preEscapedToHtml ("The 7x improvement &rarr;" :: Text)
-        H.blockquote $
-          H.p $ do
-            "Automated "
-            H.strong "e-commerce migration"
-            " for a multi-language webshop with 2,400+ products across three domains and three languages."
+    -- Decision: no consulting section. Consulting leads never came through
+    -- this site and Jappie does not want to push that work here; the site
+    -- sells fixed-price, transactional services (websites, migrations).
+    -- Consulting and case studies live on jappie.me, which the About section
+    -- and footer still link. Alternative considered: keeping a slimmed
+    -- consulting mention, rejected because it muddies the transactional
+    -- positioning for the Ellen/Laura audience.
 
     -- About
     H.section ! A.class_ "about" $ do
       H.h2 "About"
       H.div ! A.class_ "about-grid" $ do
         H.div $ do
-          H.p $ H.preEscapedToHtml ("I&rsquo;m Jappie Klooster. I build websites, webshops and software products, and I help companies that need serious technical expertise. I use technology chosen for reliability, and I explain what I do in plain language." :: Text)
-          H.p "Based in the Netherlands. Available for product partnerships, consulting engagements, and co-founder conversations."
+          H.p $ H.preEscapedToHtml ("I&rsquo;m Jappie Klooster. I build websites and webshops for entrepreneurs, for a fixed price and in plain language. Behind the scenes I bring ten-plus years of software engineering, so the technology is chosen for reliability." :: Text)
           H.p $ do
-            "For more writing and case studies, visit the "
-            H.a ! A.href "/blog/" $ "blog"
+            "Based in the Netherlands. For consulting and case studies, see "
+            H.a ! A.href "https://jappie.me/" $ "jappie.me"
             "."
         H.img ! A.class_ "about-portrait"
               ! A.src "/selfie.png"
@@ -366,13 +346,13 @@ penguinIndexPage webwinkelUrl = penguinBaseTemplate En indexMeta $
     H.section ! A.class_ "final-cta" $ do
       H.h2 "Have a problem that needs solving?"
       H.p $ do
-        "Whether you need a website, a webshop migration, or expert consulting: "
+        "Whether you need a website or a webshop migration: "
         H.a ! A.href contactMailto $ "get in touch"
         "."
       H.a ! A.href contactMailto ! A.class_ "cta-button" $ "Get in touch"
   where
     indexMeta :: PageMeta
-    indexMeta = (defaultPageMeta "Jappie Software B.V. \8212 Websites, Webshop Migrations & Consulting")
+    indexMeta = (defaultPageMeta "Jappie Software B.V. \8212 Websites & Webshop Migrations")
       { pageMetaDescription = "We build websites for small businesses and move webshops to a better platform. Fixed price, plain language, and you pay on delivery."
       , pageMetaCanonical = Just "https://jappiesoftware.com/"
       , pageMetaSwitchUrl = Just "/nl/"
@@ -414,41 +394,17 @@ penguinIndexPageNl webwinkelUrl = penguinBaseTemplate Nl indexMetaNl $
           H.strong "Bouwen en opleveren"
           ": u controleert alles voordat het live gaat, en u betaalt na oplevering."
 
-    -- Consultancy
-    H.section ! A.class_ "results" ! A.id "consulting" $ do
-      H.h2 "Deskundig advies"
-      H.p $ H.preEscapedToHtml ("We nemen ook adviesopdrachten aan waar onze expertise het verschil maakt. 10+ jaar bouwen aan productiesystemen: we maken technische keuzes en bouwen ze ook." :: Text)
-      H.div ! A.class_ "testimonials" $ do
-        H.blockquote $
-          H.p $ do
-            "Het kernplatform gebouwd voor een "
-            H.strong "herverzekerings-startup"
-            ", van de eerste architectuur tot live deals in productie. "
-            H.a ! A.href "https://jappie.me/the-peculiar-event-sourced-deadlock.html" $ H.preEscapedToHtml ("Lees over het oplossen van een productieprobleem &rarr;" :: Text)
-        H.blockquote $
-          H.p $ do
-            "Technisch lead voor een "
-            H.strong "bouw-IoT-startup"
-            ". Architectuurkeuzes die meeschaalden van pilot naar productie. 7x snellere apparaten. "
-            H.a ! A.href "https://jappie.me/stacked-against-us.html" $ H.preEscapedToHtml ("Lees het hele verhaal &rarr;" :: Text)
-            H.preEscapedToHtml (" &middot; " :: Text)
-            H.a ! A.href "https://jappie.me/firmware-lemons.html" $ H.preEscapedToHtml ("De 7x verbetering &rarr;" :: Text)
-        H.blockquote $
-          H.p $ do
-            "Geautomatiseerde "
-            H.strong "e-commerce-migratie"
-            " voor een meertalige webshop met 2.400+ producten over drie domeinen en drie talen."
+    -- Geen adviessectie: zie de Decision-notitie op de Engelse pagina.
 
     -- Over
     H.section ! A.class_ "about" $ do
       H.h2 "Over ons"
       H.div ! A.class_ "about-grid" $ do
         H.div $ do
-          H.p "Ik ben Jappie Klooster. Ik bouw websites, webshops en softwareproducten, en help bedrijven die serieuze technische expertise nodig hebben. Ik kies technologie op betrouwbaarheid, en leg in gewone taal uit wat ik doe."
-          H.p "Gevestigd in Nederland. Beschikbaar voor productpartnerschappen, adviesopdrachten en gesprekken over medeoprichterschap."
+          H.p "Ik ben Jappie Klooster. Ik bouw websites en webshops voor ondernemers, voor een vaste prijs en in gewone taal. Achter de schermen zit ruim tien jaar software-ervaring, dus de techniek is gekozen op betrouwbaarheid."
           H.p $ do
-            "Meer schrijfsels en cases vindt u op de "
-            H.a ! A.href "/blog/" $ "blog"
+            "Gevestigd in Nederland. Voor adviesopdrachten en cases: "
+            H.a ! A.href "https://jappie.me/" $ "jappie.me"
             "."
         H.img ! A.class_ "about-portrait"
               ! A.src "/selfie.png"
@@ -459,13 +415,13 @@ penguinIndexPageNl webwinkelUrl = penguinBaseTemplate Nl indexMetaNl $
     H.section ! A.class_ "final-cta" $ do
       H.h2 "Een probleem dat opgelost moet worden?"
       H.p $ do
-        "Of u nu een website, een webshopverhuizing of deskundig advies nodig hebt, "
+        "Of u nu een website of een webshopverhuizing nodig hebt, "
         H.a ! A.href contactMailto $ "neem contact op"
         "."
       H.a ! A.href contactMailto ! A.class_ "cta-button" $ "Neem contact op"
   where
     indexMetaNl :: PageMeta
-    indexMetaNl = (defaultPageMeta "Jappie Software B.V. \8212 Websites, webshopverhuizingen & advies")
+    indexMetaNl = (defaultPageMeta "Jappie Software B.V. \8212 Websites & webshopverhuizingen")
       { pageMetaDescription = "Wij bouwen websites voor ondernemers en verhuizen webshops naar een beter platform. Vaste prijs, gewone taal, en u betaalt na oplevering."
       , pageMetaLang        = "nl"
       , pageMetaCanonical   = Just "https://jappiesoftware.com/nl/"

--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -33,6 +33,7 @@ import PageChrome
   , ogLocale
   , resolveOgImage
   , companyEmail
+  , meetLink
   , whatsappFloatingButton
   , organizationJsonLd
   , serviceJsonLd
@@ -62,13 +63,6 @@ offerteMailto = toValue ("mailto:" <> companyEmail <> "?subject=Migratie%20offer
 -- existing-client work rather than new leads.
 uitbreidingMailto :: H.AttributeValue
 uitbreidingMailto = toValue ("mailto:" <> companyEmail <> "?subject=Uitbreiding%20webshop")
-
--- | Branded scheduling link used by every "plan een gesprek" button. It is a
--- 302 redirect on our own infrastructure (megavid blog/vhost.nix) to the
--- current Google Calendar booking page, so the underlying calendar can change
--- without touching built pages or already-sent outreach mails.
-meetLink :: H.AttributeValue
-meetLink = "https://meet.jappiesoftware.com"
 
 -- =============================================================================
 -- Base template

--- a/shake/test/Test.hs
+++ b/shake/test/Test.hs
@@ -75,6 +75,8 @@ meetLinkPages =
   , ("lightspeedMigrationPage", lightspeedMigrationPage)
   , ("mijnwebwinkelWaaromPage", mijnwebwinkelWaaromPage)
   , ("lightspeedWaaromPage", lightspeedWaaromPage)
+  , ("penguinWordpressPage", penguinWordpressPage (WebwinkelverhuisUrl testOrigin))
+  , ("penguinWordpressPageNl", penguinWordpressPageNl (WebwinkelverhuisUrl testOrigin))
   ]
 
 -- | Scheduling buttons must use the branded meet.jappiesoftware.com redirect,


### PR DESCRIPTION
## Summary

Two commits sharpening jappiesoftware.com into a purely transactional site:

**Refocus (commit 1)**
- Expert Consulting section dropped from both landing pages; consulting leads never came through this site. Consulting and case studies point to jappie.me from the About section (and the footer link that was already there).
- Consulting *and* Blog removed from the top menu. The blog stays reachable (footer link, all URLs live) but is unmaintained and no longer promoted; the About paragraphs pointing at it are gone too.
- Meta titles now "Websites & Webshop Migrations" / "Websites & webshopverhuizingen".

**WordPress page pass (commit 2)**
- Six pictograms on the "Wat u kunt verwachten" cards, hand-drawn in the penguin palette to match the webwinkel icon style.
- Closing CTA is now "Plan een gratis kennismaking" via meet.jappiesoftware.com (email stays as the text link; hero keeps its mailto button). Direct booking is the lowest-friction step for this audience.
- `meetLink` moved to PageChrome so both themes share the one scheduling constant.

## Test plan

- [x] `nix-build shake` passes; suite grown to 12 cases (wordpress pages must link meet.jappiesoftware.com, never a raw calendar URL)
- [x] `nix-build nix/ci.nix` passes
- [x] Playwright full-page screenshots of /nl/ and /nl/wordpress-websites.html: menu is Diensten + contact only, consulting section gone, icons and booking CTA render as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)