### PR TITLE
Webwinkelverhuis: linkbehoud beloven, geen Google-posities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,11 @@ __pycache__
 *.pyc
 redditconf.py
 result
+
+# build output and tool scratch
+_build/
+_site/
+_penguin-site/
+_webwinkelverhuis-site/
+.playwright-mcp/
+result-shake

--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -185,7 +185,7 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
         H.blockquote $
           H.p $ do
             H.strong "Panzer-ShopNL"
-            H.preEscapedToHtml (": een modeltreinwinkel met 2.400+ producten over drie domeinen en drie talen, verhuisd van MijnWebwinkel naar Shopify. Inclusief vertalingen, de volledige categorieboom en automatisch gegenereerde 301-redirects, zodat de Google-posities behouden bleven. " :: Text)
+            H.preEscapedToHtml (": een modeltreinwinkel met 2.400+ producten over drie domeinen en drie talen, verhuisd van MijnWebwinkel naar Shopify. Inclusief vertalingen, de volledige categorieboom en automatisch gegenereerde 301-redirects, zodat elke oude link bleef werken en de opgebouwde SEO meeverhuisde. " :: Text)
             H.a ! A.href "https://panzer-shop.nl/" $ H.preEscapedToHtml ("panzer-shop.nl &rarr;" :: Text)
 
     -- Why us
@@ -196,7 +196,7 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
         H.li $ H.strong "Geen risico" >> H.preEscapedToHtml (" &mdash; u betaalt pas na een succesvolle migratie" :: Text)
         H.li $ H.strong "Geautomatiseerd" >> H.preEscapedToHtml (" &mdash; geen handmatig overtypen, geen kopieerfouten" :: Text)
         H.li $ H.strong "Zelfvaliderend" >> H.preEscapedToHtml (" &mdash; het programma valideert zijn eigen werk met een uitgebreide testbatterij" :: Text)
-        H.li $ H.strong "SEO-behoud" >> H.preEscapedToHtml (" &mdash; 301-redirects zodat uw Google-posities niet verloren gaan" :: Text)
+        H.li $ H.strong "SEO-behoud" >> H.preEscapedToHtml (" &mdash; 301-redirects: elke oude link blijft werken, uw opgebouwde SEO verhuist mee" :: Text)
         H.li $ H.strong "Vaste prijs" >> H.preEscapedToHtml (" &mdash; geen uurtarief, u weet vooraf wat het kost" :: Text)
       H.p $ do
         "Meer weten over waarom shops vertrekken? Lees onze "
@@ -222,7 +222,7 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
                 ! A.alt "Grafiek met stijgende prijzen"
                 ! A.width "56" ! A.height "56"
           H.h3 "Lightspeed"
-          H.p $ H.preEscapedToHtml ("Beursgenoteerd en steeds duurder voor kleine shops. Wij verhuizen u veilig, met behoud van uw Google-posities &mdash; geen 70% verkeersverlies." :: Text)
+          H.p $ H.preEscapedToHtml ("Beursgenoteerd en steeds duurder voor kleine shops. Wij verhuizen u veilig, met een 301-redirect voor elke oude URL; bij onbegeleide migraties zagen we verhalen van 70% verkeersverlies." :: Text)
           H.a ! A.href "/migrate-lightspeed.html" ! A.class_ "cta-button-secondary" $ H.preEscapedToHtml ("Bekijk migratie &rarr;" :: Text)
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-beperkt.svg"
@@ -290,7 +290,7 @@ appPage = webwinkelBaseTemplate appMeta $ do
           H.p $ H.preEscapedToHtml ("Uw categorie&euml;n worden Shopify-collections en uw informatiepagina&rsquo;s worden meegenomen, inclusief het navigatiemenu." :: Text)
         H.li ! A.class_ "card" $ do
           H.h3 "SEO-redirects"
-          H.p "De app legt 301-redirects aan van elke oude URL naar de juiste nieuwe pagina, zodat uw Google-posities behouden blijven."
+          H.p "De app legt 301-redirects aan van elke oude URL naar de juiste nieuwe pagina, zodat elke bestaande link blijft werken en uw opgebouwde SEO meeverhuist."
         H.li ! A.class_ "card" $ do
           H.h3 "Thema"
           H.p "De app bouwt en plaatst een Shopify-thema dat de uitstraling van uw huidige winkel volgt."
@@ -375,7 +375,7 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-redirects.svg"
                 ! A.alt "Pijl die een nieuwe route neemt" ! A.width "56" ! A.height "56"
           H.h3 "SEO-redirects"
-          H.p "301-redirects van elke oude URL naar de nieuwe, volledig automatisch gegenereerd. Uw Google-posities en backlinks blijven behouden."
+          H.p "301-redirects van elke oude URL naar de nieuwe, volledig automatisch gegenereerd. Uw backlinks blijven werken en uw opgebouwde SEO verhuist mee."
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-producten.svg"
                 ! A.alt "Doos met producten" ! A.width "56" ! A.height "56"
@@ -424,7 +424,7 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $ do
         H.blockquote $
           H.p $ do
             H.strong "Panzer-ShopNL"
-            H.preEscapedToHtml (": een modeltreinwinkel met 2.400+ producten over drie domeinen en drie talen, verhuisd van MijnWebwinkel naar Shopify. Inclusief vertalingen, de volledige categorieboom en automatisch gegenereerde 301-redirects, zodat de Google-posities behouden bleven. " :: Text)
+            H.preEscapedToHtml (": een modeltreinwinkel met 2.400+ producten over drie domeinen en drie talen, verhuisd van MijnWebwinkel naar Shopify. Inclusief vertalingen, de volledige categorieboom en automatisch gegenereerde 301-redirects, zodat elke oude link bleef werken en de opgebouwde SEO meeverhuisde. " :: Text)
             H.a ! A.href "https://panzer-shop.nl/" $ H.preEscapedToHtml ("panzer-shop.nl &rarr;" :: Text)
 
     -- Pricing
@@ -452,7 +452,7 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $ do
         H.li $ H.strong "Geen risico" >> H.preEscapedToHtml (" &mdash; u betaalt pas na succesvolle migratie" :: Text)
         H.li $ H.strong "Geautomatiseerd" >> H.preEscapedToHtml (" &mdash; geen handmatig overtypen, geen kopieerfouten" :: Text)
         H.li $ H.strong "Zelfvaliderend" >> H.preEscapedToHtml (" &mdash; het programma valideert zijn eigen werk met een uitgebreide testbatterij" :: Text)
-        H.li $ H.strong "SEO-behoud" >> H.preEscapedToHtml (" &mdash; 301-redirects zodat uw Google-posities niet verloren gaan" :: Text)
+        H.li $ H.strong "SEO-behoud" >> H.preEscapedToHtml (" &mdash; 301-redirects: elke oude link blijft werken, uw opgebouwde SEO verhuist mee" :: Text)
         H.li $ H.strong "Meertalig" >> H.preEscapedToHtml (" &mdash; vertalingen correct gekoppeld via offici&euml;le APIs" :: Text)
         H.li $ H.strong "Vaste prijs" >> H.preEscapedToHtml (" &mdash; geen uurtarief, u weet vooraf wat het kost" :: Text)
 
@@ -529,7 +529,7 @@ ccvshopMigrationPage = webwinkelBaseTemplate ccvMeta $
           H.p "Klantgegevens en bestelgeschiedenis worden overgezet zodat uw klanten direct kunnen inloggen op de nieuwe shop."
         H.li ! A.class_ "card" $ do
           H.h3 "SEO-redirects"
-          H.p "301-redirects van elke oude URL naar de nieuwe URL. Uw Google-posities en backlinks blijven behouden."
+          H.p "301-redirects van elke oude URL naar de nieuwe URL. Uw backlinks blijven werken en uw opgebouwde SEO verhuist mee."
         H.li ! A.class_ "card" $ do
           H.h3 $ H.preEscapedToHtml ("Categorie&euml;n" :: Text)
           H.p $ H.preEscapedToHtml ("De volledige categorieboom wordt overgezet naar Shopify Collections met vertaalde titels en het navigatiemenu." :: Text)
@@ -573,7 +573,7 @@ ccvshopMigrationPage = webwinkelBaseTemplate ccvMeta $
         H.li $ H.strong "Geen risico" >> H.preEscapedToHtml (" &mdash; u betaalt pas na succesvolle migratie" :: Text)
         H.li $ H.strong "Platformonafhankelijk" >> H.preEscapedToHtml (" &mdash; u kiest de bestemming, wij migreren naar elk platform" :: Text)
         H.li $ H.strong "Geautomatiseerd" >> H.preEscapedToHtml (" &mdash; geen handmatig overtypen, geen kopieerfouten" :: Text)
-        H.li $ H.strong "SEO-behoud" >> H.preEscapedToHtml (" &mdash; 301-redirects zodat uw Google-posities niet verloren gaan" :: Text)
+        H.li $ H.strong "SEO-behoud" >> H.preEscapedToHtml (" &mdash; 301-redirects: elke oude link blijft werken, uw opgebouwde SEO verhuist mee" :: Text)
         H.li $ H.strong "Meertalig" >> H.preEscapedToHtml (" &mdash; vertalingen correct gekoppeld via offici&euml;le Shopify APIs" :: Text)
         H.li $ H.strong "Zelfvaliderend" >> H.preEscapedToHtml (" &mdash; het programma valideert zijn eigen werk met een uitgebreide testbatterij" :: Text)
         H.li $ H.strong "Vaste prijs" >> H.preEscapedToHtml (" &mdash; geen uurtarief, u weet vooraf wat het kost" :: Text)
@@ -671,7 +671,7 @@ lightspeedMigrationPage = webwinkelBaseTemplate lightspeedMeta $
           H.p "Klantgegevens, bestelgeschiedenis en accountdata worden overgezet zodat uw klanten direct kunnen inloggen op de nieuwe shop."
         H.li ! A.class_ "card" $ do
           H.h3 "SEO-redirects"
-          H.p "301-redirects van elke oude URL naar de nieuwe URL. Uw Google-posities en backlinks blijven behouden. Geen 70% verkeersverlies zoals bij een onbegeleide migratie."
+          H.p "301-redirects van elke oude URL naar de nieuwe URL. Uw backlinks blijven werken en uw opgebouwde SEO verhuist mee; bij onbegeleide migraties zagen we verhalen van 70% verkeersverlies."
         H.li ! A.class_ "card" $ do
           H.h3 $ H.preEscapedToHtml ("Categorie&euml;n & navigatie" :: Text)
           H.p $ H.preEscapedToHtml ("De volledige categorieboom wordt overgezet naar Shopify Collections met vertaalde titels en het navigatiemenu." :: Text)
@@ -709,7 +709,7 @@ lightspeedMigrationPage = webwinkelBaseTemplate lightspeedMeta $
       H.h2 "Waarom via ons?"
       H.div ! A.class_ "testimonials" $ do
         H.blockquote $ do
-          H.p $ H.preEscapedToHtml ("U bent niet de enige: 59% van alle Lightspeed-vertrekkers kiest Shopify. Maar zonder begeleiding raakt u uw Google-posities kwijt &mdash; wij hebben verhalen gezien van 70% verkeersverlies bij een onbegeleide migratie. Wij zorgen dat uw SEO intact blijft." :: Text)
+          H.p $ H.preEscapedToHtml ("U bent niet de enige: 59% van alle Lightspeed-vertrekkers kiest Shopify. Maar zonder begeleiding gaan bij de overstap vaak oude URLs kapot; wij hebben verhalen gezien van 70% verkeersverlies bij een onbegeleide migratie. Wij zorgen dat elke oude URL blijft doorverwijzen en uw opgebouwde SEO meeverhuist." :: Text)
           H.p $ do
             H.a ! A.href "/waarom-lightspeed.html" $ "Waarom verlaten steeds meer webshops Lightspeed?"
             H.preEscapedToHtml (" &rarr;" :: Text)
@@ -717,7 +717,7 @@ lightspeedMigrationPage = webwinkelBaseTemplate lightspeedMeta $
       H.ul $ do
         H.li $ H.strong "Geen risico" >> H.preEscapedToHtml (" &mdash; u betaalt pas na succesvolle migratie" :: Text)
         H.li $ H.strong "Platformonafhankelijk" >> H.preEscapedToHtml (" &mdash; u kiest de bestemming, wij migreren naar elk platform" :: Text)
-        H.li $ H.strong "SEO-behoud" >> H.preEscapedToHtml (" &mdash; 301-redirects zodat uw Google-posities niet verloren gaan" :: Text)
+        H.li $ H.strong "SEO-behoud" >> H.preEscapedToHtml (" &mdash; 301-redirects: elke oude link blijft werken, uw opgebouwde SEO verhuist mee" :: Text)
         H.li $ H.strong "Geautomatiseerd" >> H.preEscapedToHtml (" &mdash; geen handmatig overtypen, geen kopieerfouten" :: Text)
         H.li $ H.strong "Meertalig" >> H.preEscapedToHtml (" &mdash; vertalingen correct gekoppeld via offici&euml;le Shopify APIs" :: Text)
         H.li $ H.strong "Zelfvaliderend" >> H.preEscapedToHtml (" &mdash; het programma valideert zijn eigen werk met een uitgebreide testbatterij" :: Text)
@@ -761,14 +761,14 @@ lightspeedMigrationPage = webwinkelBaseTemplate lightspeedMeta $
     lightspeedMeta :: PageMeta
     lightspeedMeta = PageMeta
       { pageMetaTitle       = "Ontsnap Lightspeed \8212 Migratie naar Shopify \8212 Webwinkelverhuis"
-      , pageMetaDescription = "Geautomatiseerde migratie van Lightspeed naar Shopify. Producten, vertalingen, afbeeldingen, voorraad en SEO-redirects. Geen verkeersverlies. Vanaf \8364" <> migratieBasisprijsEuro <> "."
+      , pageMetaDescription = "Geautomatiseerde migratie van Lightspeed naar Shopify. Producten, vertalingen, afbeeldingen, voorraad en SEO-redirects. Vanaf \8364" <> migratieBasisprijsEuro <> "."
       , pageMetaLang        = "nl"
       , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/migrate-lightspeed.html"
       , pageMetaOgImage     = Nothing
       , pageMetaSwitchUrl   = Nothing
       , pageMetaExtraHead   = faqPageJsonLd lightspeedFaq <> serviceJsonLd
           "Lightspeed naar Shopify migratie"
-          "Geautomatiseerde migratie van Lightspeed naar Shopify: producten, vertalingen, afbeeldingen, voorraad en SEO-redirects, zonder verkeersverlies."
+          "Geautomatiseerde migratie van Lightspeed naar Shopify: producten, vertalingen, afbeeldingen, voorraad en SEO-redirects."
           "https://webwinkelverhuis.nl/migrate-lightspeed.html"
       }
 
@@ -781,7 +781,7 @@ lightspeedFaq =
   , ( "Wat als er iets niet klopt na de migratie?"
     , "Die kans is klein: de migratie is volledig geautomatiseerd en het programma valideert zijn eigen werk met een uitgebreide testbatterij. Inmiddels hebben we dit ook meermaals gedaan. Maar fouten kunnen gebeuren, en als er toch iets niet klopt, lossen we het gratis op." )
   , ( "Verlies ik mijn Google-posities?"
-    , "Nee. Wij genereren automatisch 301-redirects voor elke URL. Dit is het belangrijkste onderdeel van een veilige migratie en de reden dat u dit niet zelf wilt doen." )
+    , "Elke oude URL krijgt automatisch een 301-redirect, zodat al uw links en backlinks blijven werken en de opgebouwde SEO meeverhuist. Google kan na elke grote sitewijziging tijdelijk schommelen; het blijvende verlies uit de horrorverhalen komt door ontbrekende redirects, en dat dekken wij volledig af." )
   , ( "Werkt het ook voor meertalige webshops?"
     , "Ja. Nederlands, Duits, Engels, Frans of een andere taal: het programma ondersteunt elke taalcombinatie die Lightspeed en Shopify beide ondersteunen." )
   , ( "Worden mijn klantaccounts overgezet?"

--- a/webwinkel/content/mijnwebwinkel-google-posities-behouden.org
+++ b/webwinkel/content/mijnwebwinkel-google-posities-behouden.org
@@ -58,8 +58,8 @@ nieuwe pagina, zonder kopieerfouten.
 Voordat er ook maar iets live gaat krijgt u een testshop en een
 verificatieoverzicht, zodat u zelf kunt controleren dat de adressen kloppen.
 Pas als dat goed staat schakelen we over. Vanaf dag één zijn alle redirects
-actief, dus ook in de weken waarin Google de nieuwe URLs oppikt verliest u
-geen verkeer.
+actief, dus ook in de weken waarin Google de nieuwe URLs oppikt komt elke
+bezoeker en elke oude link gewoon op de juiste pagina uit.
 
 #+BEGIN_EXPORT html
 <details><summary>Voor de techneuten: maar die artikelcodes veranderen toch?</summary><p>Klopt, de a-codes in MijnWebwinkel-URLs lijken te veranderen, wat het idee geeft dat een redirectkaart binnen no-time verouderd is. Wij hebben die codes over meerdere weken systematisch geobserveerd en vastgesteld dat ze een vast, eenduidig patroon volgen. Daardoor kunnen we de oude URLs betrouwbaar koppelen aan de nieuwe pagina's, ook de adressen met numerieke product-ID's. De volledige redirectkaart genereren we automatisch, niet met de hand.</p></details>
@@ -67,10 +67,10 @@ geen verkeer.
 
 * Wat dat voor u betekent
 
-Geen onverwachte omzetdip na de overstap. Geen weken werk om met de hand
-redirects in te kloppen. En geen organisch verkeer dat u kwijtraakt aan een
-foutpagina. Uw bezoekers en uw Google-posities komen gewoon op de nieuwe
-shop terecht.
+Geen weken werk om met de hand redirects in te kloppen, en geen organisch
+verkeer dat u kwijtraakt aan een foutpagina: uw bezoekers en uw backlinks
+komen gewoon op de nieuwe shop terecht. Google kan na een grote wijziging
+altijd tijdelijk schommelen; wat wij afdekken is dat er niets kapotgaat.
 
 Wilt u eerst lezen [[https://webwinkelverhuis.nl/waarom-mijnwebwinkel.html][waarom
 MijnWebwinkel niet meer wordt doorontwikkeld]], of meteen weten hoe
@@ -84,9 +84,11 @@ migratie en de redirects.
 
 *Verlies ik mijn Google-posities als ik van MijnWebwinkel migreer?*
 
-Niet als het goed gebeurt. Het verlies ontstaat doordat oude URLs na de
-overstap niet meer bestaan en geen 301-redirect hebben. Met een redirect voor
-elke oude URL blijven uw posities en backlinks behouden.
+Blijvend verlies ontstaat doordat oude URLs na de overstap niet meer
+bestaan en geen 301-redirect hebben; dat dekken wij volledig af, met een
+redirect voor elke oude URL, zodat al uw links en backlinks blijven werken
+en de opgebouwde SEO meeverhuist. Tijdelijke schommelingen na een grote
+wijziging kunnen altijd bij Google.
 
 *Hoe weet u zeker dat alle URLs worden afgevangen?*
 
@@ -103,10 +105,10 @@ betrouwbaar naar de juiste nieuwe URL doorsturen.
 *Hoe lang duurt het voordat Google de nieuwe URLs oppikt?*
 
 Doorgaans enkele weken. Doordat de redirects vanaf dag één actief zijn,
-verliest u in de tussentijd geen verkeer.
+komt elke bezoeker in de tussentijd gewoon op de juiste pagina uit.
 
 #+BEGIN_EXPORT html
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Verlies ik mijn Google-posities als ik van MijnWebwinkel migreer?","acceptedAnswer":{"@type":"Answer","text":"Niet als het goed gebeurt. Het verlies ontstaat doordat oude URLs na de overstap niet meer bestaan en geen 301-redirect hebben. Met een redirect voor elke oude URL blijven uw posities en backlinks behouden."}},{"@type":"Question","name":"Hoe weet u zeker dat alle URLs worden afgevangen?","acceptedAnswer":{"@type":"Answer","text":"Ons programma crawlt uw volledige webshop en legt elke URL vast, niet een steekproef. Elke vastgelegde URL krijgt een redirect, die we voor de overstap samen met u verifiëren."}},{"@type":"Question","name":"De artikelcodes lijken te veranderen. Werkt het dan wel?","acceptedAnswer":{"@type":"Answer","text":"Ja. We hebben die codes over meerdere weken geobserveerd en vastgesteld dat ze een vast, eenduidig patroon volgen. Daardoor kunnen we elke oude URL betrouwbaar naar de juiste nieuwe URL doorsturen."}},{"@type":"Question","name":"Hoe lang duurt het voordat Google de nieuwe URLs oppikt?","acceptedAnswer":{"@type":"Answer","text":"Doorgaans enkele weken. Doordat de redirects vanaf dag een actief zijn, verliest u in de tussentijd geen verkeer."}}]}
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Verlies ik mijn Google-posities als ik van MijnWebwinkel migreer?","acceptedAnswer":{"@type":"Answer","text":"Blijvend verlies ontstaat door oude URLs zonder 301-redirect; dat dekken wij volledig af met een redirect voor elke oude URL, zodat alle links en backlinks blijven werken en de opgebouwde SEO meeverhuist. Tijdelijke schommelingen na een grote wijziging kunnen altijd bij Google."}},{"@type":"Question","name":"Hoe weet u zeker dat alle URLs worden afgevangen?","acceptedAnswer":{"@type":"Answer","text":"Ons programma crawlt uw volledige webshop en legt elke URL vast, niet een steekproef. Elke vastgelegde URL krijgt een redirect, die we voor de overstap samen met u verifiëren."}},{"@type":"Question","name":"De artikelcodes lijken te veranderen. Werkt het dan wel?","acceptedAnswer":{"@type":"Answer","text":"Ja. We hebben die codes over meerdere weken geobserveerd en vastgesteld dat ze een vast, eenduidig patroon volgen. Daardoor kunnen we elke oude URL betrouwbaar naar de juiste nieuwe URL doorsturen."}},{"@type":"Question","name":"Hoe lang duurt het voordat Google de nieuwe URLs oppikt?","acceptedAnswer":{"@type":"Answer","text":"Doorgaans enkele weken. Doordat de redirects vanaf dag een actief zijn, komt elke bezoeker in de tussentijd gewoon op de juiste pagina uit."}}]}
 </script>
 #+END_EXPORT


### PR DESCRIPTION
## Summary
- Alle "Google-posities blijven behouden"/"geen verkeersverlies"-beloften versmald naar het echte leverbaar: 301-redirect per oude URL, links en backlinks blijven werken, opgebouwde SEO verhuist mee.
- FAQ's (incl. JSON-LD) benoemen eerlijk dat Google na een grote wijziging tijdelijk kan schommelen; de 70%-verhalen blijven als observatie over onbegeleide migraties.
- Raakt de drie platformpagina's, de homepage-testimonial, meta-descriptions en de posities-blogpost.

## Test plan
- [x] `nix-build nix/ci.nix` groen; gerenderde output bevat geen posities-/verkeersverlies-beloften meer (grep over alle pagina's en blog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)