### PR TITLE
Scanner: Shopify in de lijst van beoordeelde platformen

### DIFF
--- a/elm/src/ScannerForm.elm
+++ b/elm/src/ScannerForm.elm
@@ -811,7 +811,7 @@ nietHerkendWeergave rapport invoer =
     [ h3 [ Attr.class "scanner-rapport-kop" ] [ text ("Rapport voor " ++ rapport.url) ]
     , p [ Attr.class "scanner-platform" ] [ strong [] [ text "Platform niet herkend." ] ]
     , p []
-        [ text "Wij beoordelen webshops op MijnWebwinkel, CCV Shop, Lightspeed en WooCommerce. Draait uw shop ergens anders, dan kunnen wij er weinig zinnigs over zeggen. Controleer het adres of probeer een andere shop:" ]
+        [ text "Wij beoordelen webshops op MijnWebwinkel, CCV Shop, Lightspeed, WooCommerce en Shopify. Draait uw shop ergens anders, dan kunnen wij er weinig zinnigs over zeggen. Controleer het adres of probeer een andere shop:" ]
     ]
         ++ invoerWeergave invoer Nothing
 


### PR DESCRIPTION
## Summary
- De scanner-backend (megavid webshop-scanner) herkent en ondersteunt Shopify al volledig: cdn.shopify.com-fingerprint, OpenPlatform-verdict, dus alles-oplosbaar plus de losse-klussen/gesprek-route. Alleen de niet-herkend-melding in de frontend noemde vier platformen; Shopify staat er nu bij.
- De homepage-FAQ over migratie-bronplatformen blijft bewust zonder Shopify: het scope-besluit van 18 juli laat Shopify-vertrekkers links liggen. Beoordelen is een ander kanaal dan wegmigreren.

## Test plan
- [x] Alle 59 elm-tests groen; nix-build nix/ci.nix slaagt

🤖 Generated with [Claude Code](https://claude.com/claude-code)