### PR TITLE
Webwinkelverhuis-sitemap: lastmod op elke pagina, ook de statische

### DIFF
--- a/shake/Shakefile.hs
+++ b/shake/Shakefile.hs
@@ -54,6 +54,7 @@ import WebwinkelTemplates
   , mijnwebwinkelWaaromPage
   , lightspeedWaaromPage
   , relativizeWebwinkelContentImages
+  , webwinkelverhuisSitemap
   )
 import Slug (toSlug)
 import Templates
@@ -68,6 +69,7 @@ import Templates
   )
 import Types
   ( Article(..)
+  , articleLastmod
   , Page(..)
   , NavLink(..)
   , PaginationInfo(..)
@@ -754,7 +756,7 @@ generateWebwinkelverhuisSite config articles = do
   -- Atom feed
   T.writeFile "_webwinkelverhuis-site/blog/atom" (generateAtomFeed config sortedArticles)
 
-  T.writeFile "_webwinkelverhuis-site/sitemap.xml" (generateWebwinkelverhuisSitemap sortedArticles)
+  T.writeFile "_webwinkelverhuis-site/sitemap.xml" (webwinkelverhuisSitemap sortedArticles)
   T.writeFile "_webwinkelverhuis-site/robots.txt" webwinkelverhuisRobotsTxt
 
 -- | File name for penguin paginated blog index
@@ -840,11 +842,6 @@ sitemapUrlDated loc modified =
 formatSitemapDate :: UTCTime -> Text
 formatSitemapDate = T.pack . formatTime defaultTimeLocale "%Y-%m-%d"
 
--- | Most recent known modification date for an article: the explicit modified
--- date when present, otherwise the original publication date.
-articleLastmod :: Article -> UTCTime
-articleLastmod article = fromMaybe (articleDate article) (articleModified article)
-
 -- | robots.txt for the penguin site, with sitemap reference.
 penguinRobotsTxt :: Text
 penguinRobotsTxt = T.unlines
@@ -853,25 +850,6 @@ penguinRobotsTxt = T.unlines
   , ""
   , "Sitemap: https://jappiesoftware.com/sitemap.xml"
   ]
-
--- | Sitemap for the webwinkelverhuis.nl site. Hand-written pages get a loc only
--- (we don't fabricate dates), while blog articles carry a real lastmod.
-generateWebwinkelverhuisSitemap :: [Article] -> Text
-generateWebwinkelverhuisSitemap articles = T.unlines $
-  [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-  , "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
-  , sitemapUrl "https://webwinkelverhuis.nl/"
-  , sitemapUrl "https://webwinkelverhuis.nl/prijzen.html"
-  , sitemapUrl "https://webwinkelverhuis.nl/scan.html"
-  , sitemapUrl "https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html"
-  , sitemapUrl "https://webwinkelverhuis.nl/migrate-ccvshop.html"
-  , sitemapUrl "https://webwinkelverhuis.nl/migrate-lightspeed.html"
-  , sitemapUrl "https://webwinkelverhuis.nl/waarom-mijnwebwinkel.html"
-  , sitemapUrl "https://webwinkelverhuis.nl/waarom-lightspeed.html"
-  , sitemapUrl "https://webwinkelverhuis.nl/blog/"
-  ]
-  ++ map (\art -> sitemapUrlDated ("https://webwinkelverhuis.nl/blog/" <> articleUrl art) (articleLastmod art)) articles
-  ++ ["</urlset>"]
 
 -- | robots.txt for the webwinkelverhuis.nl site.
 webwinkelverhuisRobotsTxt :: Text

--- a/shake/Types.hs
+++ b/shake/Types.hs
@@ -2,6 +2,7 @@
 module Types
   ( SiteConfig(..)
   , Article(..)
+  , articleLastmod
   , Page(..)
   , NavLink(..)
   , PaginationInfo(..)
@@ -15,6 +16,7 @@ module Types
   , webwinkelSiteConfig
   ) where
 
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Time (UTCTime)
 import Text.Blaze.Html (Html)
@@ -122,6 +124,11 @@ data Article = Article
   , articleFootnotesHtml :: Maybe Html  -- ^ Extracted footnotes section
   , articleUrl         :: Text
   }
+
+-- | The date an article last changed: the modified date when set,
+-- otherwise the publication date. Sitemaps and feeds advertise this.
+articleLastmod :: Article -> UTCTime
+articleLastmod article = fromMaybe (articleDate article) (articleModified article)
 
 data Page = Page
   { pageTitle    :: Text

--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -19,15 +19,19 @@ module WebwinkelTemplates
   , mijnwebwinkelWaaromPage
   , lightspeedWaaromPage
   , relativizeWebwinkelContentImages
+  , webwinkelverhuisSitemap
+  , webwinkelverhuisStaticPages
   ) where
 
 import Data.Text (Text)
+import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
+import Data.Time (Day, UTCTime(..), defaultTimeLocale, formatTime, fromGregorian)
 import Text.Blaze.Html5 (Html, (!))
 import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 
-import Types (SiteConfig(..), Article(..), PaginationInfo(..))
+import Types (SiteConfig(..), Article(..), PaginationInfo(..), articleLastmod)
 import PageChrome
   ( PageMeta(..)
   , defaultPageMeta
@@ -1587,3 +1591,72 @@ webwinkelArticlePage _config article =
       , pageMetaLang        = "nl"
       , pageMetaCanonical   = Just ("https://webwinkelverhuis.nl/blog/" <> articleUrl article)
       }
+
+-- | Generate sitemap.xml for webwinkelverhuis.nl. Every entry carries a
+-- lastmod: Google's recrawl prioritisation reads it, and without one on
+-- the static pages a copy rewrite stays invisible until the next
+-- organic crawl (the index stood at 4 of 15 pages on 2026-08-03 while
+-- the whole site had just been rewritten).
+webwinkelverhuisSitemap :: [Article] -> Text
+webwinkelverhuisSitemap articles = T.unlines $
+  [ "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+  , "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
+  ]
+  ++ map webwinkelStaticSitemapEntry webwinkelverhuisStaticPages
+  ++ [webwinkelBlogIndexSitemapEntry articles]
+  ++ map webwinkelArticleSitemapEntry articles
+  ++ ["</urlset>"]
+
+-- | The static pages with the day their copy last changed. Bump the day
+-- when editing a page's copy; the blog index and articles get their
+-- dates from the article metadata automatically. Current dates: the
+-- site-wide rewrite of 2/3 aug 2026 (scanner-pagina, CCV/MWW-copy,
+-- migratie-heroes, tagline).
+--
+-- Decision: hand-maintained lastmod days for the static pages,
+-- reversing the earlier "we don't fabricate dates" stance (which
+-- emitted the static entries dateless). Deriving dates from git at
+-- build time is not possible (nix builds from a gitignoreSource copy
+-- without .git), and dateless entries provably starved recrawl: on
+-- 2026-08-03 Google had indexed 4 of 15 pages with the newest crawl
+-- weeks old while the whole site had just been rewritten. The dates
+-- here are real copy-change days from git history, kept honest by the
+-- bump-on-edit rule above.
+webwinkelverhuisStaticPages :: [(Text, Day)]
+webwinkelverhuisStaticPages =
+  [ ("https://webwinkelverhuis.nl/", fromGregorian 2026 8 3)
+  , ("https://webwinkelverhuis.nl/prijzen.html", fromGregorian 2026 8 3)
+  , ("https://webwinkelverhuis.nl/scan.html", fromGregorian 2026 8 3)
+  , ("https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html", fromGregorian 2026 8 3)
+  , ("https://webwinkelverhuis.nl/migrate-ccvshop.html", fromGregorian 2026 8 3)
+  , ("https://webwinkelverhuis.nl/migrate-lightspeed.html", fromGregorian 2026 8 3)
+  , ("https://webwinkelverhuis.nl/waarom-mijnwebwinkel.html", fromGregorian 2026 8 2)
+  , ("https://webwinkelverhuis.nl/waarom-lightspeed.html", fromGregorian 2026 8 2)
+  ]
+
+webwinkelStaticSitemapEntry :: (Text, Day) -> Text
+webwinkelStaticSitemapEntry (url, changedOn) =
+  webwinkelSitemapLine url (UTCTime changedOn 0)
+
+-- | The blog index changes whenever an article is added or edited, so
+-- it advertises the newest article lastmod. An empty article list means
+-- a broken site build; crash loudly rather than emit a dateless entry.
+webwinkelBlogIndexSitemapEntry :: [Article] -> Text
+webwinkelBlogIndexSitemapEntry articles =
+  case articles of
+    [] -> error "webwinkelverhuis sitemap: blog index entry needs at least one article"
+    _oneOrMore ->
+      webwinkelSitemapLine "https://webwinkelverhuis.nl/blog/"
+        (maximum (map articleLastmod articles))
+
+webwinkelArticleSitemapEntry :: Article -> Text
+webwinkelArticleSitemapEntry article =
+  webwinkelSitemapLine
+    ("https://webwinkelverhuis.nl/blog/" <> articleUrl article)
+    (articleLastmod article)
+
+webwinkelSitemapLine :: Text -> UTCTime -> Text
+webwinkelSitemapLine url modified =
+  "  <url><loc>" <> url <> "</loc><lastmod>"
+    <> T.pack (formatTime defaultTimeLocale "%Y-%m-%d" modified)
+    <> "</lastmod></url>"

--- a/shake/test/Test.hs
+++ b/shake/test/Test.hs
@@ -18,6 +18,7 @@ module Main (main) where
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
+import Data.Time (UTCTime(..), fromGregorian)
 import Test.Tasty (TestTree, defaultMain, testGroup)
 import Test.Tasty.HUnit (assertBool, testCase)
 import Text.Blaze.Html (Html)
@@ -27,6 +28,7 @@ import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 
 import PageChrome (faqAnswerHtml, faqPageJsonLd, renderFaqItem)
+import Types (Article(..))
 import PenguinTemplates
   ( WebwinkelverhuisUrl(..)
   , penguinIndexPage
@@ -43,6 +45,8 @@ import WebwinkelTemplates
   , mijnwebwinkelWaaromPage
   , lightspeedWaaromPage
   , relativizeWebwinkelContentImages
+  , webwinkelverhuisSitemap
+  , webwinkelverhuisStaticPages
   )
 
 -- | A recognisable fake origin: it can only appear in the output when the
@@ -167,4 +171,62 @@ main = defaultMain $
         [relativizesImageSourcesOnly]
     , testGroup "FAQ answers carry markup into both surfaces"
         [faqAnswersCarryLinks]
+    , testGroup "webwinkelverhuis sitemap advertises lastmod"
+        [ everyStaticPageEntryIsDated
+        , blogIndexAdvertisesNewestArticleLastmod
+        , articleWithoutModifiedFallsBackToPublicationDate
+        ]
     ]
+
+-- | An article carrying only the fields the sitemap reads; the rest is
+-- inert filler.
+sitemapTestArticle :: Text -> UTCTime -> Maybe UTCTime -> Article
+sitemapTestArticle url published modified = Article
+  { articleTitle       = "test"
+  , articleSlug        = url
+  , articleCategory    = "test"
+  , articleDate        = published
+  , articleModified    = modified
+  , articleTags        = []
+  , articleContent     = mempty
+  , articleContentText = ""
+  , articleSummary     = Nothing
+  , articleSummaryText = Nothing
+  , articleFootnotesHtml = Nothing
+  , articleUrl         = url
+  }
+
+-- | The sitemap rendered from two articles: an old post that was
+-- recently edited (modified 2026-08-01) and a newer post never edited.
+sitemapUnderTest :: Text
+sitemapUnderTest = webwinkelverhuisSitemap
+  [ sitemapTestArticle "oud-maar-bijgewerkt.html"
+      (UTCTime (fromGregorian 2026 6 14) 0)
+      (Just (UTCTime (fromGregorian 2026 8 1) 0))
+  , sitemapTestArticle "nieuw-nooit-bijgewerkt.html"
+      (UTCTime (fromGregorian 2026 7 10) 0)
+      Nothing
+  ]
+
+everyStaticPageEntryIsDated :: TestTree
+everyStaticPageEntryIsDated = testCase "every static page entry carries a lastmod" $
+  mapM_
+    (\(url, _day) -> assertBool (T.unpack url <> " entry has no lastmod")
+      (("<loc>" <> url <> "</loc><lastmod>") `T.isInfixOf` sitemapUnderTest))
+    webwinkelverhuisStaticPages
+
+-- | The blog index date must be the newest lastmod over all articles,
+-- which here comes from a *modified* override on the oldest post: this
+-- fails both when the index ignores modified dates and when it picks
+-- the newest publication date instead of the maximum lastmod.
+blogIndexAdvertisesNewestArticleLastmod :: TestTree
+blogIndexAdvertisesNewestArticleLastmod = testCase "blog index carries the newest article lastmod" $
+  assertBool "blog/ entry does not advertise 2026-08-01"
+    ("<loc>https://webwinkelverhuis.nl/blog/</loc><lastmod>2026-08-01</lastmod>"
+      `T.isInfixOf` sitemapUnderTest)
+
+articleWithoutModifiedFallsBackToPublicationDate :: TestTree
+articleWithoutModifiedFallsBackToPublicationDate = testCase "article without modified uses its publication date" $
+  assertBool "never-edited article does not carry its publication date"
+    ("<loc>https://webwinkelverhuis.nl/blog/nieuw-nooit-bijgewerkt.html</loc><lastmod>2026-07-10</lastmod>"
+      `T.isInfixOf` sitemapUnderTest)


### PR DESCRIPTION
## Samenvatting
- Search Console stond 2026-08-03 op 4 van de 15 pagina's geindexeerd (nieuwste crawl 17 jul) terwijl de site in het weekend was herschreven; de statische sitemap-entries droegen geen lastmod, dus Google kreeg geen signaal dat er iets veranderd was.
- Elke sitemap-entry draagt nu een lastmod: statische pagina's uit een hand-bijgehouden tabel (bump-bij-edit; de Decision-comment legt vast waarom de eerdere geen-datums-keuze omgaat en waarom git-datums in de nix-build niet kunnen), de blogindex de nieuwste artikel-lastmod, artikelen hun eigen datum.
- Generatie verhuisd naar WebwinkelTemplates zodat de logica testbaar is; `articleLastmod` gedeeld via Types. Lege artikellijst crasht luid in plaats van een datumloze entry te maken.

## Test plan
- [x] Drie nieuwe unit tests: elke statische entry gedateerd, blogindex draagt het maximum van de artikel-lastmods (modified-override wint), artikel zonder modified valt terug op publicatiedatum
- [x] Volledige `nix-build .` groen: compile, unit tests, site-render en xmllint over de gegenereerde sitemap
- [x] Gegenereerde sitemap handmatig nagekeken: 15 entries, alle gedateerd (statisch 2/3 aug, blogindex 1 aug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)