### PR TITLE
Webwinkel-hero: prijs vooraan (Vanaf €1999 + Bereken uw prijs)

### DIFF
--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -217,8 +217,13 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
       H.div ! A.class_ "hero-grid" $ do
         H.div $ do
           H.h1 "Verhuis uw webshop. Zonder dataverlies, zonder SEO-verlies."
-          H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Vastgelopen op MijnWebwinkel, CCV Shop of Lightspeed? Wij verhuizen uw complete webshop geautomatiseerd naar Shopify of een ander platform &mdash; producten, vertalingen, afbeeldingen, klantdata en SEO-redirects. U betaalt pas na een succesvolle migratie." :: Text)
-          H.a ! A.href offerteMailto ! A.class_ "cta-button" $ "Vraag een offerte aan"
+          H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Vastgelopen op MijnWebwinkel, CCV Shop of Lightspeed? Wij verhuizen uw complete webshop geautomatiseerd naar Shopify of een ander platform &mdash; producten, vertalingen, afbeeldingen, klantdata en SEO-redirects." :: Text)
+          H.p ! A.class_ "hero-prijs" $ do
+            H.strong $ H.preEscapedToHtml ("Vanaf &euro;" <> migratieBasisprijsEuro)
+            H.preEscapedToHtml (". U betaalt pas na een succesvolle migratie. Bereken in een minuut wat uw eigen migratie kost." :: Text)
+          H.div ! A.class_ "hero-cta" $ do
+            H.a ! A.href "/prijzen.html" ! A.class_ "cta-button" $ "Bereken uw prijs"
+            H.a ! A.href offerteMailto ! A.class_ "cta-button-secondary" $ "Vraag een offerte aan"
         H.img ! A.class_ "hero-image"
               ! A.src "/illustratie-verhuizen.svg"
               ! A.alt "Illustratie van dozen die van een oude webshop naar een nieuwe verhuizen"

--- a/webwinkel/style.css
+++ b/webwinkel/style.css
@@ -599,3 +599,21 @@ footer small {
 .calc-offerte {
   cursor: pointer;
 }
+
+/* Prijs vooraan in de hero: het eerste dat prospects vragen is "wat kost het". */
+.hero-prijs {
+  margin-bottom: 1.25rem;
+  color: #33414f;
+  font-size: 1.05em;
+}
+.hero-prijs strong {
+  color: #e8590c;
+  font-size: 1.25em;
+}
+/* Twee hero-knoppen naast elkaar, links uitgelijnd (niet gecentreerd). */
+.hero-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}


### PR DESCRIPTION
Inzicht uit gesprekken: het **eerste** wat prospects vragen (CanyonZone, MiniGigant) is "wat kost het?". De prijs stond pas onder de vouw; de hero zei niets over kosten.

Nu antwoordt de hero het meteen:
- Een prominente **"Vanaf €1999. U betaalt pas na een succesvolle migratie. Bereken in een minuut wat uw eigen migratie kost."**-regel (prijs in oranje).
- Primaire knop **"Bereken uw prijs"** → /prijzen (de rekenhulp), met **"Vraag een offerte aan"** ernaast als secundaire actie.

Zo krijgt de bezoeker zijn belangrijkste vraag beantwoord vóór hij hoeft te vragen, en leidt de primaire actie naar de calculator (die zelf eindigt met een offerte-knop). Visueel geverifieerd; `nix-build nix/ci.nix` groen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)