### PR TITLE
CCV-FAQ: terminal hoeft niet vervangen, alleen voor geïntegreerde kassa

### DIFF
--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -967,12 +967,14 @@ ccvshopFaq =
   -- Decision: POS-antwoord is bewust eerlijk over de beperking en
   -- maakt er een bestemmingskeuze van: bij WooCommerce blijft de
   -- CCV-terminal via Nederlandse kassasoftware gekoppeld, bij
-  -- Shopify moet hij vervangen omdat Shopify POS alleen eigen
-  -- terminals via Shopify Payments integreert (help.shopify.com,
-  -- gecheckt 2 aug 2026). Bron-onderzoek in
+  -- Shopify kan hij alleen als losse (niet-geïntegreerde) pin
+  -- blijven, want geïntegreerd ondersteunt Shopify POS uitsluitend
+  -- eigen terminals via Shopify Payments (help.shopify.com, gecheckt
+  -- 2 aug 2026). "Moet vervangen" zeggen we dus niet: dat geldt
+  -- alleen voor wie een geïntegreerde kassa wil. Bron-onderzoek in
   -- jappiesoft/research/ccv-woocommerce-market-onderzoek.org.
   , ( "Ik heb ook een fysieke winkel met een CCV-pinterminal. Kan die mee?"
-    , "Dat hangt af van uw bestemming. Kiest u WooCommerce, dan kan uw CCV-terminal gewoon blijven: Nederlandse kassasoftware koppelt de terminal en synchroniseert de voorraad met uw webshop, en uw pincontract loopt door. Kiest u Shopify, dan moet de terminal vervangen worden, want Shopify POS werkt alleen met eigen terminals via Shopify Payments. Die vervanging is eenmalig en bescheiden (Shopify-terminals kosten \8364" <> "59 tot \8364" <> "249) en daarna bent u ook voor het pinnen van CCV af. Wij hebben ervaring met het inrichten van kassa's en pinterminals en nemen dit gewoon in het migratietraject mee." )
+    , "Dat hangt af van uw bestemming. Kiest u WooCommerce, dan kan uw CCV-terminal gewoon gekoppeld blijven: Nederlandse kassasoftware verbindt de terminal en synchroniseert de voorraad met uw webshop, en uw pincontract loopt door. Kiest u Shopify, dan koppelt de terminal niet meer met de kassa; hij kan wel als losse pin blijven werken, maar dan typt u elk bedrag over. Wilt u winkel en webshop weer als \233\233n geheel, dan vervangt u hem door een Shopify-terminal. Die overstap is eenmalig en bescheiden (\8364" <> "59 tot \8364" <> "249) en daarna bent u ook voor het pinnen van CCV af. Wij hebben ervaring met het inrichten van kassa's en pinterminals en nemen dit gewoon in het migratietraject mee." )
   ]
 
 -- =============================================================================


### PR DESCRIPTION
## Waarom

Correctie op #111 na adversarial review: het FAQ-antwoord zei dat de CCV-terminal bij een Shopify-migratie vervangen moet worden. Dat overdrijft en sprak het eigen onderzoeksdoc (jappiesoft #157) tegen, dat de losse-pin-route documenteert: de terminal kan niet-geïntegreerd naast de kassa blijven werken met het bestaande acquiring-contract. Alleen wie winkel en webshop weer als één geheel wil, vervangt hem.

## Wat

Het FAQ-antwoord benoemt nu beide Shopify-routes eerlijk: losse pin blijft mogelijk (met de praktische consequentie dat elk bedrag overgetypt wordt), en de Shopify-terminal (€59 tot €249 eenmalig) voor wie de voorraad- en kassa-integratie terug wil. De decision-comment is meegecorrigeerd.

## Verificatie

- [x] Lokale build bekeken, tekst rendert correct
- [x] nix-build nix/ci.nix slaagt

🤖 Generated with [Claude Code](https://claude.com/claude-code)