### PR TITLE
Scanner-tweaks: kernmetingen ingeklapt, een upsell-blok, scan-knop in de hero

### DIFF
--- a/elm/src/ScannerForm.elm
+++ b/elm/src/ScannerForm.elm
@@ -5,12 +5,14 @@ port module ScannerForm exposing
     , Msg(..)
     , Oplosbaarheid(..)
     , Rapport
+    , RapportStand
     , ScanId(..)
     , ScanStatus(..)
     , Score
     , UitklapStand(..)
     , Verbeterpunt
     , WachtStand(..)
+    , ingeklapteRapportStand
     , initieelModel
     , leesStartRespons
     , leesStatusRespons
@@ -21,6 +23,7 @@ port module ScannerForm exposing
     , scanStatusDecoder
     , topVerbeterpunten
     , update
+    , view
     )
 
 {-| "Beoordeel mijn webshop" op webwinkelverhuis.nl.
@@ -28,10 +31,10 @@ port module ScannerForm exposing
 De bezoeker vult het adres van zijn webshop in; de server draait een scan
 (1 tot 2 minuten) en dit programma peilt elke drie seconden de status tot het
 rapport klaar is. Het rapport toont het herkende platform, de scores, de
-kernmetingen en de verbeterpunten, met bij elk punt of het oplosbaar is of
-vastligt in het huidige platform. Punten die vastliggen voeden het
-migratie-aanbod; oplosbare punten het losse-klussen-aanbod. Beide verwijzen
-naar een gratis gesprek.
+kernmetingen (standaard ingeklapt) en de verbeterpunten, met bij elk punt of
+het oplosbaar is of vastligt in het huidige platform. Ligt er iets vast, dan
+volgt alleen het migratie-aanbod met een knop naar de prijs-rekenhulp; ligt
+er niets vast, dan alleen het losse-klussen-aanbod met een gesprek-knop.
 
 API-contract (zelfde origin):
 
@@ -59,9 +62,10 @@ import Url
 -- prijscalculator (PrijsCalculator.elm): JS geeft de events door aan gtag en
 -- raakt de Elm-state niet aan. Events: scanner_started bij het aanvragen,
 -- scanner_klaar zodra een rapport op het scherm staat, scanner_mislukt bij
--- elke mislukking, en gesprek_knop_klik voor de gesprek-knoppen in het
--- rapport (de statische ctaTrackScript van de pagina hangt zijn listeners aan
--- DOMContentLoaded en ziet door Elm gerenderde links niet).
+-- elke mislukking, gesprek_knop_klik voor de gesprek-knop en
+-- scanner_naar_calculator voor de rekenhulp-knop in het rapport (de statische
+-- ctaTrackScript van de pagina hangt zijn listeners aan DOMContentLoaded en
+-- ziet door Elm gerenderde links niet).
 
 
 {-| Stuurt een analytics-event naar JavaScript, waar de pagina het aan Google
@@ -248,7 +252,7 @@ type Fase
     = Invoeren (Maybe String)
     | Aanvragen
     | Wachten ScanId WachtStand
-    | Geslaagd Rapport UitklapStand
+    | Geslaagd Rapport RapportStand
     | Mislukt String
 
 
@@ -259,10 +263,26 @@ type WachtStand
     | Bezig
 
 
-{-| Of de punten na de top 5 zichtbaar zijn. -}
+{-| Of een inklapbaar rapportdeel open- of dichtgeklapt staat. -}
 type UitklapStand
     = Ingeklapt
     | Uitgeklapt
+
+
+{-| De uitklapstand van de twee inklapbare rapportdelen: de kernmetingen en
+de verbeterpunten na de top 5. Beide beginnen ingeklapt, zodat het rapport
+opent met de scores en de top 5. -}
+type alias RapportStand =
+    { puntenUitklap : UitklapStand
+    , kernmetingenUitklap : UitklapStand
+    }
+
+
+ingeklapteRapportStand : RapportStand
+ingeklapteRapportStand =
+    { puntenUitklap = Ingeklapt
+    , kernmetingenUitklap = Ingeklapt
+    }
 
 
 type alias Model =
@@ -467,8 +487,10 @@ type Msg
     | PeilMoment
     | StatusOntvangen (Result String ScanStatus)
     | UitklapGewisseld
+    | KernmetingenGewisseld
     | OpnieuwGeprobeerd
     | GesprekGeklikt
+    | CalculatorGeklikt
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )
@@ -500,13 +522,21 @@ update msg model =
             verwerkStatus resultaat model
 
         UitklapGewisseld ->
-            ( { model | fase = wisselUitklap model.fase }, Cmd.none )
+            ( { model | fase = metRapportStand wisselPuntenUitklap model.fase }, Cmd.none )
+
+        -- Bewust zonder analytics-event: de kernmetingen-knop is bladeren
+        -- binnen het rapport, geen funnel-stap.
+        KernmetingenGewisseld ->
+            ( { model | fase = metRapportStand wisselKernmetingenUitklap model.fase }, Cmd.none )
 
         OpnieuwGeprobeerd ->
             ( { model | fase = Invoeren Nothing }, Cmd.none )
 
         GesprekGeklikt ->
             ( model, gaEvent "gesprek_knop_klik" [] )
+
+        CalculatorGeklikt ->
+            ( model, gaEvent "scanner_naar_calculator" [] )
 
 
 {-| Peil alleen wanneer we nog op de scan wachten; in elke andere fase is het
@@ -547,7 +577,7 @@ verwerkStatus resultaat model =
                     ( { model | fase = Mislukt scanMisluktMelding }, gaEvent "scanner_mislukt" [] )
 
                 Ok (StatusKlaar rapport) ->
-                    ( { model | fase = Geslaagd rapport Ingeklapt }
+                    ( { model | fase = Geslaagd rapport ingeklapteRapportStand }
                     , gaEvent "scanner_klaar" [ ( "platform", Encode.string rapport.platform ) ]
                     )
 
@@ -567,14 +597,13 @@ verwerkStatus resultaat model =
             ( model, Cmd.none )
 
 
-wisselUitklap : Fase -> Fase
-wisselUitklap fase =
+{-| Pas de uitklapstand van het rapport aan; buiten de rapportfase is er
+niets uit te klappen en verandert er niets. -}
+metRapportStand : (RapportStand -> RapportStand) -> Fase -> Fase
+metRapportStand pasAan fase =
     case fase of
-        Geslaagd rapport Ingeklapt ->
-            Geslaagd rapport Uitgeklapt
-
-        Geslaagd rapport Uitgeklapt ->
-            Geslaagd rapport Ingeklapt
+        Geslaagd rapport stand ->
+            Geslaagd rapport (pasAan stand)
 
         Invoeren mFout ->
             Invoeren mFout
@@ -587,6 +616,26 @@ wisselUitklap fase =
 
         Mislukt melding ->
             Mislukt melding
+
+
+wisselStand : UitklapStand -> UitklapStand
+wisselStand stand =
+    case stand of
+        Ingeklapt ->
+            Uitgeklapt
+
+        Uitgeklapt ->
+            Ingeklapt
+
+
+wisselPuntenUitklap : RapportStand -> RapportStand
+wisselPuntenUitklap stand =
+    { stand | puntenUitklap = wisselStand stand.puntenUitklap }
+
+
+wisselKernmetingenUitklap : RapportStand -> RapportStand
+wisselKernmetingenUitklap stand =
+    { stand | kernmetingenUitklap = wisselStand stand.kernmetingenUitklap }
 
 
 
@@ -615,6 +664,13 @@ meetUrl =
     "https://meet.jappiesoftware.com"
 
 
+{-| De prijs-rekenhulp op de eigen prijzenpagina, dezelfde bestemming als de
+rekenhulp-knoppen elders op de site (zie WebwinkelTemplates.hs). -}
+rekenhulpUrl : String
+rekenhulpUrl =
+    "/prijzen.html#rekenhulp"
+
+
 view : Model -> Html Msg
 view model =
     div [ Attr.class "webshop-scanner" ] (faseWeergave model)
@@ -632,8 +688,8 @@ faseWeergave model =
         Wachten _ stand ->
             laadWeergave (wachtTekst stand)
 
-        Geslaagd rapport uitklap ->
-            rapportWeergave rapport uitklap
+        Geslaagd rapport stand ->
+            rapportWeergave rapport stand
 
         Mislukt melding ->
             misluktWeergave melding
@@ -718,20 +774,36 @@ misluktWeergave melding =
 -- RAPPORTWEERGAVE
 
 
-rapportWeergave : Rapport -> UitklapStand -> List (Html Msg)
-rapportWeergave rapport uitklap =
+rapportWeergave : Rapport -> RapportStand -> List (Html Msg)
+rapportWeergave rapport stand =
     [ h3 [ Attr.class "scanner-rapport-kop" ] [ text ("Rapport voor " ++ rapport.url) ]
     , p [ Attr.class "scanner-platform" ] [ text (platformRegel rapport) ]
     , div [ Attr.class "scanner-scores" ] (List.map scoreWeergave rapport.scores)
-    , h3 [] [ text "Kernmetingen" ]
-    , dl [ Attr.class "scanner-kernmetingen" ] (List.concatMap kernmetingWeergave rapport.kernmetingen)
-    , h3 [] [ text "Verbeterpunten" ]
     ]
+        ++ kernmetingenDeel rapport stand.kernmetingenUitklap
+        ++ [ h3 [] [ text "Verbeterpunten" ] ]
         ++ List.map (puntWeergave rapport.platform) (topVerbeterpunten rapport.verbeterpunten)
-        ++ uitklapDeel rapport uitklap
-        ++ migratieBlok rapport
-        ++ oplosBlok rapport
+        ++ uitklapDeel rapport stand.puntenUitklap
+        ++ upsellBlok rapport
         ++ [ metaRegel rapport ]
+
+
+{-| De kernmetingen, standaard ingeklapt: de meeste bezoekers hebben genoeg
+aan de scores en de verbeterpunten, en de ruwe metingen blijven een klik weg.
+De labels komen van de server en tonen we onvertaald. -}
+kernmetingenDeel : Rapport -> UitklapStand -> List (Html Msg)
+kernmetingenDeel rapport uitklap =
+    case uitklap of
+        Ingeklapt ->
+            [ h3 [] [ text "Kernmetingen" ]
+            , uitklapKnop KernmetingenGewisseld "Toon de kernmetingen"
+            ]
+
+        Uitgeklapt ->
+            [ h3 [] [ text "Kernmetingen" ]
+            , dl [ Attr.class "scanner-kernmetingen" ] (List.concatMap kernmetingWeergave rapport.kernmetingen)
+            , uitklapKnop KernmetingenGewisseld "Verberg de kernmetingen"
+            ]
 
 
 platformRegel : Rapport -> String
@@ -829,16 +901,16 @@ uitklapDeel rapport uitklap =
     else
         case uitklap of
             Ingeklapt ->
-                [ uitklapKnop ("Toon alle " ++ String.fromInt (List.length rapport.verbeterpunten) ++ " punten") ]
+                [ uitklapKnop UitklapGewisseld ("Toon alle " ++ String.fromInt (List.length rapport.verbeterpunten) ++ " punten") ]
 
             Uitgeklapt ->
                 List.map (puntWeergave rapport.platform) (restVerbeterpunten rapport.verbeterpunten)
-                    ++ [ uitklapKnop "Verberg de extra punten" ]
+                    ++ [ uitklapKnop UitklapGewisseld "Verberg de extra punten" ]
 
 
-uitklapKnop : String -> Html Msg
-uitklapKnop tekst =
-    button [ Attr.class "cta-button-secondary scanner-uitklap", onClick UitklapGewisseld ] [ text tekst ]
+uitklapKnop : Msg -> String -> Html Msg
+uitklapKnop bericht tekst =
+    button [ Attr.class "cta-button-secondary scanner-uitklap", onClick bericht ] [ text tekst ]
 
 
 
@@ -849,6 +921,12 @@ uitklapKnop tekst =
 -- verbeterpuntenlijst zelf (telling van oplosbaar/vast), niet uit het losse
 -- vastOpPlatform-veld van de server, zodat badges en blokken nooit kunnen
 -- afwijken van wat er op het scherm staat.
+
+-- Decision: precies een upsell-blok, nooit twee (twee keer een aanbod onder
+-- een rapport leest als leuren). Ligt er iets vast in het platform, dan is
+-- verhuizen het antwoord en gaat de knop naar de prijs-rekenhulp: de
+-- bezoeker wil op dat moment een prijs, geen agenda. Ligt er niets vast, dan
+-- is het aanbod de losse klussen en blijft de gesprek-knop.
 
 
 aantalVast : Rapport -> Int
@@ -861,50 +939,53 @@ heeftOplosbarePunten rapport =
     List.any (\punt -> punt.oplosbaar == Oplosbaar) rapport.verbeterpunten
 
 
-{-| Migratie-aanbod: alleen wanneer er punten zijn die in het huidige
-platform vastliggen. -}
-migratieBlok : Rapport -> List (Html Msg)
-migratieBlok rapport =
-    if aantalVast rapport == 0 then
-        []
+{-| Het ene upsell-blok onder het rapport: migratie zodra er punten
+vastliggen, anders losse klussen. -}
+upsellBlok : Rapport -> List (Html Msg)
+upsellBlok rapport =
+    if aantalVast rapport > 0 then
+        migratieBlok rapport
 
     else
-        [ div [ Attr.class "scanner-upsell scanner-upsell-migratie" ]
-            [ h3 [] [ text "Vast aan uw platform" ]
-            , p [] [ text (vastZin (aantalVast rapport) rapport.platform) ]
-            , gesprekKnop "cta-button"
-            ]
+        oplosBlok rapport
+
+
+{-| Migratie-aanbod met een knop naar de prijs-rekenhulp op /prijzen. -}
+migratieBlok : Rapport -> List (Html Msg)
+migratieBlok rapport =
+    [ div [ Attr.class "scanner-upsell scanner-upsell-migratie" ]
+        [ h3 [] [ text "Vast aan uw platform" ]
+        , p [] [ text (vastZin (aantalVast rapport) rapport.platform) ]
+        , a [ Attr.href rekenhulpUrl, Attr.class "cta-button", onClick CalculatorGeklikt ]
+            [ text "Bereken uw verhuisprijs" ]
         ]
+    ]
 
 
 vastZin : Int -> String -> String
 vastZin aantal platformNaam =
     if aantal == 1 then
-        "1 punt ligt vast in " ++ platformNaam ++ " en is alleen op te lossen door te verhuizen. Dat is ons vak."
+        "1 punt ligt vast in " ++ platformNaam ++ ". Verhuizen lost het op."
 
     else
-        String.fromInt aantal ++ " punten liggen vast in " ++ platformNaam ++ " en zijn alleen op te lossen door te verhuizen. Dat is ons vak."
+        String.fromInt aantal ++ " punten liggen vast in " ++ platformNaam ++ ". Verhuizen lost ze op."
 
 
-{-| Losse-klussen-aanbod voor de punten die wel op het huidige platform
-oplosbaar zijn. -}
+{-| Losse-klussen-aanbod voor de punten die op het huidige platform
+oplosbaar zijn; alleen getoond als er niets vastligt. -}
 oplosBlok : Rapport -> List (Html Msg)
 oplosBlok rapport =
     if heeftOplosbarePunten rapport then
         [ div [ Attr.class "scanner-upsell" ]
             [ h3 [] [ text "Liever laten doen?" ]
             , p [] [ text "De oplosbare punten pakken wij voor u op, tegen een vaste prijs." ]
-            , gesprekKnop "cta-button-secondary"
+            , a [ Attr.href meetUrl, Attr.class "cta-button", onClick GesprekGeklikt ]
+                [ text "Plan een gesprek" ]
             ]
         ]
 
     else
         []
-
-
-gesprekKnop : String -> Html Msg
-gesprekKnop knopKlasse =
-    a [ Attr.href meetUrl, Attr.class knopKlasse, onClick GesprekGeklikt ] [ text "Plan een gesprek" ]
 
 
 metaRegel : Rapport -> Html Msg

--- a/elm/tests/ScannerFormTest.elm
+++ b/elm/tests/ScannerFormTest.elm
@@ -9,11 +9,13 @@ fases die ze aansturen wel.
 
 import Dict
 import Expect
+import Html.Attributes as Attr
 import Http
 import Json.Decode as Decode
 import ScannerForm
     exposing
         ( Fase(..)
+        , Model
         , Msg(..)
         , Oplosbaarheid(..)
         , Rapport
@@ -22,6 +24,7 @@ import ScannerForm
         , UitklapStand(..)
         , Verbeterpunt
         , WachtStand(..)
+        , ingeklapteRapportStand
         , initieelModel
         , leesStartRespons
         , leesStatusRespons
@@ -31,8 +34,11 @@ import ScannerForm
         , scanStatusDecoder
         , topVerbeterpunten
         , update
+        , view
         )
 import Test exposing (Test, describe, test)
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
 
 
 {-| Fixture die het API-contract volgt, inclusief een score zonder waarde
@@ -236,15 +242,18 @@ updateTests =
                             { initieelModel | fase = Wachten (ScanId "abc123") Bezig }
                         )
                     ).fase
-        , test "een klaar-status rendert het rapport ingeklapt" <|
+        , test "een klaar-status rendert het rapport volledig ingeklapt" <|
             \_ ->
-                Expect.equal (Geslaagd verwachtRapport Ingeklapt) faseNaKlaar
-        , test "uitklappen wisselt naar Uitgeklapt" <|
+                Expect.equal (Geslaagd verwachtRapport ingeklapteRapportStand) faseNaKlaar
+        , test "punten uitklappen laat de kernmetingen ingeklapt" <|
             \_ ->
-                Expect.equal (Geslaagd verwachtRapport Uitgeklapt)
+                Expect.equal
+                    (Geslaagd verwachtRapport
+                        { puntenUitklap = Uitgeklapt, kernmetingenUitklap = Ingeklapt }
+                    )
                     (Tuple.first
                         (update UitklapGewisseld
-                            { initieelModel | fase = Geslaagd verwachtRapport Ingeklapt }
+                            { initieelModel | fase = Geslaagd verwachtRapport ingeklapteRapportStand }
                         )
                     ).fase
         , test "een mislukt-status eindigt in de misluktfase" <|
@@ -285,6 +294,78 @@ isMislukt fase =
             False
 
 
+{-| Model in de rapportfase, opgebouwd via de echte update-flow: een
+klaar-status die binnenkomt terwijl we op de scan wachten. -}
+modelMetRapport : Rapport -> Model
+modelMetRapport rapport =
+    Tuple.first
+        (update (StatusOntvangen (Ok (StatusKlaar rapport)))
+            { initieelModel | fase = Wachten (ScanId "abc123") Bezig }
+        )
+
+
+{-| Rapport zonder vastzittende punten: alleen de oplosbare punten uit de
+fixture blijven over. -}
+oplosbaarRapport : Rapport
+oplosbaarRapport =
+    { verwachtRapport
+        | verbeterpunten =
+            List.filter (\p -> p.oplosbaar == Oplosbaar) verwachtRapport.verbeterpunten
+        , vastOpPlatform = 0
+    }
+
+
+rekenhulpLink : Selector.Selector
+rekenhulpLink =
+    Selector.attribute (Attr.href "/prijzen.html#rekenhulp")
+
+
+gesprekLink : Selector.Selector
+gesprekLink =
+    Selector.attribute (Attr.href "https://meet.jappiesoftware.com")
+
+
+viewTests : Test
+viewTests =
+    describe "rapportweergave via view"
+        [ test "kernmetingen zijn standaard ingeklapt" <|
+            \_ ->
+                view (modelMetRapport verwachtRapport)
+                    |> Query.fromHtml
+                    |> Query.hasNot [ Selector.text "Largest Contentful Paint" ]
+        , test "ingeklapte kernmetingen tonen een toon-knop" <|
+            \_ ->
+                view (modelMetRapport verwachtRapport)
+                    |> Query.fromHtml
+                    |> Query.has [ Selector.text "Toon de kernmetingen" ]
+        , test "na de toon-knop staan de kernmetingen op het scherm" <|
+            \_ ->
+                view (Tuple.first (update KernmetingenGewisseld (modelMetRapport verwachtRapport)))
+                    |> Query.fromHtml
+                    |> Query.has [ Selector.text "Largest Contentful Paint", Selector.text "8,4 s" ]
+        , test "met een vast punt linkt de upsell naar de rekenhulp" <|
+            \_ ->
+                view (modelMetRapport verwachtRapport)
+                    |> Query.fromHtml
+                    |> Query.has [ rekenhulpLink, Selector.text "Bereken uw verhuisprijs" ]
+        , test "met een vast punt is er geen gesprek-knop" <|
+            \_ ->
+                view (modelMetRapport verwachtRapport)
+                    |> Query.fromHtml
+                    |> Query.hasNot [ gesprekLink ]
+        , test "zonder vaste punten staat de gesprek-knop er" <|
+            \_ ->
+                view (modelMetRapport oplosbaarRapport)
+                    |> Query.fromHtml
+                    |> Query.has [ gesprekLink, Selector.text "Plan een gesprek" ]
+        , test "zonder vaste punten is er geen rekenhulp-upsell" <|
+            \_ ->
+                view (modelMetRapport oplosbaarRapport)
+                    |> Query.fromHtml
+                    |> Query.hasNot [ rekenhulpLink ]
+        ]
+
+
 suite : Test
 suite =
     describe "ScannerForm"
@@ -293,4 +374,5 @@ suite =
         , urlTests
         , topVijfTests
         , updateTests
+        , viewTests
         ]

--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -322,17 +322,15 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
         H.div $ do
           H.h1 "Webshop verhuizen zonder data en SEO verlies."
           H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Vastgelopen op MijnWebwinkel, CCV Shop of Lightspeed? Wij verhuizen uw complete webshop geautomatiseerd naar Shopify of een ander platform. U betaalt pas na een succesvolle migratie." :: Text)
-          -- Decision: the landing-page CTAs point at the price calculator
-          -- instead of an offerte-mailto. The calculator gives the visitor an
-          -- immediate, tangible result (Gemini-feedback: CTAs should offer
-          -- direct value) and its own offerte button follows once they have a
-          -- price on screen.
-          H.a ! A.href "/prijzen.html#rekenhulp" ! A.class_ "cta-button" $ "Bereken direct uw prijs"
-          -- Naast de prijsvraag de twijfelvraag: "is mijn shop eigenlijk
-          -- slecht af?". De gratis scan (/scan.html) beantwoordt die met een
-          -- meting in plaats van een verkooppraatje.
-          -- TODO put live once we know it works well
-          -- H.a ! A.href "/scan.html" ! A.class_ "cta-button-secondary" $ "Beoordeel mijn webshop"
+          -- Decision: one hero button, and it points at the gratis scan
+          -- (/scan.html) instead of the price calculator: the scan gives the
+          -- visitor an immediate, personal result and feeds the migration
+          -- offer from measured facts. The calculator stays reachable via
+          -- the Prijzen nav item, the prijzen-section card below and the
+          -- scanner's own rekenhulp-knop. Like the previous hero CTA this is
+          -- an internal link: GA4's automatic pageview of /scan.html is the
+          -- click signal, no extra event (see ctaTrackScript).
+          H.a ! A.href "/scan.html" ! A.class_ "cta-button" $ "Beoordeel mijn webshop"
         H.img ! A.class_ "hero-image"
               ! A.src "/illustratie-verhuizen.svg"
               ! A.alt "Illustratie van dozen die van een oude webshop naar een nieuwe verhuizen"


### PR DESCRIPTION
Feedback-ronde op de webshop-scanner van #118.

## Wat er verandert

- Kernmetingen staan standaard ingeklapt achter een toon-knop in dezelfde stijl als de verbeterpunten-uitklapknop; geen analytics-event voor dit bladeren. De labels komen van de server en worden onvertaald getoond.
- Precies een upsell-blok in plaats van twee gesprek-blokken naast elkaar:
  - Ligt er een punt vast in het platform, dan alleen het migratie-blok met "Bereken uw verhuisprijs" naar `/prijzen.html#rekenhulp` (dezelfde bestemming als de rekenhulp-CTAs elders op de site), gemeten als `scanner_naar_calculator` via de bestaande analytics-port.
  - Ligt er niets vast, dan alleen het losse-klussen-blok met de "Plan een gesprek"-knop naar meet.jappiesoftware.com (`gesprek_knop_klik`, als voorheen).
- De hero van de landingspagina krijgt weer een knop en die wijst naar de scan: "Beoordeel mijn webshop" als primaire CTA in plaats van de rekenhulp-knop. Net als de vorige hero-CTA geen los klik-event voor deze interne link; de GA4-pageview van /scan.html is het signaal (conform de ctaTrackScript-conventie). De rekenhulp blijft bereikbaar via de nav, de prijzen-sectie en de scanner-upsell.

## Tests

`elm/tests/ScannerFormTest.elm` toetst via de echte update/view-logica (Test.Html.Query): kernmetingen beginnen ingeklapt en verschijnen na de toon-knop; een rapport met vast punt toont de rekenhulp-knop en geen gesprek-knop; een rapport zonder vaste punten toont alleen de gesprek-knop. De bestaande fase-tests zijn meeverhuisd naar de nieuwe RapportStand.

## Test plan

- [x] `nix-build default.nix` groen (site + beide Elm-apps, shake-suite, seo-analyzer)
- [x] `elm-test` groen: 53 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
