### PR TITLE
Restore the tails lines and fix rendering slips

### DIFF
--- a/content/sizing.md
+++ b/content/sizing.md
@@ -262,6 +262,8 @@ If you went bust, this is the most valuable investment lesson you'll learn at a 
 This [experiment](https://elmwealth.com/lessons-from-betting-on-a-biased-coin-cool-heads-and-cautionary-tales/)
 was run with finance students and young professionals, and apparently 28% of them managed
 to go bust as well, so don't feel bad.
+Two thirds of the players even bet on tails at some point.
+Everyone knew heads was the better bet, and they fucked it up anyway.
 
 The trick is bet sizing. 
 I mean the entire game is bet sizing so it may seem a bit silly as an observation. 


### PR DESCRIPTION
## Summary
- Re-adds the pruned lines: "Two thirds of the players even bet on tails at some point. Everyone knew heads was the better bet, and they fucked it up anyway." (Supported by the linked Elm Wealth source: 41 of 61 subjects, 67%.)
- Rebased on latest master; the rendering fixes this PR originally carried (dangling `[^trading]`, `/big/`, "scheme's") landed on master independently in "bleep bloop", so the diff is now just the two lines.

## Test plan
- [x] Site rebuilt; tails lines present in the generated page
- [x] nix-build nix/ci.nix passes locally after the rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)