### PR TITLE
Show delivered Voedzame Kost build in Recent work on wordpress pages

### DIFF
--- a/shake/PenguinTemplates.hs
+++ b/shake/PenguinTemplates.hs
@@ -58,6 +58,12 @@ penguinOgImage = "https://jappiesoftware.com/og-default.png"
 contactMailto :: H.AttributeValue
 contactMailto = toValue ("mailto:" <> companyEmail)
 
+-- | Laura's LinkedIn post announcing the voedzamekost.nl launch, linked as
+-- social proof next to the site itself. Tracking parameters (utm_*, rcm)
+-- are stripped: rcm identifies the account the share link was copied from.
+voedzameKostAnnouncementUrl :: H.AttributeValue
+voedzameKostAnnouncementUrl = "https://www.linkedin.com/posts/laura-koster-852458a4_voeding-diaebtist-gedragsverandering-share-7483083081000681473-yX2e/"
+
 -- | Origin (no trailing slash) of the webwinkelverhuis.nl site as linked from
 -- jappiesoftware.com pages. Production passes the real domain; the local
 -- serve mode passes http://localhost:8002 so both locally served sites
@@ -438,8 +444,9 @@ penguinIndexPageNl webwinkelUrl = penguinBaseTemplate Nl indexMetaNl $
 -- | The "WordPress Websites" service landing page. We build fixed-price
 -- WordPress sites for small businesses (warm-intro leads so far), and this page
 -- gives that work a home and frames it as the natural first step before a
--- webshop, linking onward to the migration service on webwinkelverhuis.nl. The
--- two recent builds (Voedzame Kost, Het Waardegebaar) are the proof of work.
+-- webshop, linking onward to the migration service on webwinkelverhuis.nl.
+-- The delivered build (Voedzame Kost, live since July 2026) is the proof of
+-- work; Het Waardegebaar joins the list once it is delivered.
 penguinWordpressPage :: WebwinkelverhuisUrl -> Html
 penguinWordpressPage (WebwinkelverhuisUrl webwinkelUrl) = penguinBaseTemplate En wordpressMeta $
   H.main $ do
@@ -490,16 +497,20 @@ penguinWordpressPage (WebwinkelverhuisUrl webwinkelUrl) = penguinBaseTemplate En
           H.h3 "Update it yourself, no need to call us"
           H.p "A personal video walkthrough plus a short written manual: edit text, replace a photo, update a page. After that you can do it yourself, and we stay available for bigger jobs."
 
-    -- Recent work: hidden until these projects are actually delivered and live.
-    {-
+    -- Recent work: Voedzame Kost was delivered (live 2026-07) and shows here;
+    -- Het Waardegebaar stays hidden below until it is delivered and live.
     H.section ! A.class_ "results" $ do
       H.h2 "Recent work"
-      H.div ! A.class_ "testimonials" $ do
+      H.div ! A.class_ "testimonials" $
         H.blockquote $
           H.p $ do
             H.strong "Voedzame Kost"
             H.preEscapedToHtml (": a warm, calm site for a dietitian and ACT coach. A two-colour system separates private clients from organisations, with a workshop showcase and WhatsApp contact. " :: Text)
             H.a ! A.href "https://voedzamekost.nl/" $ H.preEscapedToHtml ("voedzamekost.nl &rarr;" :: Text)
+            " ("
+            H.a ! A.href voedzameKostAnnouncementUrl $ "announcement"
+            ")"
+    {-
         H.blockquote $
           H.p $ do
             H.strong "Het Waardegebaar"
@@ -606,16 +617,20 @@ penguinWordpressPageNl (WebwinkelverhuisUrl webwinkelUrl) = penguinBaseTemplate 
           H.h3 "Zelf aanpassen zonder ons te bellen"
           H.p "Een persoonlijke videorondleiding plus een korte handleiding: tekst aanpassen, een foto vervangen, een pagina bijwerken. U kunt het daarna zelf, en voor grotere klussen blijven we bereikbaar."
 
-    -- Recent werk: verborgen tot deze projecten daadwerkelijk opgeleverd en live zijn.
-    {-
+    -- Recent werk: Voedzame Kost is opgeleverd (live juli 2026) en staat hier;
+    -- Het Waardegebaar blijft hieronder verborgen tot het opgeleverd en live is.
     H.section ! A.class_ "results" $ do
       H.h2 "Recent werk"
-      H.div ! A.class_ "testimonials" $ do
+      H.div ! A.class_ "testimonials" $
         H.blockquote $
           H.p $ do
             H.strong "Voedzame Kost"
             H.preEscapedToHtml (": een warme, rustige site voor een di\235tist en ACT-coach. Een twee-kleurensysteem scheidt particulieren van organisaties, met een workshop-showcase en WhatsApp-contact. " :: Text)
             H.a ! A.href "https://voedzamekost.nl/" $ H.preEscapedToHtml ("voedzamekost.nl &rarr;" :: Text)
+            " ("
+            H.a ! A.href voedzameKostAnnouncementUrl $ "aankondiging"
+            ")"
+    {-
         H.blockquote $
           H.p $ do
             H.strong "Het Waardegebaar"

--- a/shake/test/Test.hs
+++ b/shake/test/Test.hs
@@ -90,6 +90,26 @@ usesMeetLinkCase (pageName, page) = testCase pageName $ do
   assertBool "links a raw calendar.app.google URL instead of the meet redirect"
     (not ("calendar.app.google" `T.isInfixOf` rendered))
 
+-- | Every statically renderable page of both brand sites: the index pages
+-- plus everything already in 'meetLinkPages' (which contains the wordpress
+-- and webwinkel service pages).
+allStaticPages :: [(String, Html)]
+allStaticPages =
+  [ ("penguinIndexPage", penguinIndexPage (WebwinkelverhuisUrl testOrigin))
+  , ("penguinIndexPageNl", penguinIndexPageNl (WebwinkelverhuisUrl testOrigin))
+  ] <> meetLinkPages
+
+-- | No page may publish share-URL tracking parameters. URLs copied from a
+-- platform's share button (LinkedIn in particular) embed utm_* junk and an
+-- rcm token that identifies the account the link was copied from; pasting
+-- one verbatim into a template leaks that token to every visitor. Links
+-- must be cleaned before they go in (see voedzameKostAnnouncementUrl).
+noTrackingParamsCase :: (String, Html) -> TestTree
+noTrackingParamsCase (pageName, page) = testCase pageName $ do
+  let rendered = TL.toStrict (renderHtml page)
+  assertBool "a link carries share-URL tracking parameters (utm_* or rcm=)"
+    (not ("utm_" `T.isInfixOf` rendered) && not ("rcm=" `T.isInfixOf` rendered))
+
 main :: IO ()
 main = defaultMain $
   testGroup "shake-blog templates"
@@ -97,4 +117,6 @@ main = defaultMain $
         (map linksFollowOriginCase pagesUnderTest)
     , testGroup "scheduling buttons use meet.jappiesoftware.com"
         (map usesMeetLinkCase meetLinkPages)
+    , testGroup "no page publishes share-URL tracking parameters"
+        (map noTrackingParamsCase allStaticPages)
     ]


### PR DESCRIPTION
Voedzame Kost is delivered and live on https://voedzamekost.nl/ (checked: HTTP 200), so this un-hides the "Recent work" section on the English and Dutch wordpress service pages. It shows the Voedzame Kost blockquote with a link to the live site and to [Laura's LinkedIn announcement](https://www.linkedin.com/posts/laura-koster-852458a4_voeding-diaebtist-gedragsverandering-share-7483083081000681473-yX2e/). Het Waardegebaar stays commented out until it is delivered and live.

Details:
- The announcement URL is a top-level constant with the share-URL tracking parameters stripped. The `rcm` token in a copied share link identifies the account it was copied from and should not be published.
- New test group: no statically renderable page of either brand site may publish `utm_*` or `rcm=` tracking parameters. Same shape as the existing meet-link policy test.
- `nix-build nix/ci.nix` passes locally (site builds, test suite green, SEO analysis clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)