### PR TITLE
Webwinkel: rekenhulp-CTA, homepage-FAQ, 'weet ik nog niet' in rekenhulp

### DIFF
--- a/elm/src/PrijsCalculator.elm
+++ b/elm/src/PrijsCalculator.elm
@@ -1,5 +1,6 @@
 port module PrijsCalculator exposing
     ( BronPlatform(..)
+    , DoelPlatform(..)
     , Model
     , Msg(..)
     , ThemaKeuze(..)
@@ -158,11 +159,14 @@ type BronPlatform
 
 
 {-| Waar migreren we naartoe? Beïnvloedt de prijs niet, maar is nuttig voor de
-offerte. Shopify is onze standaard; WooCommerce doen we ook. -}
+offerte. Shopify is onze standaard; WooCommerce doen we ook. "Weet ik nog niet"
+is een volwaardige keuze: welk platform past hangt af van de situatie van de
+shop, en dat adviseren we in het gratis gesprek. -}
 type DoelPlatform
     = DoelShopify
     | DoelWoocommerce
     | DoelAnders
+    | DoelWeetNiet
 
 
 {-| Hoe moet de nieuwe shop eruitzien? Een net standaard-uiterlijk zit in de
@@ -279,6 +283,9 @@ leesDoel waarde =
     else if waarde == "anders" then
         DoelAnders
 
+    else if waarde == "weetniet" then
+        DoelWeetNiet
+
     else
         DoelShopify
 
@@ -328,6 +335,9 @@ doelNaarWaarde doel =
         DoelAnders ->
             "anders"
 
+        DoelWeetNiet ->
+            "weetniet"
+
 
 doelOmschrijving : DoelPlatform -> String
 doelOmschrijving doel =
@@ -339,7 +349,10 @@ doelOmschrijving doel =
             "WooCommerce"
 
         DoelAnders ->
-            "Een ander platform / weet ik nog niet"
+            "Een ander platform"
+
+        DoelWeetNiet ->
+            "Weet ik nog niet / ik wil advies"
 
 
 {-| Inverse van leesThema: de keuzewaarde die bij een themakeuze hoort. -}
@@ -741,6 +754,7 @@ doelVeld doel =
             [ keuzeOptie (doelNaarWaarde doel) "shopify" (doelOmschrijving DoelShopify)
             , keuzeOptie (doelNaarWaarde doel) "woocommerce" (doelOmschrijving DoelWoocommerce)
             , keuzeOptie (doelNaarWaarde doel) "anders" (doelOmschrijving DoelAnders)
+            , keuzeOptie (doelNaarWaarde doel) "weetniet" (doelOmschrijving DoelWeetNiet)
             ]
         ]
 
@@ -903,11 +917,33 @@ bronNoot bron =
             []
 
 
-{-| Losse waarschuwingen voor keuzes die we niet kant-en-klaar kunnen prijzen:
-een nieuw ontwerp en een onbekend bronplatform gaan altijd op aanvraag. -}
+{-| Geruststelling bij "weet ik nog niet": geen platformkeuze is geen blokkade,
+we adviseren in het gratis gesprek op basis van de situatie van de shop. De
+richtprijs rekent dan met Shopify, onze standaard, als uitgangspunt. -}
+doelNoot : DoelPlatform -> List (Html Msg)
+doelNoot doel =
+    case doel of
+        DoelWeetNiet ->
+            [ p [ Attr.class "calc-note" ]
+                [ text "Nog geen platform op het oog? Prima: in het gratis gesprek adviseren we een platform op basis van uw situatie. De richtprijs rekent met Shopify als uitgangspunt." ]
+            ]
+
+        DoelShopify ->
+            []
+
+        DoelWoocommerce ->
+            []
+
+        DoelAnders ->
+            []
+
+
+{-| Losse waarschuwingen en geruststellingen bij keuzes die uitleg vragen: een
+nieuw ontwerp en een onbekend bronplatform gaan op aanvraag, en een nog
+onbekend doelplatform krijgt de advies-toezegging. -}
 opAanvraagNoten : Model -> List (Html Msg)
 opAanvraagNoten model =
-    themaNoot model.thema ++ bronNoot model.bron ++ pointOfSaleNoot model.pointOfSale
+    themaNoot model.thema ++ bronNoot model.bron ++ doelNoot model.doel ++ pointOfSaleNoot model.pointOfSale
 
 
 {-| Bij point-of-sale komt de installatie op locatie: die en de reiskosten

--- a/elm/tests/PricingTest.elm
+++ b/elm/tests/PricingTest.elm
@@ -11,10 +11,13 @@ import Expect
 import PrijsCalculator
     exposing
         ( BronPlatform(..)
+        , DoelPlatform(..)
         , Model
+        , Msg(..)
         , ThemaKeuze(..)
         , initieelModel
         , totaalCenten
+        , update
         )
 import Test exposing (Test, describe, test)
 
@@ -106,5 +109,16 @@ suite =
                             , nieuwsbrief = True
                             , voorraad = True
                         }
+                    )
+        , test "doelkeuze 'weetniet' in de dropdown wordt DoelWeetNiet" <|
+            \_ ->
+                Expect.equal DoelWeetNiet
+                    (Tuple.first (update (DoelGewijzigd "weetniet") initieelModel)).doel
+        , test "doelplatform beinvloedt de prijs niet, ook 'weet ik nog niet' niet" <|
+            \_ ->
+                Expect.equal (List.repeat 4 199900)
+                    (List.map
+                        (\doel -> totaalCenten { initieelModel | doel = doel })
+                        [ DoelShopify, DoelWoocommerce, DoelAnders, DoelWeetNiet ]
                     )
         ]

--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -263,7 +263,12 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
         H.div $ do
           H.h1 "Verhuis uw webshop. Zonder dataverlies, zonder SEO-verlies."
           H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Vastgelopen op MijnWebwinkel, CCV Shop of Lightspeed? Wij verhuizen uw complete webshop geautomatiseerd naar Shopify of een ander platform &mdash; producten, vertalingen, afbeeldingen, klantdata en SEO-redirects. U betaalt pas na een succesvolle migratie." :: Text)
-          H.a ! A.href offerteMailto ! A.class_ "cta-button" $ "Vraag een offerte aan"
+          -- Decision: the landing-page CTAs point at the price calculator
+          -- instead of an offerte-mailto. The calculator gives the visitor an
+          -- immediate, tangible result (Gemini-feedback: CTAs should offer
+          -- direct value) and its own offerte button follows once they have a
+          -- price on screen.
+          H.a ! A.href "/prijzen.html#rekenhulp" ! A.class_ "cta-button" $ "Bereken direct uw prijs"
         H.img ! A.class_ "hero-image"
               ! A.src "/illustratie-verhuizen.svg"
               ! A.alt "Illustratie van dozen die van een oude webshop naar een nieuwe verhuizen"
@@ -342,8 +347,13 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
           H.p ! A.class_ "price" $ H.preEscapedToHtml ("Vanaf &euro;" <> migratieBasisprijsEuro)
           H.p $ H.preEscapedToHtml ("Inclusief 1.000 producten en &eacute;&eacute;n taal: producten, afbeeldingen, categorie&euml;n, klantdata, voorraad en SEO-redirects. Grotere catalogi, extra talen en losse diensten (domeinverhuizing, e-mail-setup) hebben een vaste meerprijs." :: Text)
           H.p $ H.a ! A.href "/prijzen.html" $ H.preEscapedToHtml ("Bekijk de volledige prijzen &rarr;" :: Text)
-          H.a ! A.href offerteMailto ! A.class_ "cta-button" $ "Vraag een offerte aan"
+          H.a ! A.href "/prijzen.html#rekenhulp" ! A.class_ "cta-button" $ "Bereken direct uw prijs"
       H.p ! A.class_ "engagement-note" $ H.preEscapedToHtml ("Vaste prijs, vooraf afgesproken, en u betaalt pas na een succesvolle migratie. Getoonde prijzen zijn een indicatie; uw offerte is de echte prijsgarantie." :: Text)
+
+    -- FAQ
+    H.section ! A.class_ "about" $ do
+      H.h2 "Veelgestelde vragen"
+      H.dl $ mapM_ renderFaqItem homeFaq
 
     -- Final CTA
     H.section ! A.class_ "final-cta" $ do
@@ -359,8 +369,28 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
       , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/"
       , pageMetaOgImage     = Nothing
       , pageMetaSwitchUrl   = Nothing
-      , pageMetaExtraHead   = mempty
+      , pageMetaExtraHead   = faqPageJsonLd homeFaq
       }
+
+-- | The homepage FAQ: the questions that most often keep a visitor from
+-- reaching out, answered before they leave. The same pairs feed the visible
+-- list and 'faqPageJsonLd'. The platform-choice answer deliberately offers
+-- advice instead of a platform list: which platform fits depends on the
+-- shop's situation, and "weet ik nog niet" is a fine starting point (also
+-- selectable in the price calculator).
+homeFaq :: [(Text, Text)]
+homeFaq =
+  [ ( "Kan mijn webshop verhuisd worden?"
+    , "Vrijwel altijd. Producten, teksten, afbeeldingen, klanten en de categoriestructuur zetten we geautomatiseerd over vanaf MijnWebwinkel, CCV Shop, Lightspeed en andere platformen, inclusief 301-redirects van al uw oude URLs zodat uw Google-posities meeverhuizen." )
+  , ( "Naar welk platform kan ik het beste verhuizen?"
+    , "Dat hangt af van uw situatie: uw assortiment, uw koppelingen en hoeveel u zelf wilt kunnen aanpassen. Shopify is het meest gekozen doelplatform en WooCommerce doen we ook. Weet u het nog niet? In een gratis gesprek adviseren we een platform op basis van uw situatie, en in de rekenhulp kunt u die keuze gewoon openlaten." )
+  , ( "Hoe lang duurt een migratie?"
+    , "Het technische overzetten van uw producten duurt maar enkele uren. Maar er komt bij een verhuizing meestal meer kijken: het thema, apps en plugins, betaalmethoden, en rustig wennen aan uw nieuwe shop. Reken daarom op ongeveer een maand van start tot livegang." )
+  , ( "Wat kost een webshop-migratie?"
+    , "Een vaste prijs vanaf " <> migratieBasisprijsEuro <> " euro, afhankelijk van het aantal producten en talen, en u betaalt pas na een geslaagde migratie. Met de rekenhulp op de prijzenpagina berekent u in een minuut uw richtprijs." )
+  , ( "Kan mijn shop blijven doorverkopen tijdens de migratie?"
+    , "Ja. De nieuwe shop bouwen we naast uw huidige webshop op, die gewoon doordraait en verkoopt. Pas bij de livegang wijst u uw domein om." )
+  ]
 
 -- =============================================================================
 -- MijnWebwinkel migration landing page
@@ -487,7 +517,7 @@ prijzenPage = webwinkelBaseTemplate prijzenMeta $
       H.h1 "Prijzen"
       H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Vaste prijzen, vooraf afgesproken. U betaalt pas na een succesvolle migratie. Hieronder ziet u precies waar u aan toe bent." :: Text)
 
-    H.section ! A.class_ "engagement" $ do
+    H.section ! A.class_ "engagement" ! A.id "rekenhulp" $ do
       H.h2 "Bereken uw richtprijs"
       H.p "Beantwoord een paar vragen over uw shop en u ziet meteen een indicatie."
       H.div ! A.id "prijs-calculator-mount" $ mempty


### PR DESCRIPTION
## Samenvatting
Drie punten uit de Gemini-review van webwinkelverhuis.nl:

- De "Vraag een offerte aan"-knoppen op de landingspagina wijzen nu naar de rekenhulp ("Bereken direct uw prijs", `/prijzen.html#rekenhulp`): een CTA met direct tastbaar resultaat. De offerteknop zit in de rekenhulp zelf, zodra er een prijs op het scherm staat.
- Homepage-FAQ (vijf vragen) met FAQPage structured data via het bestaande `faqPageJsonLd`-patroon. De platformkeuze-vraag belooft advies op basis van de situatie van de shop in plaats van een platformlijstje.
- Rekenhulp: "Waar wilt u naartoe?" krijgt een aparte optie "Weet ik nog niet / ik wil advies" met een geruststellende noot (advies in het gratis gesprek, richtprijs met Shopify als uitgangspunt); "Een ander platform" staat er nu los van.

## Test plan
- [x] `elm-test`: 20 tests groen, incl. twee nieuwe (weetniet parset; doelplatform beïnvloedt de prijs niet)
- [x] Haskell-suite: 23 tests groen; `nix-build nix/ci.nix` slaagt
- [x] In de browser geverifieerd: beide CTA's op de homepage, FAQ-sectie zichtbaar, weetniet-optie toont de adviesnoot in de rekenhulp

🤖 Generated with [Claude Code](https://claude.com/claude-code)