### PR TITLE
Call out the reader's tails bets on the game-over screen

### DIFF
--- a/content/sizing.md
+++ b/content/sizing.md
@@ -129,6 +129,7 @@ Try it out:
   let gameActive = true;
   let timerInterval = null;
   let flipCount = 0;
+  let tailsBetCount = 0;
 
   const balanceDisplay = root.querySelector('.balance');
   const timerDisplay = root.querySelector('.timer');
@@ -179,6 +180,9 @@ Try it out:
     }
 
     flipCount++;
+    if (playerChoice === 'tails') {
+      tailsBetCount++;
+    }
 
     const landedHeads = Math.random() < headsProbability;
     const landedSide = landedHeads ? 'Heads' : 'Tails';
@@ -232,9 +236,15 @@ Try it out:
     clearInterval(timerInterval);
     controls.style.display = 'none';
     gameOverScreen.style.display = 'block';
+    // Only revealed at the end, so the reader can incriminate themselves first.
+    const tailsCallout = tailsBetCount === 0 ? '' : `
+      <div>You bet on tails <strong>${tailsBetCount}</strong> ${tailsBetCount === 1 ? 'time' : 'times'}.
+      The coin was rigged for heads, dear reader.</div>
+    `;
     gameOverScreen.innerHTML = `
       ${message}
       <div>It took you exactly <strong>${flipCount}</strong> presses to get here.</div>
+      ${tailsCallout}
     `;
     gameOverScreen.className = `game-over ${isWin ? 'win-text' : 'lose-text'}`;
     updateUI();


### PR DESCRIPTION
## Summary
- The game now counts tails bets and, only at game over, adds: "You bet on tails N times. The coin was rigged for heads, dear reader."
- Nothing is shown mid-game, so readers incriminate themselves naturally before the article reveals the two-thirds stat right below.
- Players who never bet tails see no extra line.

## Test plan
- [x] Browser-tested all three paths: no callout on a heads-only game, "1 time" singular, "2 times" plural
- [x] nix-build nix/ci.nix passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)