### PR TITLE
Scanner: niet-herkend platform toont geen rapport, wel een nieuwe zoekbox

### DIFF
--- a/elm/src/ScannerForm.elm
+++ b/elm/src/ScannerForm.elm
@@ -689,7 +689,11 @@ faseWeergave model =
             laadWeergave (wachtTekst stand)
 
         Geslaagd rapport stand ->
-            rapportWeergave rapport stand
+            if rapport.platformHerkend then
+                rapportWeergave rapport stand
+
+            else
+                nietHerkendWeergave rapport model.invoer
 
         Mislukt melding ->
             misluktWeergave melding
@@ -785,7 +789,24 @@ rapportWeergave rapport stand =
         ++ List.map (puntWeergave rapport.platform) (topVerbeterpunten rapport.verbeterpunten)
         ++ uitklapDeel rapport stand.puntenUitklap
         ++ upsellBlok rapport
-        ++ [ metaRegel rapport ]
+
+
+{-| Vervangt het volledige rapport wanneer de scanner het platform niet
+herkent. Besluit Jappie (2 aug 2026): wij fixeren op de ondersteunde
+webshopplatformen en zijn bewust geen generiek Lighthouse-loket, dus een
+niet-herkend platform krijgt geen scores, verbeterpunten of aanbod te
+zien: alleen de melding en een nieuwe zoekbox. Het formulier is hetzelfde
+als op de startfase ('invoerWeergave'), met het gescande adres nog
+ingevuld zodat een tikfout snel hersteld is; 'ScanAangevraagd' werkt
+vanuit elke fase, dus opnieuw scannen werkt hiervandaan direct. -}
+nietHerkendWeergave : Rapport -> String -> List (Html Msg)
+nietHerkendWeergave rapport invoer =
+    [ h3 [ Attr.class "scanner-rapport-kop" ] [ text ("Rapport voor " ++ rapport.url) ]
+    , p [ Attr.class "scanner-platform" ] [ strong [] [ text "Platform niet herkend." ] ]
+    , p []
+        [ text "Wij beoordelen webshops op MijnWebwinkel, CCV Shop, Lightspeed en WooCommerce. Draait uw shop ergens anders, dan kunnen wij er weinig zinnigs over zeggen. Controleer het adres of probeer een andere shop:" ]
+    ]
+        ++ invoerWeergave invoer Nothing
 
 
 {-| De kernmetingen, standaard ingeklapt: de meeste bezoekers hebben genoeg
@@ -986,33 +1007,6 @@ oplosBlok rapport =
 
     else
         []
-
-
-metaRegel : Rapport -> Html Msg
-metaRegel rapport =
-    p [ Attr.class "scanner-meta" ]
-        [ small []
-            [ text
-                ("Gemeten op "
-                    ++ String.left 10 rapport.gemeten
-                    ++ " met Lighthouse "
-                    ++ rapport.lighthouseVersie
-                    ++ ", "
-                    ++ metingenTekst rapport.metingen
-                    ++ "."
-                )
-            ]
-        ]
-
-
-metingenTekst : Int -> String
-metingenTekst aantal =
-    if aantal == 1 then
-        "1 meting"
-
-    else
-        String.fromInt aantal ++ " metingen"
-
 
 
 -- MAIN

--- a/elm/src/ScannerForm.elm
+++ b/elm/src/ScannerForm.elm
@@ -791,11 +791,18 @@ rapportWeergave rapport stand =
         ++ upsellBlok rapport
 
 
+-- Decision: een niet-herkend platform krijgt geen rapport (geen scores,
+-- verbeterpunten of aanbod), alleen "Platform niet herkend." en de
+-- zoekbox opnieuw. Gekozen door Jappie (2 aug 2026) boven het alternatief
+-- (het volledige Lighthouse-rapport tonen met "platform: niet herkend"
+-- erboven, zoals het eerst deed): wij fixeren op de ondersteunde
+-- webshopplatformen en willen geen generiek Lighthouse-loket zijn, en
+-- zonder herkend platform kunnen we oplosbaar-versus-vast toch niet
+-- duiden, dus het rapport zou leuren zonder advies te dragen.
+
+
 {-| Vervangt het volledige rapport wanneer de scanner het platform niet
-herkent. Besluit Jappie (2 aug 2026): wij fixeren op de ondersteunde
-webshopplatformen en zijn bewust geen generiek Lighthouse-loket, dus een
-niet-herkend platform krijgt geen scores, verbeterpunten of aanbod te
-zien: alleen de melding en een nieuwe zoekbox. Het formulier is hetzelfde
+herkent: alleen de melding en een nieuwe zoekbox. Het formulier is hetzelfde
 als op de startfase ('invoerWeergave'), met het gescande adres nog
 ingevuld zodat een tikfout snel hersteld is; 'ScanAangevraagd' werkt
 vanuit elke fase, dus opnieuw scannen werkt hiervandaan direct. -}

--- a/elm/tests/ScannerFormTest.elm
+++ b/elm/tests/ScannerFormTest.elm
@@ -363,6 +363,48 @@ viewTests =
                 view (modelMetRapport oplosbaarRapport)
                     |> Query.fromHtml
                     |> Query.hasNot [ rekenhulpLink ]
+        , test "de Lighthouse-attributieregel staat niet meer onder het rapport" <|
+            \_ ->
+                view (modelMetRapport verwachtRapport)
+                    |> Query.fromHtml
+                    |> Query.hasNot [ Selector.text "Lighthouse" ]
+        ]
+
+
+{-| Rapport waarvan de scanner het platform niet herkende. -}
+nietHerkendRapport : Rapport
+nietHerkendRapport =
+    { verwachtRapport | platformHerkend = False, platform = "onbekend" }
+
+
+nietHerkendTests : Test
+nietHerkendTests =
+    describe "platform niet herkend: geen rapport, wel een nieuwe zoekbox"
+        [ test "de melding staat op het scherm" <|
+            \_ ->
+                view (modelMetRapport nietHerkendRapport)
+                    |> Query.fromHtml
+                    |> Query.has [ Selector.text "Platform niet herkend." ]
+        , test "scores en verbeterpunten blijven verborgen" <|
+            \_ ->
+                view (modelMetRapport nietHerkendRapport)
+                    |> Query.fromHtml
+                    |> Query.hasNot [ Selector.text "Verbeterpunten" ]
+        , test "geen upsell naar rekenhulp of gesprek" <|
+            \_ ->
+                view (modelMetRapport nietHerkendRapport)
+                    |> Query.fromHtml
+                    |> Query.hasNot [ rekenhulpLink ]
+        , test "de zoekbox staat klaar voor een volgende poging" <|
+            \_ ->
+                view (modelMetRapport nietHerkendRapport)
+                    |> Query.fromHtml
+                    |> Query.has [ Selector.tag "input", Selector.text "Beoordeel mijn webshop" ]
+        , test "een herkend platform toont geen niet-herkend-melding" <|
+            \_ ->
+                view (modelMetRapport verwachtRapport)
+                    |> Query.fromHtml
+                    |> Query.hasNot [ Selector.text "Platform niet herkend." ]
         ]
 
 
@@ -375,4 +417,5 @@ suite =
         , topVijfTests
         , updateTests
         , viewTests
+        , nietHerkendTests
         ]


### PR DESCRIPTION
## Summary
- Fixatie op de ondersteunde platformen: een scan met `platformHerkend: false` toont geen scores, verbeterpunten of upsell meer, maar "Platform niet herkend." met een korte uitleg en het scanformulier opnieuw (adres blijft ingevuld voor tikfout-herstel; opnieuw scannen werkt direct omdat ScanAangevraagd fase-onafhankelijk is). Geen generiek Lighthouse-loket.
- De Lighthouse-attributieregel onder het rapport is verwijderd; de bijbehorende metaRegel/metingenTekst-functies ook. De velden blijven in het rapport-decoder-contract zodat de server niet mee hoeft te wijzigen.
- Server-side draait de Lighthouse-meting nu nog wél voor niet-herkende platformen; als dat rekentijd gaat kosten is een vroege platform-check vóór de meting een logische vervolgstap aan de backendkant.

## Test plan
- [x] Vijf nieuwe view-tests (melding zichtbaar, rapportdelen verborgen, geen upsell, zoekbox aanwezig, herkend pad ongewijzigd) plus een guard dat "Lighthouse" niet meer in het rapport staat; alle 59 elm-tests groen
- [x] nix-build nix/ci.nix slaagt

🤖 Generated with [Claude Code](https://claude.com/claude-code)