### PR TITLE
Webwinkel: blogpost "Het miljard van Shopify"

### DIFF
--- a/shake/Shakefile.hs
+++ b/shake/Shakefile.hs
@@ -53,7 +53,6 @@ import WebwinkelTemplates
   , lightspeedMigrationPage
   , mijnwebwinkelWaaromPage
   , lightspeedWaaromPage
-  , shopifyMiljardPage
   , relativizeWebwinkelContentImages
   , webwinkelverhuisSitemap
   )
@@ -729,7 +728,6 @@ generateWebwinkelverhuisSite config articles = do
   writeWebwinkelHtmlFile "_webwinkelverhuis-site/migrate-lightspeed.html" lightspeedMigrationPage
   writeWebwinkelHtmlFile "_webwinkelverhuis-site/waarom-mijnwebwinkel.html" mijnwebwinkelWaaromPage
   writeWebwinkelHtmlFile "_webwinkelverhuis-site/waarom-lightspeed.html" lightspeedWaaromPage
-  writeWebwinkelHtmlFile "_webwinkelverhuis-site/shopify-miljard.html" shopifyMiljardPage
 
   -- Individual blog article pages
   mapM_ (\art ->

--- a/shake/Shakefile.hs
+++ b/shake/Shakefile.hs
@@ -53,6 +53,7 @@ import WebwinkelTemplates
   , lightspeedMigrationPage
   , mijnwebwinkelWaaromPage
   , lightspeedWaaromPage
+  , shopifyMiljardPage
   , relativizeWebwinkelContentImages
   , webwinkelverhuisSitemap
   )
@@ -728,6 +729,7 @@ generateWebwinkelverhuisSite config articles = do
   writeWebwinkelHtmlFile "_webwinkelverhuis-site/migrate-lightspeed.html" lightspeedMigrationPage
   writeWebwinkelHtmlFile "_webwinkelverhuis-site/waarom-mijnwebwinkel.html" mijnwebwinkelWaaromPage
   writeWebwinkelHtmlFile "_webwinkelverhuis-site/waarom-lightspeed.html" lightspeedWaaromPage
+  writeWebwinkelHtmlFile "_webwinkelverhuis-site/shopify-miljard.html" shopifyMiljardPage
 
   -- Individual blog article pages
   mapM_ (\art ->

--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -18,6 +18,7 @@ module WebwinkelTemplates
   , lightspeedMigrationPage
   , mijnwebwinkelWaaromPage
   , lightspeedWaaromPage
+  , shopifyMiljardPage
   , relativizeWebwinkelContentImages
   , webwinkelverhuisSitemap
   , webwinkelverhuisStaticPages
@@ -875,6 +876,9 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $ do
           H.p $ do
             H.a ! A.href "/waarom-mijnwebwinkel.html" $ "Waarom wordt MijnWebwinkel niet meer doorontwikkeld?"
             H.preEscapedToHtml (" &rarr;" :: Text)
+          H.p $ do
+            H.a ! A.href "/shopify-miljard.html" $ "Het miljard van Shopify: waarom geen Nederlands platform kan bijbenen"
+            H.preEscapedToHtml (" &rarr;" :: Text)
       H.p $ H.preEscapedToHtml ("Wij zijn migratie-specialisten, geen verlengstuk van &eacute;&eacute;n platform. U kiest het platform: Shopify, WooCommerce, of iets anders. Wij regelen de techniek." :: Text)
       H.ul $ do
         H.li $ H.strong "Geen risico" >> ": u betaalt pas na succesvolle migratie"
@@ -1049,6 +1053,9 @@ ccvshopMigrationPage = webwinkelBaseTemplate ccvMeta $
       -- bestemming is een custom cart, 13 van 28), dus de pagina spreekt
       -- ambitie aan in plaats van angst.
       H.p $ H.preEscapedToHtml ("De meeste winkeliers verlaten CCV Shop niet omdat het kapot is, maar omdat ze eruit groeien: maatwerk of functies die er niet in zitten. Shopify en WooCommerce groeien w&eacute;l met u mee, van extra verkoopkanalen en talen tot B2B-maatwerk en duizenden apps. En het lastigste deel van uitgroeien, alles heelhuids overzetten, is precies ons vak." :: Text)
+      H.p $ do
+        H.a ! A.href "/shopify-miljard.html" $ "Het miljard van Shopify: waarom geen Nederlands platform kan bijbenen"
+        H.preEscapedToHtml (" &rarr;" :: Text)
       H.p $ H.preEscapedToHtml ("Wij zijn migratie-specialisten, geen verlengstuk van &eacute;&eacute;n platform. U kiest het platform: Shopify, WooCommerce, of iets anders. Wij regelen de techniek." :: Text)
       H.ul $ do
         H.li $ H.strong "Geen risico" >> H.preEscapedToHtml (": u betaalt pas na succesvolle migratie" :: Text)
@@ -1546,6 +1553,139 @@ lightspeedWaaromFaq =
   ]
 
 -- =============================================================================
+-- Shopify R&D article page: het miljard dat het verschil maakt
+-- =============================================================================
+
+-- Decision: de cijfers en claims op deze pagina komen uit
+-- jappiesoft/research/ccv-woocommerce-market-onderzoek.org, sectie
+-- "Shopify R&D per jaar" (3 aug 2026): de R&D-reeks is per jaar
+-- gecheckt via de SEC XBRL-API. De per-werkdag-vergelijking staat er
+-- hard in; de themateam-vergelijking alleen gehedged, want Shopify
+-- publiceert geen teamgroottes. Toon volgt de aanzet-notitie: geen
+-- verwijt aan de NL-platformen, het is een budgetverschil, geen
+-- karakterverschil.
+shopifyMiljardPage :: Html
+shopifyMiljardPage = webwinkelBaseTemplate miljardMeta $
+  H.main $ do
+    -- Hero
+    H.section ! A.class_ "hero" $ do
+      H.h1 "Het miljard van Shopify"
+      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Shopify gaf in 2025 ruim anderhalf miljard dollar uit aan productontwikkeling. Nederlandse webshopplatformen zijn niet lui of onkundig; ze spelen een spel waarin de tegenstander per werkdag meer uitgeeft dan zij in een jaar kunnen. Dit is wat dat geld oplevert, jaar voor jaar." :: Text)
+
+    -- Timeline
+    H.section ! A.class_ "for-who" $ do
+      H.h2 "Wat Shopify per jaar uitgeeft, en wat u daarvan terugziet"
+      H.p $ H.preEscapedToHtml ("De bedragen komen rechtstreeks uit de jaarrekeningen die Shopify bij de Amerikaanse beurswaakhond SEC deponeert." :: Text)
+      H.ol $ do
+        H.li $ do
+          H.strong "2019"
+          H.preEscapedToHtml (": $355 miljoen. De basislijn van v&oacute;&oacute;r corona, toen al een veelvoud van wat de hele Nederlandse platformsector uitgaf." :: Text)
+        H.li $ do
+          H.strong "2020"
+          H.preEscapedToHtml (": $552 miljoen. De coronagolf: de Shop-app, een volledig vernieuwd kassasysteem en de uitbouw van Shop Pay." :: Text)
+        H.li $ do
+          H.strong "2021"
+          H.preEscapedToHtml (": $854 miljoen. Het jaar van het winkelfundament: " :: Text)
+          H.a ! A.href "https://www.shopify.com/partners/blog/shopify-unite-announcements-2021" $ "Online Store 2.0"
+          H.preEscapedToHtml (" met secties op elke pagina, en " :: Text)
+          H.a ! A.href "https://www.shopify.com/blog/dawn-shopify-theme" $ "Dawn"
+          H.preEscapedToHtml (" als gratis referentiethema, zo&apos;n 35% sneller dan zijn voorganger. Dit ene jaar is de reden dat een standaard Shopify-thema er moderner uitziet dan wat Nederlandse platformen leveren." :: Text)
+        H.li $ do
+          H.strong "2022"
+          H.preEscapedToHtml (": $1.503 miljoen. De expansiepiek: de grootste overname ooit (" :: Text)
+          H.a ! A.href "https://techcrunch.com/2022/05/05/shopify-acquires-shipping-logistics-startup-deliverr-for-2-1b/" $ "logistiekbedrijf Deliverr, $2,1 miljard"
+          H.preEscapedToHtml ("), headless bouwen met Hydrogen, een opengebroken checkout en B2B-verkoop." :: Text)
+        H.li $ do
+          H.strong "2023"
+          H.preEscapedToHtml (": $1.730 miljoen, het hoogste bedrag ooit. En toch het jaar van de koerswending: " :: Text)
+          H.a ! A.href "https://www.shopify.com/news/shopify-completes-sale-of-shopify-logistics-to-flexport" $ "de logistiek ging de deur uit"
+          H.preEscapedToHtml (", alle aandacht terug naar de webshop zelf. " :: Text)
+          H.a ! A.href "https://www.shopify.com/editions/summer2023" $ "Editions Summer &apos;23"
+          H.preEscapedToHtml (" introduceerde de AI-lijn: Shopify Magic en assistent Sidekick." :: Text)
+        H.li $ do
+          H.strong "2024"
+          H.preEscapedToHtml (": $1.367 miljoen. Op papier een dip (nasleep van de reorganisatie), in de praktijk niet: de cadans van ruim honderd nieuwe functies per half jaar liep gewoon door." :: Text)
+        H.li $ do
+          H.strong "2025"
+          H.preEscapedToHtml (": $1.536 miljoen, weer stijgend. En opnieuw een complete themageneratie: " :: Text)
+          H.a ! A.href "https://www.shopify.com/news/summer-25-edition-design" $ "Horizon"
+          H.preEscapedToHtml (", tien gratis thema&apos;s op een nieuw fundament met een AI-blokgenerator. Dawn, in 2021 nog het modernste gratis thema ter wereld, is daarmee alweer de vorige generatie. Het loopt alsnog jaren voor op de Nederlandse standaardthema&apos;s." :: Text)
+
+    -- The numbers
+    H.section ! A.class_ "for-who" $ do
+      H.h2 "De cijfers"
+      H.ul ! A.class_ "card-grid" $ do
+        H.li ! A.class_ "card" $ do
+          H.h3 "$6 miljoen"
+          H.p $ H.preEscapedToHtml ("Per werkdag. Dat is wat Shopify in 2025 dagelijks aan productontwikkeling uitgaf: meer per dag dan een Nederlands nicheplatform redelijkerwijs per jaar kan besteden." :: Text)
+        H.li ! A.class_ "card" $ do
+          H.h3 "2 generaties"
+          H.p $ H.preEscapedToHtml ("Complete themageneraties in vier jaar: Dawn (2021) en Horizon (2025). De standaardthema&apos;s van MijnWebwinkel en CCV Shop stammen van daarv&oacute;&oacute;r, en staan stil." :: Text)
+        H.li ! A.class_ "card" $ do
+          H.h3 "100+"
+          H.p $ H.preEscapedToHtml ("Nieuwe functies per half jaar, elk half jaar opnieuw, gebundeld in de Editions-releases." :: Text)
+        H.li ! A.class_ "card" $ do
+          H.h3 "$7,9 miljard"
+          H.p $ H.preEscapedToHtml ("Opgeteld aan productontwikkeling sinds 2019. E&eacute;n platform, zeven jaar." :: Text)
+
+    -- What this means for Dutch platforms
+    H.section ! A.class_ "audit" $ do
+      H.h2 "Waarom Nederlandse platformen dit niet kunnen bijbenen"
+      H.p $ H.preEscapedToHtml ("Dit is geen verwijt aan MijnWebwinkel of CCV Shop. Achter die platformen zitten kleine teams; CCV Shop B.V. telt in zijn geheel enkele tientallen medewerkers, en het themateam dat bij Shopify aan Dawn en Horizon bouwt is vermoedelijk in zijn eentje al groter. Wie een paar miljoen per jaar kan uitgeven, kan geen wedstrijd winnen van iemand die per werkdag zes miljoen uitgeeft. Het is geen kwestie van niet willen; meedoen is simpelweg geen optie." :: Text)
+      H.p $ H.preEscapedToHtml ("Het gevolg ziet u in uw eigen shop: thema&apos;s die al jaren dezelfde zijn, functies die maar niet komen, en een kloof die elk half jaar met ruim honderd functies groeit. Waarom dat bij MijnWebwinkel zo gelopen is leest u in " :: Text)
+      H.a ! A.href "/waarom-mijnwebwinkel.html" $ "ons artikel over MijnWebwinkel"
+      "."
+
+    -- What this means for your shop
+    H.section ! A.class_ "results" $ do
+      H.h2 "Wat betekent dit voor uw shop?"
+      H.p $ H.preEscapedToHtml ("Dat de overstap meestal groter voelt dan hij is: draait uw shop op een standaardthema van MijnWebwinkel of CCV Shop, dan is alleen al het standaardthema van uw nieuwe platform doorgaans een zichtbare opknapbeurt. U lift vanaf dag &eacute;&eacute;n mee op dat miljard per jaar, en elke Editions-release daarna is er ook voor uw shop." :: Text)
+      H.p $ do
+        H.a ! A.href "/migrate-mijnwebwinkel.html" $ "Migratie vanaf MijnWebwinkel"
+        H.preEscapedToHtml (" of " :: Text)
+        H.a ! A.href "/migrate-ccvshop.html" $ "migratie vanaf CCV Shop"
+        H.preEscapedToHtml (": volledig geautomatiseerd, vaste prijs, betaling na succes." :: Text)
+
+    -- Sources
+    H.section ! A.class_ "about" $ do
+      H.h2 "Bronnen"
+      H.ul $ do
+        H.li $ do
+          H.a ! A.href "https://data.sec.gov/api/xbrl/companyconcept/CIK0001594805/us-gaap/ResearchAndDevelopmentExpense.json" $ "SEC XBRL: Shopify Research and Development Expense per jaar"
+          " (jaarrekeningen 2019-2025)"
+        H.li $ do
+          H.a ! A.href "https://www.shopify.com/partners/blog/shopify-unite-announcements-2021" $ "Shopify Unite 2021: Online Store 2.0"
+          " (juni 2021)"
+        H.li $ do
+          H.a ! A.href "https://techcrunch.com/2022/05/05/shopify-acquires-shipping-logistics-startup-deliverr-for-2-1b/" $ "TechCrunch: Shopify koopt Deliverr voor $2,1 miljard"
+          " (mei 2022)"
+        H.li $ do
+          H.a ! A.href "https://www.shopify.com/news/shopify-completes-sale-of-shopify-logistics-to-flexport" $ "Shopify: verkoop logistiek aan Flexport afgerond"
+          " (2023)"
+        H.li $ do
+          H.a ! A.href "https://www.shopify.com/editions/summer2023" $ "Shopify Editions Summer '23: Magic en Sidekick"
+        H.li $ do
+          H.a ! A.href "https://www.shopify.com/news/summer-25-edition-design" $ "Shopify Summer Editions '25: Horizon"
+          " (mei 2025)"
+
+    -- CTA
+    H.section ! A.class_ "final-cta" $ do
+      H.h2 "Meeliften in plaats van bijbenen?"
+      H.p $ H.preEscapedToHtml ("Uw platform gaat dit gat niet meer dichten. U kunt wachten tot het verschil nog groter is, of overstappen naar het platform waar dat miljard per jaar heengaat." :: Text)
+      H.a ! A.href meetLink ! A.class_ "cta-button" $ "Plan een gratis gesprek"
+  where
+    miljardMeta :: PageMeta
+    miljardMeta = PageMeta
+      { pageMetaTitle       = "Het miljard van Shopify \8212 waarom Nederlandse platformen niet kunnen bijbenen \8212 Webwinkelverhuis"
+      , pageMetaDescription = "Shopify gaf in 2025 ruim $1,5 miljard uit aan productontwikkeling, meer per werkdag dan een Nederlands webshopplatform per jaar kan besteden. De cijfers per jaar, uit de SEC-jaarrekeningen, en wat dat voor uw shop betekent."
+      , pageMetaLang        = "nl"
+      , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/shopify-miljard.html"
+      , pageMetaOgImage     = Nothing
+      , pageMetaSwitchUrl   = Nothing
+      , pageMetaExtraHead   = mempty
+      }
+
+-- =============================================================================
 -- Blog index page (paginated listing)
 -- =============================================================================
 
@@ -1642,6 +1782,7 @@ webwinkelverhuisStaticPages =
   , ("https://webwinkelverhuis.nl/migrate-lightspeed.html", fromGregorian 2026 8 3)
   , ("https://webwinkelverhuis.nl/waarom-mijnwebwinkel.html", fromGregorian 2026 8 2)
   , ("https://webwinkelverhuis.nl/waarom-lightspeed.html", fromGregorian 2026 8 2)
+  , ("https://webwinkelverhuis.nl/shopify-miljard.html", fromGregorian 2026 8 3)
   ]
 
 webwinkelStaticSitemapEntry :: (Text, Day) -> Text

--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -18,7 +18,6 @@ module WebwinkelTemplates
   , lightspeedMigrationPage
   , mijnwebwinkelWaaromPage
   , lightspeedWaaromPage
-  , shopifyMiljardPage
   , relativizeWebwinkelContentImages
   , webwinkelverhuisSitemap
   , webwinkelverhuisStaticPages
@@ -877,7 +876,7 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $ do
             H.a ! A.href "/waarom-mijnwebwinkel.html" $ "Waarom wordt MijnWebwinkel niet meer doorontwikkeld?"
             H.preEscapedToHtml (" &rarr;" :: Text)
           H.p $ do
-            H.a ! A.href "/shopify-miljard.html" $ "Het miljard van Shopify: waarom geen Nederlands platform kan bijbenen"
+            H.a ! A.href "/blog/het-miljard-van-shopify-waarom-geen-nederlands-platform-kan-bijbenen.html" $ "Het miljard van Shopify: waarom geen Nederlands platform kan bijbenen"
             H.preEscapedToHtml (" &rarr;" :: Text)
       H.p $ H.preEscapedToHtml ("Wij zijn migratie-specialisten, geen verlengstuk van &eacute;&eacute;n platform. U kiest het platform: Shopify, WooCommerce, of iets anders. Wij regelen de techniek." :: Text)
       H.ul $ do
@@ -923,11 +922,6 @@ mijnwebwinkelFaq :: [(FaqQuestion, FaqAnswer)]
 mijnwebwinkelFaq =
   [ ( "Hoe lang duurt een migratie?"
     , faqAnswerText "Het technische overzetten van uw producten duurt maar enkele uren. Maar er komt bij een verhuizing meestal meer kijken: het thema, betaalmethoden, eventuele koppelingen, en rustig wennen aan uw nieuwe shop. Reken daarom op ongeveer een maand van start tot livegang." )
-  , ( "Wordt mijn shop er ook mooier van?"
-    , faqAnswerHtml $ do
-        "Meestal wel. De standaardthema's van MijnWebwinkel zijn al jaren niet doorontwikkeld, terwijl Shopify en WooCommerce hun standaardthema's actief bijhouden. Draait uw shop op zo'n standaardthema, dan oogt alleen al de overstap vaak als een opknapbeurt. Wilt u uw vertrouwde uitstraling houden, kies dan uitstraling overzetten in "
-        H.a ! A.href "/prijzen.html#rekenhulp" $ "de rekenhulp"
-        ": wij bouwen die na op het moderne thema-fundament van uw nieuwe platform, en ook dat verbetert de uitstraling van uw shop vrijwel altijd zichtbaar." )
   , ( "Wat gebeurt er met bestellingen tijdens de verhuizing?"
     , faqAnswerHtml $ do
         "Uw MijnWebwinkel-shop blijft gewoon open en verkoopt door terwijl wij de nieuwe shop opbouwen. Vlak voor de livegang zetten we de laatste stand over, zodat ook recente bestellingen en actuele voorraadaantallen meekomen. Bestelgeschiedenis en voorraad kiest u als optie in "
@@ -1054,7 +1048,7 @@ ccvshopMigrationPage = webwinkelBaseTemplate ccvMeta $
       -- ambitie aan in plaats van angst.
       H.p $ H.preEscapedToHtml ("De meeste winkeliers verlaten CCV Shop niet omdat het kapot is, maar omdat ze eruit groeien: maatwerk of functies die er niet in zitten. Shopify en WooCommerce groeien w&eacute;l met u mee, van extra verkoopkanalen en talen tot B2B-maatwerk en duizenden apps. En het lastigste deel van uitgroeien, alles heelhuids overzetten, is precies ons vak." :: Text)
       H.p $ do
-        H.a ! A.href "/shopify-miljard.html" $ "Het miljard van Shopify: waarom geen Nederlands platform kan bijbenen"
+        H.a ! A.href "/blog/het-miljard-van-shopify-waarom-geen-nederlands-platform-kan-bijbenen.html" $ "Het miljard van Shopify: waarom geen Nederlands platform kan bijbenen"
         H.preEscapedToHtml (" &rarr;" :: Text)
       H.p $ H.preEscapedToHtml ("Wij zijn migratie-specialisten, geen verlengstuk van &eacute;&eacute;n platform. U kiest het platform: Shopify, WooCommerce, of iets anders. Wij regelen de techniek." :: Text)
       H.ul $ do
@@ -1122,11 +1116,6 @@ ccvshopFaq :: [(FaqQuestion, FaqAnswer)]
 ccvshopFaq =
   [ ( "Hoe lang duurt een migratie?"
     , faqAnswerText "Het technische overzetten van uw producten duurt maar enkele uren. Maar er komt bij een verhuizing meestal meer kijken: het thema, apps en plugins, betaalmethoden, en rustig wennen aan uw nieuwe shop. Reken daarom op ongeveer een maand van start tot livegang." )
-  , ( "Wordt mijn shop er ook mooier van?"
-    , faqAnswerHtml $ do
-        "Meestal wel. De thema's van CCV Shop staan al jaren stil, terwijl Shopify en WooCommerce hun standaardthema's actief bijhouden. Draait uw shop op een ouder standaardthema, dan oogt alleen al de overstap vaak als een opknapbeurt. Wilt u uw vertrouwde uitstraling houden, kies dan uitstraling overzetten in "
-        H.a ! A.href "/prijzen.html#rekenhulp" $ "de rekenhulp"
-        ": wij bouwen die na op het moderne thema-fundament van uw nieuwe platform, en ook dat verbetert de uitstraling van uw shop vrijwel altijd zichtbaar." )
   , ( "Kan ik mijn domeinnaam behouden?"
     , faqAnswerText "Ja. Na de migratie wijst u uw domein naar Shopify. Alle oude URLs worden automatisch doorgestuurd." )
   , ( "Wat als er iets niet klopt na de migratie?"
@@ -1553,139 +1542,6 @@ lightspeedWaaromFaq =
   ]
 
 -- =============================================================================
--- Shopify R&D article page: het miljard dat het verschil maakt
--- =============================================================================
-
--- Decision: de cijfers en claims op deze pagina komen uit
--- jappiesoft/research/ccv-woocommerce-market-onderzoek.org, sectie
--- "Shopify R&D per jaar" (3 aug 2026): de R&D-reeks is per jaar
--- gecheckt via de SEC XBRL-API. De per-werkdag-vergelijking staat er
--- hard in; de themateam-vergelijking alleen gehedged, want Shopify
--- publiceert geen teamgroottes. Toon volgt de aanzet-notitie: geen
--- verwijt aan de NL-platformen, het is een budgetverschil, geen
--- karakterverschil.
-shopifyMiljardPage :: Html
-shopifyMiljardPage = webwinkelBaseTemplate miljardMeta $
-  H.main $ do
-    -- Hero
-    H.section ! A.class_ "hero" $ do
-      H.h1 "Het miljard van Shopify"
-      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Shopify gaf in 2025 ruim anderhalf miljard dollar uit aan productontwikkeling. Nederlandse webshopplatformen zijn niet lui of onkundig; ze spelen een spel waarin de tegenstander per werkdag meer uitgeeft dan zij in een jaar kunnen. Dit is wat dat geld oplevert, jaar voor jaar." :: Text)
-
-    -- Timeline
-    H.section ! A.class_ "for-who" $ do
-      H.h2 "Wat Shopify per jaar uitgeeft, en wat u daarvan terugziet"
-      H.p $ H.preEscapedToHtml ("De bedragen komen rechtstreeks uit de jaarrekeningen die Shopify bij de Amerikaanse beurswaakhond SEC deponeert." :: Text)
-      H.ol $ do
-        H.li $ do
-          H.strong "2019"
-          H.preEscapedToHtml (": $355 miljoen. De basislijn van v&oacute;&oacute;r corona, toen al een veelvoud van wat de hele Nederlandse platformsector uitgaf." :: Text)
-        H.li $ do
-          H.strong "2020"
-          H.preEscapedToHtml (": $552 miljoen. De coronagolf: de Shop-app, een volledig vernieuwd kassasysteem en de uitbouw van Shop Pay." :: Text)
-        H.li $ do
-          H.strong "2021"
-          H.preEscapedToHtml (": $854 miljoen. Het jaar van het winkelfundament: " :: Text)
-          H.a ! A.href "https://www.shopify.com/partners/blog/shopify-unite-announcements-2021" $ "Online Store 2.0"
-          H.preEscapedToHtml (" met secties op elke pagina, en " :: Text)
-          H.a ! A.href "https://www.shopify.com/blog/dawn-shopify-theme" $ "Dawn"
-          H.preEscapedToHtml (" als gratis referentiethema, zo&apos;n 35% sneller dan zijn voorganger. Dit ene jaar is de reden dat een standaard Shopify-thema er moderner uitziet dan wat Nederlandse platformen leveren." :: Text)
-        H.li $ do
-          H.strong "2022"
-          H.preEscapedToHtml (": $1.503 miljoen. De expansiepiek: de grootste overname ooit (" :: Text)
-          H.a ! A.href "https://techcrunch.com/2022/05/05/shopify-acquires-shipping-logistics-startup-deliverr-for-2-1b/" $ "logistiekbedrijf Deliverr, $2,1 miljard"
-          H.preEscapedToHtml ("), headless bouwen met Hydrogen, een opengebroken checkout en B2B-verkoop." :: Text)
-        H.li $ do
-          H.strong "2023"
-          H.preEscapedToHtml (": $1.730 miljoen, het hoogste bedrag ooit. En toch het jaar van de koerswending: " :: Text)
-          H.a ! A.href "https://www.shopify.com/news/shopify-completes-sale-of-shopify-logistics-to-flexport" $ "de logistiek ging de deur uit"
-          H.preEscapedToHtml (", alle aandacht terug naar de webshop zelf. " :: Text)
-          H.a ! A.href "https://www.shopify.com/editions/summer2023" $ "Editions Summer &apos;23"
-          H.preEscapedToHtml (" introduceerde de AI-lijn: Shopify Magic en assistent Sidekick." :: Text)
-        H.li $ do
-          H.strong "2024"
-          H.preEscapedToHtml (": $1.367 miljoen. Op papier een dip (nasleep van de reorganisatie), in de praktijk niet: de cadans van ruim honderd nieuwe functies per half jaar liep gewoon door." :: Text)
-        H.li $ do
-          H.strong "2025"
-          H.preEscapedToHtml (": $1.536 miljoen, weer stijgend. En opnieuw een complete themageneratie: " :: Text)
-          H.a ! A.href "https://www.shopify.com/news/summer-25-edition-design" $ "Horizon"
-          H.preEscapedToHtml (", tien gratis thema&apos;s op een nieuw fundament met een AI-blokgenerator. Dawn, in 2021 nog het modernste gratis thema ter wereld, is daarmee alweer de vorige generatie. Het loopt alsnog jaren voor op de Nederlandse standaardthema&apos;s." :: Text)
-
-    -- The numbers
-    H.section ! A.class_ "for-who" $ do
-      H.h2 "De cijfers"
-      H.ul ! A.class_ "card-grid" $ do
-        H.li ! A.class_ "card" $ do
-          H.h3 "$6 miljoen"
-          H.p $ H.preEscapedToHtml ("Per werkdag. Dat is wat Shopify in 2025 dagelijks aan productontwikkeling uitgaf: meer per dag dan een Nederlands nicheplatform redelijkerwijs per jaar kan besteden." :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "2 generaties"
-          H.p $ H.preEscapedToHtml ("Complete themageneraties in vier jaar: Dawn (2021) en Horizon (2025). De standaardthema&apos;s van MijnWebwinkel en CCV Shop stammen van daarv&oacute;&oacute;r, en staan stil." :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "100+"
-          H.p $ H.preEscapedToHtml ("Nieuwe functies per half jaar, elk half jaar opnieuw, gebundeld in de Editions-releases." :: Text)
-        H.li ! A.class_ "card" $ do
-          H.h3 "$7,9 miljard"
-          H.p $ H.preEscapedToHtml ("Opgeteld aan productontwikkeling sinds 2019. E&eacute;n platform, zeven jaar." :: Text)
-
-    -- What this means for Dutch platforms
-    H.section ! A.class_ "audit" $ do
-      H.h2 "Waarom Nederlandse platformen dit niet kunnen bijbenen"
-      H.p $ H.preEscapedToHtml ("Dit is geen verwijt aan MijnWebwinkel of CCV Shop. Achter die platformen zitten kleine teams; CCV Shop B.V. telt in zijn geheel enkele tientallen medewerkers, en het themateam dat bij Shopify aan Dawn en Horizon bouwt is vermoedelijk in zijn eentje al groter. Wie een paar miljoen per jaar kan uitgeven, kan geen wedstrijd winnen van iemand die per werkdag zes miljoen uitgeeft. Het is geen kwestie van niet willen; meedoen is simpelweg geen optie." :: Text)
-      H.p $ H.preEscapedToHtml ("Het gevolg ziet u in uw eigen shop: thema&apos;s die al jaren dezelfde zijn, functies die maar niet komen, en een kloof die elk half jaar met ruim honderd functies groeit. Waarom dat bij MijnWebwinkel zo gelopen is leest u in " :: Text)
-      H.a ! A.href "/waarom-mijnwebwinkel.html" $ "ons artikel over MijnWebwinkel"
-      "."
-
-    -- What this means for your shop
-    H.section ! A.class_ "results" $ do
-      H.h2 "Wat betekent dit voor uw shop?"
-      H.p $ H.preEscapedToHtml ("Dat de overstap meestal groter voelt dan hij is: draait uw shop op een standaardthema van MijnWebwinkel of CCV Shop, dan is alleen al het standaardthema van uw nieuwe platform doorgaans een zichtbare opknapbeurt. U lift vanaf dag &eacute;&eacute;n mee op dat miljard per jaar, en elke Editions-release daarna is er ook voor uw shop." :: Text)
-      H.p $ do
-        H.a ! A.href "/migrate-mijnwebwinkel.html" $ "Migratie vanaf MijnWebwinkel"
-        H.preEscapedToHtml (" of " :: Text)
-        H.a ! A.href "/migrate-ccvshop.html" $ "migratie vanaf CCV Shop"
-        H.preEscapedToHtml (": volledig geautomatiseerd, vaste prijs, betaling na succes." :: Text)
-
-    -- Sources
-    H.section ! A.class_ "about" $ do
-      H.h2 "Bronnen"
-      H.ul $ do
-        H.li $ do
-          H.a ! A.href "https://data.sec.gov/api/xbrl/companyconcept/CIK0001594805/us-gaap/ResearchAndDevelopmentExpense.json" $ "SEC XBRL: Shopify Research and Development Expense per jaar"
-          " (jaarrekeningen 2019-2025)"
-        H.li $ do
-          H.a ! A.href "https://www.shopify.com/partners/blog/shopify-unite-announcements-2021" $ "Shopify Unite 2021: Online Store 2.0"
-          " (juni 2021)"
-        H.li $ do
-          H.a ! A.href "https://techcrunch.com/2022/05/05/shopify-acquires-shipping-logistics-startup-deliverr-for-2-1b/" $ "TechCrunch: Shopify koopt Deliverr voor $2,1 miljard"
-          " (mei 2022)"
-        H.li $ do
-          H.a ! A.href "https://www.shopify.com/news/shopify-completes-sale-of-shopify-logistics-to-flexport" $ "Shopify: verkoop logistiek aan Flexport afgerond"
-          " (2023)"
-        H.li $ do
-          H.a ! A.href "https://www.shopify.com/editions/summer2023" $ "Shopify Editions Summer '23: Magic en Sidekick"
-        H.li $ do
-          H.a ! A.href "https://www.shopify.com/news/summer-25-edition-design" $ "Shopify Summer Editions '25: Horizon"
-          " (mei 2025)"
-
-    -- CTA
-    H.section ! A.class_ "final-cta" $ do
-      H.h2 "Meeliften in plaats van bijbenen?"
-      H.p $ H.preEscapedToHtml ("Uw platform gaat dit gat niet meer dichten. U kunt wachten tot het verschil nog groter is, of overstappen naar het platform waar dat miljard per jaar heengaat." :: Text)
-      H.a ! A.href meetLink ! A.class_ "cta-button" $ "Plan een gratis gesprek"
-  where
-    miljardMeta :: PageMeta
-    miljardMeta = PageMeta
-      { pageMetaTitle       = "Het miljard van Shopify \8212 waarom Nederlandse platformen niet kunnen bijbenen \8212 Webwinkelverhuis"
-      , pageMetaDescription = "Shopify gaf in 2025 ruim $1,5 miljard uit aan productontwikkeling, meer per werkdag dan een Nederlands webshopplatform per jaar kan besteden. De cijfers per jaar, uit de SEC-jaarrekeningen, en wat dat voor uw shop betekent."
-      , pageMetaLang        = "nl"
-      , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/shopify-miljard.html"
-      , pageMetaOgImage     = Nothing
-      , pageMetaSwitchUrl   = Nothing
-      , pageMetaExtraHead   = mempty
-      }
-
--- =============================================================================
 -- Blog index page (paginated listing)
 -- =============================================================================
 
@@ -1782,7 +1638,6 @@ webwinkelverhuisStaticPages =
   , ("https://webwinkelverhuis.nl/migrate-lightspeed.html", fromGregorian 2026 8 3)
   , ("https://webwinkelverhuis.nl/waarom-mijnwebwinkel.html", fromGregorian 2026 8 2)
   , ("https://webwinkelverhuis.nl/waarom-lightspeed.html", fromGregorian 2026 8 2)
-  , ("https://webwinkelverhuis.nl/shopify-miljard.html", fromGregorian 2026 8 3)
   ]
 
 webwinkelStaticSitemapEntry :: (Text, Day) -> Text

--- a/webwinkel/content/shopify-miljard.org
+++ b/webwinkel/content/shopify-miljard.org
@@ -1,0 +1,106 @@
+#+TITLE: Het miljard van Shopify: waarom geen Nederlands platform kan bijbenen
+#+DATE: 2026-08-03
+#+CATEGORY: shopify
+#+TAGS: shopify, ccv, mijnwebwinkel, achtergrond
+
+Shopify gaf in 2025 ruim anderhalf miljard dollar uit aan
+productontwikkeling. Nederlandse webshopplatformen zijn niet lui of
+onkundig; ze spelen een spel waarin de tegenstander per werkdag meer
+uitgeeft dan zij in een jaar kunnen. Dit is wat dat geld oplevert,
+jaar voor jaar, en wat het betekent voor uw shop.
+
+* Wat Shopify per jaar uitgeeft
+
+De bedragen komen rechtstreeks uit de jaarrekeningen die Shopify bij
+de Amerikaanse beurswaakhond SEC deponeert (bronnen onderaan).
+
+| jaar | uitgave aan productontwikkeling |
+|------+---------------------------------|
+| 2019 | $355 miljoen                    |
+| 2020 | $552 miljoen                    |
+| 2021 | $854 miljoen                    |
+| 2022 | $1.503 miljoen                  |
+| 2023 | $1.730 miljoen                  |
+| 2024 | $1.367 miljoen                  |
+| 2025 | $1.536 miljoen                  |
+
+Opgeteld: $7,9 miljard in zeven jaar. Eén platform.
+
+* Waar dat geld heenging, en wat u ervan terugziet
+
+In 2020 verwerkte het platform de coronagolf: de Shop-app, een
+volledig vernieuwd kassasysteem en de uitbouw van Shop Pay.
+
+2021 was het jaar van het winkelfundament:
+[[https://www.shopify.com/partners/blog/shopify-unite-announcements-2021][Online Store 2.0]]
+met secties op elke pagina, en
+[[https://www.shopify.com/blog/dawn-shopify-theme][Dawn]] als gratis
+referentiethema, zo'n 35% sneller dan zijn voorganger. Dit ene jaar
+is de reden dat een standaard Shopify-thema er moderner uitziet dan
+wat Nederlandse platformen leveren.
+
+2022 was de expansiepiek: de grootste overname ooit
+([[https://techcrunch.com/2022/05/05/shopify-acquires-shipping-logistics-startup-deliverr-for-2-1b/][logistiekbedrijf Deliverr, $2,1 miljard]]),
+headless bouwen met Hydrogen, een opengebroken checkout en
+B2B-verkoop.
+
+2023 bracht het hoogste bedrag ooit, en toch de koerswending:
+[[https://www.shopify.com/news/shopify-completes-sale-of-shopify-logistics-to-flexport][de logistiek ging de deur uit]],
+alle aandacht terug naar de webshop zelf.
+[[https://www.shopify.com/editions/summer2023][Editions Summer '23]]
+introduceerde de AI-lijn: Shopify Magic en assistent Sidekick.
+
+2024 lijkt op papier een dip (de nasleep van een reorganisatie),
+maar de cadans van ruim honderd nieuwe functies per half jaar liep
+gewoon door.
+
+En in 2025 steeg het budget weer, met opnieuw een complete
+themageneratie als zichtbaarste resultaat:
+[[https://www.shopify.com/news/summer-25-edition-design][Horizon]],
+tien gratis thema's op een nieuw fundament met een AI-blokgenerator.
+Dawn, in 2021 nog het modernste gratis thema ter wereld, is daarmee
+alweer de vorige generatie. Het loopt alsnog jaren voor op de
+Nederlandse standaardthema's.
+
+* De rekensom die alles zegt
+
+Deel $1.536 miljoen door ongeveer 250 werkdagen en u komt op ruim
+$6 miljoen per werkdag. Dat is meer per dag dan een Nederlands
+nicheplatform redelijkerwijs per jaar aan ontwikkeling kan besteden.
+
+Dit is geen verwijt aan MijnWebwinkel of CCV Shop. Achter die
+platformen zitten kleine teams; CCV Shop B.V. telt in zijn geheel
+enkele tientallen medewerkers, en het themateam dat bij Shopify aan
+Dawn en Horizon bouwt is vermoedelijk in zijn eentje al groter. Wie
+een paar miljoen per jaar kan uitgeven, kan geen wedstrijd winnen van
+iemand die per werkdag zes miljoen uitgeeft. Het is geen kwestie van
+niet willen; meedoen is simpelweg geen optie.
+
+Het gevolg ziet u in uw eigen shop: thema's die al jaren dezelfde
+zijn, functies die maar niet komen, en een kloof die elk half jaar
+met ruim honderd functies groeit. Waarom dat bij MijnWebwinkel zo
+gelopen is leest u in
+[[https://webwinkelverhuis.nl/waarom-mijnwebwinkel.html][ons artikel over MijnWebwinkel]].
+
+* Wat betekent dit voor uw shop?
+
+Dat de overstap meestal groter voelt dan hij is: draait uw shop op
+een standaardthema van MijnWebwinkel of CCV Shop, dan is alleen al
+het standaardthema van uw nieuwe platform doorgaans een zichtbare
+opknapbeurt. U lift vanaf dag één mee op dat miljard per jaar, en
+elke Editions-release daarna is er ook voor uw shop.
+
+Overweegt u de overstap? Bekijk onze
+[[https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html][migratie vanaf MijnWebwinkel]]
+of
+[[https://webwinkelverhuis.nl/migrate-ccvshop.html][migratie vanaf CCV Shop]]:
+volledig geautomatiseerd, vaste prijs, betaling na succes.
+
+* Bronnen
+
+- [[https://data.sec.gov/api/xbrl/companyconcept/CIK0001594805/us-gaap/ResearchAndDevelopmentExpense.json][SEC XBRL: Shopify Research and Development Expense per jaar]] (jaarrekeningen 2019-2025)
+- [[https://www.shopify.com/partners/blog/shopify-unite-announcements-2021][Shopify Unite 2021: Online Store 2.0]] (juni 2021)
+- [[https://techcrunch.com/2022/05/05/shopify-acquires-shipping-logistics-startup-deliverr-for-2-1b/][TechCrunch: Shopify koopt Deliverr voor $2,1 miljard]] (mei 2022)
+- [[https://www.shopify.com/news/shopify-completes-sale-of-shopify-logistics-to-flexport][Shopify: verkoop logistiek aan Flexport afgerond]] (2023)
+- [[https://www.shopify.com/editions/summer2023][Shopify Editions Summer '23: Magic en Sidekick]]
+- [[https://www.shopify.com/news/summer-25-edition-design][Shopify Summer Editions '25: Horizon]] (mei 2025)


### PR DESCRIPTION
Blogpost over Shopify's R&D-uitgaven en waarom geen Nederlands platform dat spel kan meespelen, op /blog/het-miljard-van-shopify-waarom-geen-nederlands-platform-kan-bijbenen.html. Bronbasis: de research-sectie in jappiesoft PR #166 (reeks per jaar gecheckt via de SEC XBRL-API).

De eerste commit zette dit als vaste pagina neer; op Jappies aanwijzing is dat in de tweede commit omgebouwd naar een blogpost (webwinkel/content/shopify-miljard.org), waarmee de sitemap-entry automatisch via de blog-pijplijn loopt en de handmatige wiring weer verdween.

Inhoud:
- Tabel 2019-2025 met de R&D-bedragen uit de SEC-jaarrekeningen ($355 mln naar $1.536 mln, piek $1.730 mln in 2023, $7,9 mrd opgeteld).
- Per jaar waar het geld zichtbaar heenging: 2021 OS 2.0 + Dawn, 2022 expansiepiek/Deliverr, 2023 koerswending naar kern + AI, 2025 Horizon. Elk met bronlink.
- De rekensom: ruim $6 mln per werkdag in 2025, meer per dag dan een Nederlands nicheplatform per jaar kan besteden.
- Bewust milde toon (budgetverschil, geen karakterverschil); de themateam-vergelijking staat er alleen gehedged in.
- Slot koppelt aan de opknapbeurt-claim uit PR #126 en linkt naar beide migratiepagina's.

Kruislinks vanuit de waarom-blokken van de MWW- en CCV-migratiepagina's wijzen naar de blog-URL.

Verificatie: nix-build (incl. xmllint/html-checks) groen; blogpost, beide kruislinks en de automatische sitemap-entry aanwezig in de output, de oude statische pagina afwezig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)