### PR TITLE
Blogartikel-thema: bullets binnen de kaart, bredere kolom, meer ademruimte

### DIFF
--- a/webwinkel/blog.css
+++ b/webwinkel/blog.css
@@ -80,13 +80,13 @@
 /* Article page */
 .blog-article article {
   background: #ffffffd9;
-  padding: 1em 2em;
+  padding: 2em 3em;
   border: 1px solid #dbe5ef;
   border-radius: 6px;
 }
 
 .blog-article {
-  max-width: 48rem;
+  max-width: 56rem;
   margin: 0 auto;
   padding: 2rem 1.5rem;
 }
@@ -111,6 +111,28 @@
 
 .entry-content p {
   margin-bottom: 1rem;
+}
+
+/* The global reset in style.css strips ul/ol padding, which pushes the
+   outside-positioned bullet markers out of the article box. Restore it. */
+.entry-content ul,
+.entry-content ol {
+  padding-left: 1.75rem;
+  margin-bottom: 1rem;
+}
+
+.entry-content li {
+  margin-bottom: 0.4rem;
+}
+
+.entry-content figure {
+  margin: 1.5rem 0;
+}
+
+.entry-content figcaption {
+  color: #6a7886;
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
 }
 
 .entry-content a {
@@ -163,4 +185,14 @@
 
 .article-footer a:hover {
   text-decoration: underline;
+}
+
+@media (max-width: 700px) {
+  .blog-article {
+    padding: 1rem 0.75rem;
+  }
+
+  .blog-article article {
+    padding: 1.25em 1.25em;
+  }
 }


### PR DESCRIPTION
## Wat

De klantverhaal-pagina (en alle andere blogartikelen op webwinkelverhuis.nl) had drie themaproblemen:

- de bullet-markers hingen buiten het witte artikelvlak. Oorzaak: de universele reset in style.css zet padding op 0, en blog.css had geen eigen ul/ol-regels, dus de outside-positioned markers vielen buiten de kaart.
- de kolom was smal (48rem) met weinig binnenpadding, waardoor het geheel krap oogde.
- figure en figcaption stonden door dezelfde reset ook op marge 0, dus afbeeldingen en onderschriften plakten tegen de tekst.

## Fix (alleen webwinkel/blog.css)

- ul/ol in .entry-content krijgen padding-left 1.75rem en ondermarge, li's krijgen wat lucht tussen elkaar
- artikel verbreed naar 56rem, binnenpadding naar 2em 3em
- figure krijgt verticale marge, figcaption een gedempte kleur en kleiner lettertype
- media query op 700px (zelfde breakpoint als style.css) die de padding op mobiel terugschroeft zodat de tekstkolom niet dichtgeknepen wordt

## Verificatie

Lokaal gedraaid via server.sh en met Playwright gecontroleerd op 1280px en 375px: bullets staan binnen de kaart, mobiel houdt een leesbare kolombreedte. `nix-build nix/ci.nix` slaagt (SEO-analyse: geen defecten).

🤖 Generated with [Claude Code](https://claude.com/claude-code)