### PR TITLE
Scanner-frontend: eerlijke melding bij tijdelijk-geweigerd (429)

### DIFF
--- a/elm/src/ScannerForm.elm
+++ b/elm/src/ScannerForm.elm
@@ -228,6 +228,7 @@ type ScanStatus
     = StatusWachtrij Int
     | StatusBezig
     | StatusMislukt
+    | StatusTijdelijkGeweigerd
     | StatusKlaar Rapport
 
 
@@ -247,6 +248,9 @@ statusInhoudDecoder status =
 
     else if status == "mislukt" then
         Decode.succeed StatusMislukt
+
+    else if status == "tijdelijk-geweigerd" then
+        Decode.succeed StatusTijdelijkGeweigerd
 
     else if status == "klaar" then
         Decode.map StatusKlaar (Decode.field "rapport" rapportDecoder)
@@ -590,6 +594,14 @@ verwerkStatus resultaat model =
                 Ok StatusMislukt ->
                     ( { model | fase = Mislukt scanMisluktMelding }, gaEvent "scanner_mislukt" [] )
 
+                Ok StatusTijdelijkGeweigerd ->
+                    -- De shop zelf weigerde de meting met een 429 (zie
+                    -- megavid #145); eerlijk melden en later terugkomen
+                    -- werkt beter dan een generiek "mislukt".
+                    ( { model | fase = Mislukt tijdelijkGeweigerdMelding }
+                    , gaEvent "scanner_geweigerd" []
+                    )
+
                 Ok (StatusKlaar rapport) ->
                     ( { model | fase = Geslaagd rapport ingeklapteRapportStand }
                     , gaEvent "scanner_klaar" [ ( "platform", Encode.string rapport.platform ) ]
@@ -777,6 +789,12 @@ wachtTekst stand =
 
         Bezig ->
             "We meten uw webshop."
+
+
+{-| Melding wanneer de gescande shop onze meting tijdelijk weigert. -}
+tijdelijkGeweigerdMelding : String
+tijdelijkGeweigerdMelding =
+    "Deze shop beperkt tijdelijk onze metingen (te veel verzoeken kort na elkaar). Probeer het over een uur opnieuw."
 
 
 misluktWeergave : String -> List (Html Msg)

--- a/elm/tests/ScannerFormTest.elm
+++ b/elm/tests/ScannerFormTest.elm
@@ -139,6 +139,10 @@ decoderTests =
                     (Decode.decodeString scanStatusDecoder
                         ("""{"status":"klaar","rapport":""" ++ rapportJson ++ "}")
                     )
+        , test "status tijdelijk-geweigerd decodeert naar de eigen uitkomst" <|
+            \_ ->
+                Expect.equal (Ok StatusTijdelijkGeweigerd)
+                    (Decode.decodeString scanStatusDecoder """{"status":"tijdelijk-geweigerd"}""")
         , test "een onbekende status faalt in plaats van stil door te gaan" <|
             \_ ->
                 Expect.err
@@ -270,6 +274,14 @@ updateTests =
                             )
                         ).fase
                     )
+        , test "tijdelijk-geweigerd eindigt in de misluktfase met de wacht-melding" <|
+            \_ ->
+                Expect.equal (Mislukt "Deze shop beperkt tijdelijk onze metingen (te veel verzoeken kort na elkaar). Probeer het over een uur opnieuw.")
+                    (Tuple.first
+                        (update (StatusOntvangen (Ok StatusTijdelijkGeweigerd))
+                            { initieelModel | fase = Wachten (ScanId "abc123") Bezig }
+                        )
+                    ).fase
         , test "opnieuw proberen keert terug naar de invoer" <|
             \_ ->
                 Expect.equal (Invoeren Nothing)


### PR DESCRIPTION
## Summary
- Rescue: strandde toen #122 net vóór de push gemerged werd; hoort bij de #145-fix (megavid #148).
- Status "tijdelijk-geweigerd" (shop antwoordt zelf 429 op de meting) toont nu "Deze shop beperkt tijdelijk onze metingen... probeer het over een uur opnieuw" in plaats van het generieke mislukt, met eigen analytics-event scanner_geweigerd.

## Test plan
- [x] Cherry-pick op verse master; 65 elm-tests groen (decoder- en fase-overgangstest voor de nieuwe status)

🤖 Generated with [Claude Code](https://claude.com/claude-code)