### PR TITLE
Webwinkel: je-vorm, gehashte assets, slanker menu, band speelt een keer

### DIFF
--- a/elm/src/PrijsCalculator.elm
+++ b/elm/src/PrijsCalculator.elm
@@ -21,8 +21,8 @@ intern in hele centen gerekend zodat er geen afrondingsfouten op de komma
 ontstaan; pas bij het tonen zetten we centen om naar euro's.
 
 De vragen zijn met opzet in gewone taal gesteld, voor een webshop-eigenaar
-zonder technische kennis: geen "registrar" of "MX-records", maar "uw domeinnaam"
-en "uw e-mailadressen".
+zonder technische kennis: geen "registrar" of "MX-records", maar "je domeinnaam"
+en "je e-mailadressen".
 
 Deze indicatie is bewust geen offerte: alleen een offerte legt de prijs vast.
 Dat staat ook onder de uitkomst, zodat de bezoeker weet dat dit een richtprijs
@@ -735,7 +735,7 @@ keuzeOptie huidig waarde omschrijving =
 bronVeld : BronPlatform -> Html Msg
 bronVeld bron =
     label [ Attr.class "calc-field" ]
-        [ span [ Attr.class "calc-label" ] [ text "Waar draait uw webshop nu?" ]
+        [ span [ Attr.class "calc-label" ] [ text "Waar draait je webshop nu?" ]
         , select [ onInput BronGewijzigd ]
             [ keuzeOptie (bronNaarWaarde bron) "mijnwebwinkel" (bronOmschrijving BronMijnwebwinkel)
             , keuzeOptie (bronNaarWaarde bron) "ccv" (bronOmschrijving BronCcvShop)
@@ -749,7 +749,7 @@ bronVeld bron =
 doelVeld : DoelPlatform -> Html Msg
 doelVeld doel =
     label [ Attr.class "calc-field" ]
-        [ span [ Attr.class "calc-label" ] [ text "Waar wilt u naartoe?" ]
+        [ span [ Attr.class "calc-label" ] [ text "Waar wil je naartoe?" ]
         , select [ onInput DoelGewijzigd ]
             [ keuzeOptie (doelNaarWaarde doel) "shopify" (doelOmschrijving DoelShopify)
             , keuzeOptie (doelNaarWaarde doel) "woocommerce" (doelOmschrijving DoelWoocommerce)
@@ -762,7 +762,7 @@ doelVeld doel =
 themaVeld : ThemaKeuze -> Html Msg
 themaVeld thema =
     label [ Attr.class "calc-field" ]
-        [ span [ Attr.class "calc-label" ] [ text "Hoe moet uw nieuwe shop eruitzien?" ]
+        [ span [ Attr.class "calc-label" ] [ text "Hoe moet je nieuwe shop eruitzien?" ]
         , select [ onInput ThemaGewijzigd ]
             [ keuzeOptie (themaNaarWaarde thema) "standaard" (themaOmschrijving ThemaStandaard)
             , keuzeOptie (themaNaarWaarde thema) "overzetten" (themaOmschrijving ThemaOverzetten)
@@ -925,7 +925,7 @@ doelNoot doel =
     case doel of
         DoelWeetNiet ->
             [ p [ Attr.class "calc-note" ]
-                [ text "Nog geen platform op het oog? Prima: in het gratis gesprek adviseren we een platform op basis van uw situatie. De richtprijs rekent met Shopify als uitgangspunt." ]
+                [ text "Nog geen platform op het oog? Prima: in het gratis gesprek adviseren we een platform op basis van je situatie. De richtprijs rekent met Shopify als uitgangspunt." ]
             ]
 
         DoelShopify ->
@@ -952,7 +952,7 @@ pointOfSaleNoot : Bool -> List (Html Msg)
 pointOfSaleNoot pointOfSale =
     if pointOfSale then
         [ p [ Attr.class "calc-note" ]
-            [ text "Kassa/point-of-sale zetten we bij u op locatie op. Installatie en reiskosten rekenen we daar los bij, op aanvraag." ]
+            [ text "Kassa/point-of-sale zetten we bij je op locatie op. Installatie en reiskosten rekenen we daar los bij, op aanvraag." ]
         ]
 
     else
@@ -967,30 +967,30 @@ view : Model -> Html Msg
 view model =
     div [ Attr.class "prijs-calculator" ]
         [ fieldset [ Attr.class "calc-inputs" ]
-            [ legend [] [ text "Uw webshop" ]
+            [ legend [] [ text "Je webshop" ]
             , bronVeld model.bron
             , doelVeld model.doel
-            , getalVeld "Hoeveel producten heeft uw webshop ongeveer?" model.productenInvoer "t/m 1.000 zit in de basisprijs" ProductenGewijzigd
-            , getalVeld "In hoeveel talen staat uw webshop?" model.talenInvoer "1 taal zit in de basisprijs" TalenGewijzigd
+            , getalVeld "Hoeveel producten heeft je webshop ongeveer?" model.productenInvoer "t/m 1.000 zit in de basisprijs" ProductenGewijzigd
+            , getalVeld "In hoeveel talen staat je webshop?" model.talenInvoer "1 taal zit in de basisprijs" TalenGewijzigd
             , themaVeld model.thema
             , div [ Attr.class "calc-check-group" ]
-                [ span [ Attr.class "calc-label" ] [ text "Wat wilt u meenemen naar de nieuwe shop?" ]
-                , aanvinkVeld "Klantaccounts" "Uw klanten houden hun eigen inlog" model.klantaccounts KlantaccountsGewijzigd
-                , aanvinkVeld "Bestelgeschiedenis" "Alle eerdere bestellingen van uw klanten" model.orderhistorie OrderhistorieGewijzigd
-                , aanvinkVeld "Nieuwsbrief-aanmeldingen" "De adressenlijst van uw nieuwsbrief" model.nieuwsbrief NieuwsbriefGewijzigd
+                [ span [ Attr.class "calc-label" ] [ text "Wat wil je meenemen naar de nieuwe shop?" ]
+                , aanvinkVeld "Klantaccounts" "Je klanten houden hun eigen inlog" model.klantaccounts KlantaccountsGewijzigd
+                , aanvinkVeld "Bestelgeschiedenis" "Alle eerdere bestellingen van je klanten" model.orderhistorie OrderhistorieGewijzigd
+                , aanvinkVeld "Nieuwsbrief-aanmeldingen" "De adressenlijst van je nieuwsbrief" model.nieuwsbrief NieuwsbriefGewijzigd
                 , aanvinkVeld "Voorraadaantallen" "De actuele voorraad per product" model.voorraad VoorraadGewijzigd
-                , aanvinkVeld "Reviews / beoordelingen" "Uw opgebouwde productbeoordelingen" model.reviews ReviewsGewijzigd
+                , aanvinkVeld "Reviews / beoordelingen" "Je opgebouwde productbeoordelingen" model.reviews ReviewsGewijzigd
                 ]
             , div [ Attr.class "calc-check-group" ] <|
                 [ span [ Attr.class "calc-label" ] [ text "Extra diensten en koppelingen" ] ]
                     ++ domeinEmailVelden model
-                    ++ [ aanvinkVeld "Verzendkoppeling (bijv. DHL)" "Pakketten en labels rechtstreeks vanuit uw shop" model.verzendkoppeling VerzendkoppelingGewijzigd
+                    ++ [ aanvinkVeld "Verzendkoppeling (bijv. DHL)" "Pakketten en labels rechtstreeks vanuit je shop" model.verzendkoppeling VerzendkoppelingGewijzigd
                        , aanvinkVeld "B2B-kanaal (zakelijke klanten)" "Aparte prijzen en inlog voor zakelijke klanten" model.b2bKanaal B2bKanaalGewijzigd
                        , aanvinkVeld "Kassa / point-of-sale voor mijn fysieke winkel" "Verkopen in de winkel \u{00E9}n online met \u{00E9}\u{00E9}n systeem (Shopify POS)" model.pointOfSale PointOfSaleGewijzigd
                        ]
             ]
         , div [ Attr.class "calc-result" ] <|
-            [ h3 [] [ text "Uw richtprijs" ]
+            [ h3 [] [ text "Je richtprijs" ]
             , uitsplitsing model
             , p [ Attr.class "calc-total" ]
                 [ span [] [ text "Totaal (excl. BTW)" ]
@@ -1010,12 +1010,12 @@ domeinEmailVelden model =
     if bundeltDomeinEnEmail model.bron then
         [ aanvinkVeld
             ("Mijn domeinnaam staat nog bij " ++ bronOmschrijving model.bron)
-            "Het internetadres van uw shop (bijv. uwshop.nl). Weet u het niet zeker? Dan zoeken we het samen uit."
+            "Het internetadres van je shop (bijv. uwshop.nl). Weet je het niet zeker? Dan zoeken we het samen uit."
             model.domeinBijMijnwebwinkel
             DomeinGewijzigd
         , aanvinkVeld
             ("Mijn e-mailadressen horen bij " ++ bronOmschrijving model.bron)
-            "Bijvoorbeeld info@uwshop.nl die u via dat platform gebruikt"
+            "Bijvoorbeeld info@uwshop.nl die je via dat platform gebruikt"
             model.emailBijMijnwebwinkel
             EmailGewijzigd
         ]
@@ -1029,15 +1029,15 @@ webshop-domein. Beide moeten ingevuld zijn voordat de offerte-knop verstuurt. -}
 contactVelden : Model -> Html Msg
 contactVelden model =
     div [ Attr.class "calc-contact" ]
-        [ verplichtVeld model.offertePoging "Uw naam" "Voor- en achternaam" model.naam NaamGewijzigd
-        , verplichtVeld model.offertePoging "Uw webshop (domeinnaam)" "bijv. uwshop.nl" model.webshopDomein WebshopDomeinGewijzigd
+        [ verplichtVeld model.offertePoging "Je naam" "Voor- en achternaam" model.naam NaamGewijzigd
+        , verplichtVeld model.offertePoging "Je webshop (domeinnaam)" "bijv. uwshop.nl" model.webshopDomein WebshopDomeinGewijzigd
         ]
 
 
 lockInNoot : Html Msg
 lockInNoot =
     p [ Attr.class "calc-lockin" ]
-        [ text "Dit is een richtprijs. Wilt u tegen deze prijs verhuizen? Vraag nu een offerte aan." ]
+        [ text "Dit is een richtprijs. Wil je tegen deze prijs verhuizen? Vraag nu een offerte aan." ]
 
 
 {-| Geruststelling onder de offerte-knop: de aanvraag verplicht tot niets, de
@@ -1045,7 +1045,7 @@ bezoeker vraagt alleen een bevestiging van de getoonde prijs. -}
 vrijblijvendNoot : Html Msg
 vrijblijvendNoot =
     p [ Attr.class "calc-vrijblijvend" ]
-        [ text "Vrijblijvend: met deze aanvraag zit u nergens aan vast. U vraagt alleen een bevestiging van deze prijs, en beslist daarna rustig zelf." ]
+        [ text "Vrijblijvend: met deze aanvraag zit je nergens aan vast. Je vraagt alleen een bevestiging van deze prijs, en beslist daarna rustig zelf." ]
 
 
 formulierGeldig : Model -> Bool
@@ -1107,7 +1107,7 @@ offerteBody model =
             ++ [ "Totaal: " ++ formatteerEuro (totaalCenten model) ]
             ++ pointOfSaleReiskostenRegel model
             ++ [ ""
-               , "Kunt u mij hiervoor een offerte sturen?"
+               , "Kun je mij hiervoor een offerte sturen?"
                ]
         )
 

--- a/elm/src/ScannerForm.elm
+++ b/elm/src/ScannerForm.elm
@@ -327,7 +327,7 @@ init _ =
 
 legeInvoerMelding : String
 legeInvoerMelding =
-    "Vul het adres van uw webshop in."
+    "Vul het adres van je webshop in."
 
 
 ongeldigeInvoerMelding : String
@@ -384,7 +384,7 @@ valideerUrl kandidaat =
 
 netwerkMelding : String
 netwerkMelding =
-    "We konden de server niet bereiken. Controleer uw verbinding en probeer het opnieuw."
+    "We konden de server niet bereiken. Controleer je verbinding en probeer het opnieuw."
 
 
 serverMelding : String
@@ -729,7 +729,7 @@ invoerWeergave : String -> Maybe String -> List (Html Msg)
 invoerWeergave invoer mFout =
     [ form [ Attr.class "scanner-form", onSubmit ScanAangevraagd ]
         [ label [ Attr.class "calc-field" ]
-            [ span [ Attr.class "calc-label" ] [ text "Het adres van uw webshop" ]
+            [ span [ Attr.class "calc-label" ] [ text "Het adres van je webshop" ]
             , input
                 ([ Attr.type_ "text"
                  , Attr.value invoer
@@ -782,13 +782,13 @@ wachtTekst stand =
     case stand of
         InWachtrij positie ->
             if positie == 1 then
-                "U bent als eerste aan de beurt."
+                "Je bent als eerste aan de beurt."
 
             else
-                "U staat op plek " ++ String.fromInt positie ++ " in de wachtrij."
+                "Je staat op plek " ++ String.fromInt positie ++ " in de wachtrij."
 
         Bezig ->
-            "We meten uw webshop."
+            "We meten je webshop."
 
 
 {-| Melding wanneer de gescande shop onze meting tijdelijk weigert. -}
@@ -843,13 +843,13 @@ nietHerkendWeergave rapport invoer =
     [ h3 [ Attr.class "scanner-rapport-kop" ] [ text ("Rapport voor " ++ rapport.url) ]
     , p [ Attr.class "scanner-platform" ] [ strong [] [ text "Platform niet herkend." ] ]
     , p []
-        [ text "Wij beoordelen webshops op MijnWebwinkel, CCV Shop, Lightspeed, WooCommerce en Shopify. Draait uw shop ergens anders, dan kunnen wij er weinig zinnigs over zeggen. Controleer het adres of probeer een andere shop:" ]
+        [ text "Wij beoordelen webshops op MijnWebwinkel, CCV Shop, Lightspeed, WooCommerce en Shopify. Draait je shop ergens anders, dan kunnen wij er weinig zinnigs over zeggen. Controleer het adres of probeer een andere shop:" ]
     ]
         ++ invoerWeergave invoer Nothing
         ++ [ p [ Attr.class "scanner-platform-verzoek" ]
-                [ text "Draait uw shop op een platform dat wij nog niet kennen? "
+                [ text "Draait je shop op een platform dat wij nog niet kennen? "
                 , a [ Attr.href (platformVerzoekMailto rapport.url) ]
-                    [ text "Mail ons welk platform u gebruikt" ]
+                    [ text "Mail ons welk platform je gebruikt" ]
                 , text "; bij genoeg vraag voegen we het toe."
                 ]
            ]
@@ -1050,10 +1050,10 @@ upsellBlok rapport =
 migratieBlok : Rapport -> List (Html Msg)
 migratieBlok rapport =
     [ div [ Attr.class "scanner-upsell scanner-upsell-migratie" ]
-        [ h3 [] [ text "Vast aan uw platform" ]
+        [ h3 [] [ text "Vast aan je platform" ]
         , p [] [ text (vastZin (aantalVast rapport) rapport.platform) ]
         , a [ Attr.href rekenhulpUrl, Attr.class "cta-button", onClick CalculatorGeklikt ]
-            [ text "Bereken uw verhuisprijs" ]
+            [ text "Bereken je verhuisprijs" ]
         ]
     ]
 
@@ -1074,7 +1074,7 @@ oplosBlok rapport =
     if heeftOplosbarePunten rapport then
         [ div [ Attr.class "scanner-upsell" ]
             [ h3 [] [ text "Liever laten doen?" ]
-            , p [] [ text "De oplosbare punten pakken wij voor u op, tegen een vaste prijs." ]
+            , p [] [ text "De oplosbare punten pakken wij voor je op, tegen een vaste prijs." ]
             , a [ Attr.href meetUrl, Attr.class "cta-button", onClick GesprekGeklikt ]
                 [ text "Plan een gesprek" ]
             ]

--- a/elm/tests/ScannerFormTest.elm
+++ b/elm/tests/ScannerFormTest.elm
@@ -240,7 +240,7 @@ updateTests =
                     (Tuple.first (update ScanAangevraagd { initieelModel | invoer = "uwshop.nl" })).fase
         , test "ongeldige invoer blijft in de invoerfase met een melding" <|
             \_ ->
-                Expect.equal (Invoeren (Just "Vul het adres van uw webshop in."))
+                Expect.equal (Invoeren (Just "Vul het adres van je webshop in."))
                     (Tuple.first (update ScanAangevraagd initieelModel)).fase
         , test "een wachtrij-status toont de positie" <|
             \_ ->
@@ -363,7 +363,7 @@ viewTests =
             \_ ->
                 view (modelMetRapport verwachtRapport)
                     |> Query.fromHtml
-                    |> Query.has [ rekenhulpLink, Selector.text "Bereken uw verhuisprijs" ]
+                    |> Query.has [ rekenhulpLink, Selector.text "Bereken je verhuisprijs" ]
         , test "met een vast punt is er geen gesprek-knop" <|
             \_ ->
                 view (modelMetRapport verwachtRapport)
@@ -442,7 +442,7 @@ nietHerkendTests =
             \_ ->
                 view (modelMetRapport nietHerkendRapport)
                     |> Query.fromHtml
-                    |> Query.has [ Selector.tag "a", Selector.text "Mail ons welk platform u gebruikt" ]
+                    |> Query.has [ Selector.tag "a", Selector.text "Mail ons welk platform je gebruikt" ]
         , test "een herkend platform toont geen niet-herkend-melding" <|
             \_ ->
                 view (modelMetRapport verwachtRapport)

--- a/shake/AssetHash.hs
+++ b/shake/AssetHash.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Content-hash cache-busting voor de statische assets van
+-- webwinkelverhuis.nl: de pure naamgeving en de HTML-herschrijving. De
+-- IO-kant (bestanden lezen en de gehashte kopie schrijven) staat in de
+-- Shakefile; dit module is bewust puur zodat de testsuite het kan
+-- aanspreken.
+module AssetHash
+  ( GehashteAssets(..)
+  , gehashteAssetNaam
+  , herschrijfAssetVerwijzingen
+  ) where
+
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as LBS
+import Data.Digest.Pure.SHA (sha256, showDigest)
+import Data.Text (Text)
+import qualified Data.Text.Lazy as TL
+
+-- | De cache-bestendige namen van de stylesheets en Elm-bundels van
+-- webwinkelverhuis.nl: de inhoudshash zit in de bestandsnaam, zodat een
+-- browser na een deploy nooit een oude versie uit zijn cache haalt.
+data GehashteAssets = GehashteAssets
+  { gehashteStyleCss :: Text
+  , gehashteBlogCss :: Text
+  , gehashtePrijsCalculatorJs :: Text
+  , gehashteScannerFormJs :: Text
+  }
+
+-- | De cache-bestendige bestandsnaam voor een asset: de basisnaam plus de
+-- eerste 10 tekens van de sha256 van de inhoud, plus de extensie
+-- ("style-ab12cd34ef.css").
+gehashteAssetNaam :: String -> String -> ByteString -> String
+gehashteAssetNaam basisnaam extensie inhoud =
+  basisnaam
+    <> "-"
+    <> take 10 (showDigest (sha256 (LBS.fromStrict inhoud)))
+    <> "."
+    <> extensie
+
+-- | Herschrijf de logische assetnamen in een gerenderde pagina naar hun
+-- gehashte tegenhangers uit 'GehashteAssets'.
+herschrijfAssetVerwijzingen :: GehashteAssets -> TL.Text -> TL.Text
+herschrijfAssetVerwijzingen gehashte =
+    vervangAsset "/style.css" (gehashteStyleCss gehashte)
+  . vervangAsset "/blog.css" (gehashteBlogCss gehashte)
+  . vervangAsset "/prijs-calculator.js" (gehashtePrijsCalculatorJs gehashte)
+  . vervangAsset "/scanner-form.js" (gehashteScannerFormJs gehashte)
+
+vervangAsset :: Text -> Text -> TL.Text -> TL.Text
+vervangAsset logischeNaam gehashteNaam =
+  TL.replace (TL.fromStrict logischeNaam) (TL.fromStrict ("/" <> gehashteNaam))

--- a/shake/Shakefile.hs
+++ b/shake/Shakefile.hs
@@ -5,6 +5,8 @@ module Main where
 import Control.Concurrent (forkIO)
 import Control.Exception (IOException, catch, finally)
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
+import Data.Digest.Pure.SHA (sha256, showDigest)
 import Data.List (sortBy, nub)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
@@ -524,17 +526,71 @@ writeHtmlFile path html = do
   Dir.createDirectoryIfMissing True (takeDirectory path)
   TLIO.writeFile path (renderHtml html)
 
--- | Write a webwinkelverhuis.nl page, first rewriting absolute content-image
--- sources to root-relative ones ('relativizeWebwinkelContentImages') so they
--- load on the local serve preview, and refusing to emit a page that links a
--- raw calendar.app.google URL. Scheduling links must use the
+-- | De cache-bestendige namen van de stylesheets en Elm-bundels van
+-- webwinkelverhuis.nl: de inhoudshash zit in de bestandsnaam, zodat een
+-- browser na een deploy nooit een oude versie uit zijn cache haalt.
+data GehashteAssets = GehashteAssets
+  { gehashteStyleCss :: Text
+  , gehashteBlogCss :: Text
+  , gehashtePrijsCalculatorJs :: Text
+  , gehashteScannerFormJs :: Text
+  }
+
+-- Decision: cache-busting via een inhoudshash in de bestandsnaam, berekend
+-- in de Shake-build (sha256 over het bestand, zoals nix met outputs doet).
+-- Alternatief was een ?v=-queryparameter, maar sommige proxies en caches
+-- negeren querystrings; een unieke bestandsnaam is waterdicht. De ongehashte
+-- originelen blijven staan zodat een bezoeker met een oude gecachte
+-- HTML-pagina zijn assets nog kan laden.
+maakGehashteWebwinkelAssets :: IO GehashteAssets
+maakGehashteWebwinkelAssets = do
+  styleCss <- maakGehashteKopie "style" "css"
+  blogCss <- maakGehashteKopie "blog" "css"
+  prijsCalculatorJs <- maakGehashteKopie "prijs-calculator" "js"
+  scannerFormJs <- maakGehashteKopie "scanner-form" "js"
+  return GehashteAssets
+    { gehashteStyleCss = styleCss
+    , gehashteBlogCss = blogCss
+    , gehashtePrijsCalculatorJs = prijsCalculatorJs
+    , gehashteScannerFormJs = scannerFormJs
+    }
+
+-- | Kopieer een asset uit _webwinkelverhuis-site naar zijn gehashte naam
+-- ("style-ab12cd34ef.css") en geef die naam terug.
+maakGehashteKopie :: String -> String -> IO Text
+maakGehashteKopie basisnaam extensie = do
+  inhoud <- BS.readFile ("_webwinkelverhuis-site" </> basisnaam <.> extensie)
+  let hash = take 10 (showDigest (sha256 (LBS.fromStrict inhoud)))
+      naam = basisnaam <> "-" <> hash <.> extensie
+  BS.writeFile ("_webwinkelverhuis-site" </> naam) inhoud
+  return (T.pack naam)
+
+-- | Herschrijf de logische assetnamen in een gerenderde pagina naar hun
+-- gehashte tegenhangers uit 'GehashteAssets'.
+herschrijfAssetVerwijzingen :: GehashteAssets -> TL.Text -> TL.Text
+herschrijfAssetVerwijzingen gehashte =
+    vervangAsset "/style.css" (gehashteStyleCss gehashte)
+  . vervangAsset "/blog.css" (gehashteBlogCss gehashte)
+  . vervangAsset "/prijs-calculator.js" (gehashtePrijsCalculatorJs gehashte)
+  . vervangAsset "/scanner-form.js" (gehashteScannerFormJs gehashte)
+
+vervangAsset :: Text -> Text -> TL.Text -> TL.Text
+vervangAsset logischeNaam gehashteNaam =
+  TL.replace (TL.fromStrict logischeNaam) (TL.fromStrict ("/" <> gehashteNaam))
+
+-- | Write a webwinkelverhuis.nl page: rewrite absolute content-image sources
+-- to root-relative ones ('relativizeWebwinkelContentImages') so they load on
+-- the local serve preview, rewrite asset references to their content-hashed
+-- names ('herschrijfAssetVerwijzingen'), and refuse to emit a page that links
+-- a raw calendar.app.google URL. Scheduling links must use the
 -- https://meet.jappiesoftware.com redirect ('meetLink' in
 -- 'WebwinkelTemplates'): a raw link in blog content once routed visitors to
 -- the wrong calendar, and the template test suite cannot see rendered
 -- content. Crashing the build here beats publishing the bad link silently.
-writeWebwinkelHtmlFile :: FilePath -> Html -> IO ()
-writeWebwinkelHtmlFile path html = do
-  let rendered = relativizeWebwinkelContentImages (renderHtml html)
+writeWebwinkelHtmlFile :: GehashteAssets -> FilePath -> Html -> IO ()
+writeWebwinkelHtmlFile gehashteAssets path html = do
+  let rendered = herschrijfAssetVerwijzingen gehashteAssets
+        (relativizeWebwinkelContentImages (renderHtml html))
   if TL.pack "calendar.app.google" `TL.isInfixOf` rendered
     then error (path <> " links a raw calendar.app.google URL; use https://meet.jappiesoftware.com instead")
     else do
@@ -625,10 +681,14 @@ buildPenguinSites webwinkelUrl = do
   let webwinkelFiles = map (\f -> (f, "md")) webwinkelMds
                     ++ map (\f -> (f, "org")) webwinkelOrgs
   (webwinkelArticles, _webwinkelPages) <- liftIO $ parseAllContent "webwinkel/content" webwinkelFiles
-  liftIO $ generateWebwinkelverhuisSite webwinkelSiteConfig webwinkelArticles
+  -- Assets eerst: de pagina's verwijzen naar content-gehashte bestandsnamen,
+  -- dus de stylesheets en Elm-bundels moeten bestaan voordat we hashen en
+  -- de pagina's schrijven.
   copyWebwinkelStaticAssets
   buildPrijsCalculator
   buildScannerForm
+  gehashteAssets <- liftIO maakGehashteWebwinkelAssets
+  liftIO $ generateWebwinkelverhuisSite webwinkelSiteConfig webwinkelArticles gehashteAssets
 
 -- | Compile one Elm app from elm/src to a JS bundle inside the webwinkel
 -- site. Wired into the Shake build so both the production build and the local
@@ -709,33 +769,33 @@ generatePenguinSite webwinkelUrl config articles = do
 -- "waarom" pages carry their canonical URLs on this domain; jappiesoftware.com
 -- 302-redirects the old migration URLs here (in the megavid nginx config). The
 -- bare domain now serves a real landing page rather than redirecting away.
-generateWebwinkelverhuisSite :: SiteConfig -> [Article] -> IO ()
-generateWebwinkelverhuisSite config articles = do
+generateWebwinkelverhuisSite :: SiteConfig -> [Article] -> GehashteAssets -> IO ()
+generateWebwinkelverhuisSite config articles gehashteAssets = do
   let sortedArticles = sortBy (\a b -> compare (Down (articleDate a)) (Down (articleDate b))) articles
 
   Dir.createDirectoryIfMissing True "_webwinkelverhuis-site"
   Dir.createDirectoryIfMissing True "_webwinkelverhuis-site/blog"
 
   -- Landing page
-  writeWebwinkelHtmlFile "_webwinkelverhuis-site/index.html" webwinkelIndexPage
+  writeWebwinkelHtmlFile gehashteAssets "_webwinkelverhuis-site/index.html" webwinkelIndexPage
 
   -- Shopify migration app's App URL landing page
-  writeWebwinkelHtmlFile "_webwinkelverhuis-site/app.html" appPage
+  writeWebwinkelHtmlFile gehashteAssets "_webwinkelverhuis-site/app.html" appPage
 
   -- Migration and explainer pages
-  writeWebwinkelHtmlFile "_webwinkelverhuis-site/prijzen.html" prijzenPage
-  writeWebwinkelHtmlFile "_webwinkelverhuis-site/scan.html" scanPage
-  writeWebwinkelHtmlFile "_webwinkelverhuis-site/migrate-mijnwebwinkel.html" mijnwebwinkelMigrationPage
-  writeWebwinkelHtmlFile "_webwinkelverhuis-site/migrate-ccvshop.html" ccvshopMigrationPage
-  writeWebwinkelHtmlFile "_webwinkelverhuis-site/migrate-lightspeed.html" lightspeedMigrationPage
-  writeWebwinkelHtmlFile "_webwinkelverhuis-site/waarom-mijnwebwinkel.html" mijnwebwinkelWaaromPage
-  writeWebwinkelHtmlFile "_webwinkelverhuis-site/waarom-lightspeed.html" lightspeedWaaromPage
-  writeWebwinkelHtmlFile "_webwinkelverhuis-site/over-ons.html" overOnsPage
-  writeWebwinkelHtmlFile "_webwinkelverhuis-site/contact.html" contactPage
+  writeWebwinkelHtmlFile gehashteAssets "_webwinkelverhuis-site/prijzen.html" prijzenPage
+  writeWebwinkelHtmlFile gehashteAssets "_webwinkelverhuis-site/scan.html" scanPage
+  writeWebwinkelHtmlFile gehashteAssets "_webwinkelverhuis-site/migrate-mijnwebwinkel.html" mijnwebwinkelMigrationPage
+  writeWebwinkelHtmlFile gehashteAssets "_webwinkelverhuis-site/migrate-ccvshop.html" ccvshopMigrationPage
+  writeWebwinkelHtmlFile gehashteAssets "_webwinkelverhuis-site/migrate-lightspeed.html" lightspeedMigrationPage
+  writeWebwinkelHtmlFile gehashteAssets "_webwinkelverhuis-site/waarom-mijnwebwinkel.html" mijnwebwinkelWaaromPage
+  writeWebwinkelHtmlFile gehashteAssets "_webwinkelverhuis-site/waarom-lightspeed.html" lightspeedWaaromPage
+  writeWebwinkelHtmlFile gehashteAssets "_webwinkelverhuis-site/over-ons.html" overOnsPage
+  writeWebwinkelHtmlFile gehashteAssets "_webwinkelverhuis-site/contact.html" contactPage
 
   -- Individual blog article pages
   mapM_ (\art ->
-    writeWebwinkelHtmlFile ("_webwinkelverhuis-site/blog" </> T.unpack (articleUrl art))
+    writeWebwinkelHtmlFile gehashteAssets ("_webwinkelverhuis-site/blog" </> T.unpack (articleUrl art))
       (webwinkelArticlePage config art))
     sortedArticles
 
@@ -753,7 +813,7 @@ generateWebwinkelverhuisSite config articles = do
               then Just ("/blog/" <> penguinIndexFileName (pageNum + 1))
               else Nothing
           }
-    in writeWebwinkelHtmlFile ("_webwinkelverhuis-site/blog" </> T.unpack (penguinIndexFileName pageNum))
+    in writeWebwinkelHtmlFile gehashteAssets ("_webwinkelverhuis-site/blog" </> T.unpack (penguinIndexFileName pageNum))
          (webwinkelBlogIndexPage config arts pagination)
     ) (zip [1..] articlePages)
 

--- a/shake/Shakefile.hs
+++ b/shake/Shakefile.hs
@@ -5,8 +5,6 @@ module Main where
 import Control.Concurrent (forkIO)
 import Control.Exception (IOException, catch, finally)
 import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LBS
-import Data.Digest.Pure.SHA (sha256, showDigest)
 import Data.List (sortBy, nub)
 import qualified Data.Map.Strict as Map
 import Data.Maybe (fromMaybe)
@@ -40,6 +38,7 @@ import Text.Pandoc
 import Text.Pandoc.Highlighting (pygments)
 import WaiAppStatic.Types (ssIndices, unsafeToPiece, ssAddTrailingSlash)
 
+import AssetHash (GehashteAssets(..), gehashteAssetNaam, herschrijfAssetVerwijzingen)
 import Feed (generateAtomFeed)
 import Metadata (parseMarkdownMeta, parseOrgMeta, parseDateField, parseTags, isDraft)
 import PenguinTemplates (WebwinkelverhuisUrl(..), penguinIndexPage, penguinIndexPageNl, penguinWordpressPage, penguinWordpressPageNl, penguinBlogIndexPage, penguinArticlePage)
@@ -526,22 +525,13 @@ writeHtmlFile path html = do
   Dir.createDirectoryIfMissing True (takeDirectory path)
   TLIO.writeFile path (renderHtml html)
 
--- | De cache-bestendige namen van de stylesheets en Elm-bundels van
--- webwinkelverhuis.nl: de inhoudshash zit in de bestandsnaam, zodat een
--- browser na een deploy nooit een oude versie uit zijn cache haalt.
-data GehashteAssets = GehashteAssets
-  { gehashteStyleCss :: Text
-  , gehashteBlogCss :: Text
-  , gehashtePrijsCalculatorJs :: Text
-  , gehashteScannerFormJs :: Text
-  }
-
 -- Decision: cache-busting via een inhoudshash in de bestandsnaam, berekend
 -- in de Shake-build (sha256 over het bestand, zoals nix met outputs doet).
 -- Alternatief was een ?v=-queryparameter, maar sommige proxies en caches
 -- negeren querystrings; een unieke bestandsnaam is waterdicht. De ongehashte
 -- originelen blijven staan zodat een bezoeker met een oude gecachte
--- HTML-pagina zijn assets nog kan laden.
+-- HTML-pagina zijn assets nog kan laden. De pure naamgeving en
+-- herschrijving staan in 'AssetHash', zodat de testsuite ze dekt.
 maakGehashteWebwinkelAssets :: IO GehashteAssets
 maakGehashteWebwinkelAssets = do
   styleCss <- maakGehashteKopie "style" "css"
@@ -556,27 +546,13 @@ maakGehashteWebwinkelAssets = do
     }
 
 -- | Kopieer een asset uit _webwinkelverhuis-site naar zijn gehashte naam
--- ("style-ab12cd34ef.css") en geef die naam terug.
+-- ('gehashteAssetNaam', "style-ab12cd34ef.css") en geef die naam terug.
 maakGehashteKopie :: String -> String -> IO Text
 maakGehashteKopie basisnaam extensie = do
   inhoud <- BS.readFile ("_webwinkelverhuis-site" </> basisnaam <.> extensie)
-  let hash = take 10 (showDigest (sha256 (LBS.fromStrict inhoud)))
-      naam = basisnaam <> "-" <> hash <.> extensie
+  let naam = gehashteAssetNaam basisnaam extensie inhoud
   BS.writeFile ("_webwinkelverhuis-site" </> naam) inhoud
   return (T.pack naam)
-
--- | Herschrijf de logische assetnamen in een gerenderde pagina naar hun
--- gehashte tegenhangers uit 'GehashteAssets'.
-herschrijfAssetVerwijzingen :: GehashteAssets -> TL.Text -> TL.Text
-herschrijfAssetVerwijzingen gehashte =
-    vervangAsset "/style.css" (gehashteStyleCss gehashte)
-  . vervangAsset "/blog.css" (gehashteBlogCss gehashte)
-  . vervangAsset "/prijs-calculator.js" (gehashtePrijsCalculatorJs gehashte)
-  . vervangAsset "/scanner-form.js" (gehashteScannerFormJs gehashte)
-
-vervangAsset :: Text -> Text -> TL.Text -> TL.Text
-vervangAsset logischeNaam gehashteNaam =
-  TL.replace (TL.fromStrict logischeNaam) (TL.fromStrict ("/" <> gehashteNaam))
 
 -- | Write a webwinkelverhuis.nl page: rewrite absolute content-image sources
 -- to root-relative ones ('relativizeWebwinkelContentImages') so they load on

--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -132,7 +132,7 @@ offerteBodyTemplate :: Text
 offerteBodyTemplate =
   "Hallo,\n\n"
     <> "Ik wil graag een offerte voor het verhuizen van mijn webshop. "
-    <> "Om u een goede prijs te kunnen geven, alvast wat info (vul in wat u weet):\n\n"
+    <> "Om je een goede prijs te kunnen geven, alvast wat info (vul in wat je weet):\n\n"
     <> "- Huidig platform (bijv. MijnWebwinkel, CCV Shop): \n"
     <> "- Gewenst platform (Shopify of WooCommerce): \n"
     <> "- Aantal producten (ongeveer): \n"
@@ -215,6 +215,9 @@ webwinkelBaseWith ogType includeFeed meta content =
             H.span "verhuis"
             ".nl"
           H.ul $ do
+            H.li $ H.a ! A.href "/migrate-mijnwebwinkel.html" $ "MijnWebwinkel"
+            H.li $ H.a ! A.href "/migrate-lightspeed.html" $ "Lightspeed"
+            H.li $ H.a ! A.href "/migrate-ccvshop.html" $ "CCV Shop"
             H.li $ H.a ! A.href (toValue ("mailto:" <> webwinkelEmail)) ! A.class_ "footer-mail" $ toHtml webwinkelEmail
             H.li $ H.a ! A.href "tel:+31644237437" $ "+31 6 4423 7437"
             H.li $ H.a ! A.href "/blog/" $ "Blog"
@@ -224,6 +227,7 @@ webwinkelBaseWith ogType includeFeed meta content =
             H.a ! A.href "https://jappiesoftware.com/" $ "Jappie Software B.V."
             H.preEscapedToHtml (" &middot; KVK: 95097872 &middot; Ooievaarstraat 38, 8262 AN Kampen" :: Text)
       H.script $ H.preEscapedToHtml menuToggleScript
+      H.script $ H.preEscapedToHtml bandSpeelScript
       H.script $ H.preEscapedToHtml ctaTrackScript
 
 -- | Het ene menu van webwinkelverhuis.nl. Elke pagina rendert zijn header
@@ -242,10 +246,12 @@ webwinkelTopNav =
              ! customAttribute "aria-label" "Menu" $
       H.preEscapedToHtml menuKnopSvg
     H.div ! A.class_ "hoofdnav" ! A.id "hoofdnav" $ do
+      -- Decision: geen platformlinks in het menu (review Jappie, 8 aug
+      -- 2026): een bezoeker geeft maar om een van die pagina's en de lijst
+      -- groeit alleen maar. De platformkeuze loopt via de kaarten op de
+      -- landingspagina; de platformpagina's staan wel in de footer zodat
+      -- ze intern gelinkt blijven.
       H.ul $ do
-        H.li $ H.a ! A.href "/migrate-mijnwebwinkel.html" $ "MijnWebwinkel"
-        H.li $ H.a ! A.href "/migrate-lightspeed.html" $ "Lightspeed"
-        H.li $ H.a ! A.href "/migrate-ccvshop.html" $ "CCV Shop"
         H.li $ H.a ! A.href "/prijzen.html" $ "Prijzen"
         H.li $ H.a ! A.href "/blog/" $ "Blog"
         H.li $ H.a ! A.href "/over-ons.html" $ "Over ons"
@@ -289,6 +295,23 @@ menuToggleScript =
     <> "document.addEventListener('keydown',function(e){"
     <> "if(e.key==='Escape'&&nav.classList.contains('open')){zet(false);knop.focus();}"
     <> "});})();"
+
+-- | Start de band-animatie op de landingspagina zodra de band in beeld
+-- scrolt: de IntersectionObserver zet eenmalig de klasse "speel", waarna de
+-- CSS-animatie precies een keer speelt en de tabel gevuld blijft staan.
+-- Zonder JavaScript (of zonder .band op de pagina) gebeurt er niets en
+-- toont de basisstijl de tabel statisch compleet.
+bandSpeelScript :: Text
+bandSpeelScript =
+  "(function(){"
+    <> "var band=document.querySelector('.band');"
+    <> "if(!band||!('IntersectionObserver' in window)){return;}"
+    <> "var kijker=new IntersectionObserver(function(entries){"
+    <> "entries.forEach(function(e){"
+    <> "if(e.isIntersecting){band.classList.add('speel');kijker.disconnect();}"
+    <> "});},{threshold:0.15});"
+    <> "kijker.observe(band);"
+    <> "})();"
 
 -- | Track clicks on the call-to-action buttons in Google Analytics, so we see
 -- the dropoff per acquisition path: the plain "vraag een offerte aan" mailto
@@ -365,7 +388,7 @@ shopifyKostenNote :: Html
 shopifyKostenNote =
   H.p ! A.class_ "engagement-note" $ do
     H.preEscapedToHtml
-      ( "Naast onze eenmalige migratieprijs betaalt u het abonnement van uw nieuwe platform. Shopify Basic kost bijvoorbeeld &euro;"
+      ( "Naast onze eenmalige migratieprijs betaal je het abonnement van je nieuwe platform. Shopify Basic kost bijvoorbeeld &euro;"
           <> shopifyBasicJaarlijksEuroPerMaand
           <> " per maand bij jaarlijkse betaling en &euro;"
           <> shopifyBasicMaandelijksEuroPerMaand
@@ -384,11 +407,11 @@ prijzen = H.section ! A.class_ "prijs-sectie" ! A.id "prijzen" $
       H.preEscapedToHtml ("vanaf &euro;" <> migratieBasisprijsEuro <> " ")
       H.small "eenmalig"
     H.p ! A.class_ "inbegrepen" $ H.preEscapedToHtml ("Inclusief 1.000 producten en &eacute;&eacute;n taal: producten, afbeeldingen, categorie&euml;n, klantdata, voorraad en SEO-redirects." :: Text)
-    H.p ! A.class_ "meerprijs" $ H.preEscapedToHtml ("Grotere catalogi, extra talen en losse diensten (e-mail-setup, en domeinverhuizing als uw domein nog bij uw huidige platform staat) hebben een vaste meerprijs." :: Text)
+    H.p ! A.class_ "meerprijs" $ H.preEscapedToHtml ("Grotere catalogi, extra talen en losse diensten (e-mail-setup, en domeinverhuizing als je domein nog bij je huidige platform staat) hebben een vaste meerprijs." :: Text)
     H.hr
     H.p ! A.class_ "abonnement" $ do
       H.preEscapedToHtml
-        ( "Naast onze eenmalige migratieprijs betaalt u het abonnement van uw nieuwe platform. Shopify Basic kost bijvoorbeeld &euro;"
+        ( "Naast onze eenmalige migratieprijs betaal je het abonnement van je nieuwe platform. Shopify Basic kost bijvoorbeeld &euro;"
             <> shopifyBasicJaarlijksEuroPerMaand
             <> " per maand bij jaarlijkse betaling en &euro;"
             <> shopifyBasicMaandelijksEuroPerMaand
@@ -396,10 +419,10 @@ prijzen = H.section ! A.class_ "prijs-sectie" ! A.id "prijzen" $
         )
       H.a ! A.href shopifyPrijzenUrl $ "de actuele Shopify-prijzen"
       ")."
-    H.a ! A.href "/prijzen.html#rekenhulp" ! A.class_ "cta-button" $ "Bereken direct uw prijs"
+    H.a ! A.href "/prijzen.html#rekenhulp" ! A.class_ "cta-button" $ "Bereken direct je prijs"
     H.p ! A.class_ "garantie" $ do
       H.preEscapedToHtml vinkjeSvg
-      " U betaalt pas na een succesvolle migratie"
+      " Je betaalt pas na een succesvolle migratie"
 
 
 
@@ -413,9 +436,9 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
         H.div $ do
           H.p ! A.class_ "hero-chip" $ do
             H.preEscapedToHtml vinkjeSvg
-            " U betaalt pas na een succesvolle migratie"
+            " Je betaalt pas na een succesvolle migratie"
           H.h1 $ H.preEscapedToHtml ("Webshop verhuizen zonder data- en SEO&#8209;verlies." :: Text)
-          H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Vastgelopen op MijnWebwinkel, CCV Shop of Lightspeed? Wij verhuizen uw webshop geautomatiseerd naar Shopify of een ander platform." :: Text)
+          H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Vastgelopen op MijnWebwinkel, CCV Shop of Lightspeed? Wij verhuizen je webshop geautomatiseerd naar Shopify of een ander platform." :: Text)
           -- Decision: hero-CTA blijft de gratis scan (/scan.html): de scan
           -- geeft de bezoeker direct een persoonlijk resultaat en voedt het
           -- migratie-aanbod met gemeten feiten. De rekenhulp blijft
@@ -436,7 +459,7 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
 
     -- Navy checklist-band: wat er allemaal meeverhuist, in winkelierswoorden.
     H.section ! A.class_ "band" $ do
-      H.h2 "Uw webshop verhuist"
+      H.h2 "Je webshop verhuist"
       H.ul ! A.class_ "inpaklijst" $ mapM_ inpaklijstItem scanStappen
 
     -- How it works, met de testshop-foto ernaast.
@@ -447,13 +470,13 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
           H.ol $ do
             H.li $ do
               H.h3 "Scan"
-              H.p ! A.class_ "stap-tekst" $ "Ons programma leest uw huidige webshop volledig uit en zet alles over naar een testshop: producten, vertalingen, collections, redirects."
+              H.p ! A.class_ "stap-tekst" $ "Ons programma leest je huidige webshop volledig uit en zet alles over naar een testshop: producten, vertalingen, collections, redirects."
             H.li $ do
               H.h3 "Wennen"
-              H.p ! A.class_ "stap-tekst" $ "De testshop draait naast uw huidige webshop, die gewoon doordraait. U raakt op uw gemak bekend met uw nieuwe shop."
+              H.p ! A.class_ "stap-tekst" $ "De testshop draait naast je huidige webshop, die gewoon doordraait. Je raakt op je gemak bekend met je nieuwe shop."
             H.li $ do
               H.h3 "DNS-overzet"
-              H.p ! A.class_ "stap-tekst" $ "Bent u er klaar voor? Dan wijzen we uw domein op de nieuwe shop en bent u verhuisd."
+              H.p ! A.class_ "stap-tekst" $ "Ben je er klaar voor? Dan wijzen we je domein op de nieuwe shop en ben je verhuisd."
         H.div ! A.class_ "proces-beeld" $
           H.img ! A.src "/assets/beeld/proces-testshop.jpg"
                 ! A.alt "Twee laptops naast elkaar: de testshop draait naast de huidige webshop"
@@ -464,11 +487,11 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
     -- Why us
     H.section ! A.class_ "results" $ do
       H.h2 "Waarom via ons?"
-      H.p $ H.preEscapedToHtml ("Wij zijn migratie-specialisten, geen verlengstuk van &eacute;&eacute;n platform. U kiest het platform: Shopify, WooCommerce, of vraag ons advies voor uw situatie. Wij regelen de techniek." :: Text)
+      H.p $ H.preEscapedToHtml ("Wij zijn migratie-specialisten, geen verlengstuk van &eacute;&eacute;n platform. Je kiest het platform: Shopify, WooCommerce, of vraag ons advies voor je situatie. Wij regelen de techniek." :: Text)
       H.dl ! A.class_ "waarom-rijen" $ do
         H.div $ do
           H.dt "Geen risico"
-          H.dd "U betaalt pas na een succesvolle migratie."
+          H.dd "Je betaalt pas na een succesvolle migratie."
         H.div $ do
           H.dt "Geautomatiseerd"
           H.dd "Geen handmatig overtypen, geen kopieerfouten."
@@ -477,10 +500,10 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
           H.dd "Het programma valideert zijn eigen werk."
         H.div $ do
           H.dt "SEO-behoud"
-          H.dd "Elke oude link krijgt een 301-redirect en blijft werken; uw opgebouwde SEO verhuist mee."
+          H.dd "Elke oude link krijgt een 301-redirect en blijft werken; je opgebouwde SEO verhuist mee."
         H.div $ do
           H.dt "Vaste prijs"
-          H.dd "Geen uurtarief, u weet vooraf wat het kost."
+          H.dd "Geen uurtarief, je weet vooraf wat het kost."
       H.p $ do
         "Meer weten over waarom shops vertrekken? Lees onze "
         H.a ! A.href "/blog/" $ "blog"
@@ -491,14 +514,14 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
     -- Secondary buttons: the green primary is reserved for the offerte and
     -- plan-een-gesprek actions.
     H.section ! A.class_ "for-who" ! A.id "platforms" $ do
-      H.h2 "Vanaf welk platform verhuist u?"
+      H.h2 "Vanaf welk platform verhuis je?"
       H.ul ! A.class_ "card-grid" $ do
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-bevroren.svg"
                 ! A.alt "Sneeuwvlok: het platform is bevroren"
                 ! A.width "56" ! A.height "56"
           H.h3 "MijnWebwinkel"
-          H.p $ H.preEscapedToHtml ("Bevroren platform, verdubbelde prijzen, gesloten community. Wij zetten alles over, inclusief de automatisch gegenereerde 301-redirects voor uw artikel-URLs." :: Text)
+          H.p $ H.preEscapedToHtml ("Bevroren platform, verdubbelde prijzen, gesloten community. Wij zetten alles over, inclusief de automatisch gegenereerde 301-redirects voor je artikel-URLs." :: Text)
           H.a ! A.href "/migrate-mijnwebwinkel.html" ! A.class_ "cta-button-secondary" $ H.preEscapedToHtml ("Bekijk migratie &rarr;" :: Text)
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-prijsstijging.svg"
@@ -512,7 +535,7 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
                 ! A.alt "Hangslot: beperkte mogelijkheden"
                 ! A.width "56" ! A.height "56"
           H.h3 "CCV Shop"
-          H.p $ H.preEscapedToHtml ("Steeds duurder, terwijl het winkelbestand krimpt en het zwaartepunt na de Fiserv-overname bij betalen en kassa ligt. Wij zetten uw producten, talen, klantaccounts en voorraad volledig geautomatiseerd over." :: Text)
+          H.p $ H.preEscapedToHtml ("Steeds duurder, terwijl het winkelbestand krimpt en het zwaartepunt na de Fiserv-overname bij betalen en kassa ligt. Wij zetten je producten, talen, klantaccounts en voorraad volledig geautomatiseerd over." :: Text)
           H.a ! A.href "/migrate-ccvshop.html" ! A.class_ "cta-button-secondary" $ H.preEscapedToHtml ("Bekijk migratie &rarr;" :: Text)
 
     -- Pricing: listed openly. Hiding the price reads as evasive to a
@@ -531,7 +554,7 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
       H.div ! A.class_ "contact" $ do
         H.div $ do
           H.h2 "Klaar om te verhuizen?"
-          H.p ! A.class_ "contact-intro" $ "Plan een gratis, vrijblijvend gesprek. We bekijken samen uw webshop en geven direct een inschatting."
+          H.p ! A.class_ "contact-intro" $ "Plan een gratis, vrijblijvend gesprek. We bekijken samen je webshop en geven direct een inschatting."
           H.div ! A.class_ "contact-acties" $ do
             H.a ! A.href meetLink ! A.class_ "cta-button" $ "Plan een gesprek"
             H.a ! A.href offerteMailto ! A.class_ "cta-button-secondary" $ "Offerte per e-mail"
@@ -548,7 +571,7 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
   where
     indexMeta :: PageMeta
     indexMeta = PageMeta
-      { pageMetaTitle       = "Webwinkelverhuis \8212 Verhuis uw webshop zonder zorgen"
+      { pageMetaTitle       = "Webwinkelverhuis \8212 Verhuis je webshop zonder zorgen"
       , pageMetaDescription = "Geautomatiseerde webshop-migratie van MijnWebwinkel, CCV Shop of Lightspeed naar Shopify. Producten, vertalingen, klantdata en SEO-redirects. Betaling na succesvolle migratie."
       , pageMetaLang        = "nl"
       , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/"
@@ -566,18 +589,18 @@ webwinkelIndexPage = webwinkelBaseTemplate indexMeta $
 homeFaq :: [(FaqQuestion, FaqAnswer)]
 homeFaq =
   [ ( "Kan mijn webshop verhuisd worden?"
-    , faqAnswerText "Vrijwel altijd. Producten, teksten, afbeeldingen, klanten en de categoriestructuur zetten we geautomatiseerd over vanaf MijnWebwinkel, CCV Shop, Lightspeed en andere platformen, inclusief 301-redirects van al uw oude URLs zodat uw Google-posities meeverhuizen." )
+    , faqAnswerText "Vrijwel altijd. Producten, teksten, afbeeldingen, klanten en de categoriestructuur zetten we geautomatiseerd over vanaf MijnWebwinkel, CCV Shop, Lightspeed en andere platformen, inclusief 301-redirects van al je oude URLs zodat je Google-posities meeverhuizen." )
   , ( "Naar welk platform kan ik het beste verhuizen?"
-    , faqAnswerText "Dat hangt af van uw situatie: uw assortiment, uw koppelingen en hoeveel u zelf wilt kunnen aanpassen. Shopify is het meest gekozen doelplatform omdat het makkelijk is. WooCommerce kan een goede optie zijn omdat het flexibel is. Weet u het nog niet? In een gratis gesprek adviseren we een platform op basis van uw situatie, en in de rekenhulp kunt u die keuze gewoon openlaten." )
+    , faqAnswerText "Dat hangt af van je situatie: je assortiment, je koppelingen en hoeveel je zelf wilt kunnen aanpassen. Shopify is het meest gekozen doelplatform omdat het makkelijk is. WooCommerce kan een goede optie zijn omdat het flexibel is. Weet je het nog niet? In een gratis gesprek adviseren we een platform op basis van je situatie, en in de rekenhulp kun je die keuze gewoon openlaten." )
   , ( "Hoe lang duurt een migratie?"
-    , faqAnswerText "Het technische overzetten van uw producten duurt maar enkele uren. Maar er komt bij een verhuizing meestal meer kijken: het thema, apps en plugins, betaalmethoden, en rustig wennen aan uw nieuwe shop. Reken daarom op ongeveer een maand van start tot livegang." )
+    , faqAnswerText "Het technische overzetten van je producten duurt maar enkele uren. Maar er komt bij een verhuizing meestal meer kijken: het thema, apps en plugins, betaalmethoden, en rustig wennen aan je nieuwe shop. Reken daarom op ongeveer een maand van start tot livegang." )
   , ( "Wat kost een webshop-migratie?"
     , faqAnswerHtml $ do
-        toHtml ("Een vaste prijs vanaf " <> migratieBasisprijsEuro <> " euro, afhankelijk van het aantal producten en talen, en u betaalt pas na een geslaagde migratie. Met ")
+        toHtml ("Een vaste prijs vanaf " <> migratieBasisprijsEuro <> " euro, afhankelijk van het aantal producten en talen, en je betaalt pas na een geslaagde migratie. Met ")
         H.a ! A.href "/prijzen.html#rekenhulp" $ "de rekenhulp op de prijzenpagina"
-        " berekent u in een minuut uw richtprijs." )
+        " bereken je in een minuut je richtprijs." )
   , ( "Kan mijn shop blijven doorverkopen tijdens de migratie?"
-    , faqAnswerText "Ja. De nieuwe shop bouwen we naast uw huidige webshop op, die gewoon doordraait en verkoopt. Pas bij de livegang zetten we uw domein om naar waar u heen wilt. Tegen die tijd heeft u vertrouwen in het nieuwe systeem en is alles getest." )
+    , faqAnswerText "Ja. De nieuwe shop bouwen we naast je huidige webshop op, die gewoon doordraait en verkoopt. Pas bij de livegang zetten we je domein om naar waar je heen wilt. Tegen die tijd heb je vertrouwen in het nieuwe systeem en is alles getest." )
   ]
 
 -- =============================================================================
@@ -670,45 +693,45 @@ appPage = webwinkelBaseTemplate appMeta $ do
   H.main $ do
     H.section ! A.class_ "hero" $ do
       H.h1 "De migratie-app"
-      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("U ziet deze pagina omdat de migratie-app van Webwinkelverhuis in uw Shopify-winkel is ge&iuml;nstalleerd. Dat is precies de bedoeling: de app is het gereedschap waarmee wij uw webshop naar Shopify overzetten." :: Text)
-      H.a ! A.href "#meer" ! A.class_ "cta-button" $ "Wat we verder voor u kunnen doen"
+      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Je ziet deze pagina omdat de migratie-app van Webwinkelverhuis in je Shopify-winkel is ge&iuml;nstalleerd. Dat is precies de bedoeling: de app is het gereedschap waarmee wij je webshop naar Shopify overzetten." :: Text)
+      H.a ! A.href "#meer" ! A.class_ "cta-button" $ "Wat we verder voor je kunnen doen"
 
     H.section ! A.class_ "for-who" ! A.id "what" $ do
       H.h2 "Wat de app doet"
       H.ul ! A.class_ "card-grid" $ do
         H.li ! A.class_ "card" $ do
           H.h3 "Producten plaatsen"
-          H.p "De app zet uw producten, varianten, afbeeldingen, prijzen en SKU's in uw nieuwe Shopify-winkel."
+          H.p "De app zet je producten, varianten, afbeeldingen, prijzen en SKU's in je nieuwe Shopify-winkel."
         H.li ! A.class_ "card" $ do
           H.h3 $ H.preEscapedToHtml ("Categorie&euml;n en pagina&rsquo;s" :: Text)
-          H.p $ H.preEscapedToHtml ("Uw categorie&euml;n worden Shopify-collections en uw informatiepagina&rsquo;s worden meegenomen, inclusief het navigatiemenu." :: Text)
+          H.p $ H.preEscapedToHtml ("Je categorie&euml;n worden Shopify-collections en je informatiepagina&rsquo;s worden meegenomen, inclusief het navigatiemenu." :: Text)
         H.li ! A.class_ "card" $ do
           H.h3 "SEO-redirects"
-          H.p "De app legt 301-redirects aan van elke oude URL naar de juiste nieuwe pagina, zodat elke bestaande link blijft werken en uw opgebouwde SEO meeverhuist."
+          H.p "De app legt 301-redirects aan van elke oude URL naar de juiste nieuwe pagina, zodat elke bestaande link blijft werken en je opgebouwde SEO meeverhuist."
         H.li ! A.class_ "card" $ do
           H.h3 "Thema"
-          H.p "De app bouwt en plaatst een Shopify-thema dat de uitstraling van uw huidige winkel volgt."
+          H.p "De app bouwt en plaatst een Shopify-thema dat de uitstraling van je huidige winkel volgt."
 
     H.section ! A.class_ "audit" $ do
       H.h2 "Waarom de app toegang vraagt"
       H.p "Om dit werk te doen vraagt de app toegang tot precies de onderdelen die hij plaatst:"
       H.ul $ do
-        H.li $ H.strong "Producten" >> ": om uw artikelen, varianten en collections aan te maken."
-        H.li $ H.strong "Content" >> ": om uw pagina's, navigatie en redirects over te zetten."
+        H.li $ H.strong "Producten" >> ": om je artikelen, varianten en collections aan te maken."
+        H.li $ H.strong "Content" >> ": om je pagina's, navigatie en redirects over te zetten."
         H.li $ H.strong "Klanten" >> ": om bestaande klantaccounts mee te nemen."
         H.li $ H.preEscapedToHtml ("<strong>Thema&rsquo;s</strong>: om het nieuwe thema te plaatsen." :: Text)
         H.li $ H.strong "Vertalingen" >> ": om meertalige content correct te koppelen."
 
     H.section ! A.class_ "about" $ do
       H.h2 "Veilig en tijdelijk"
-      H.p "De app is alleen nodig tijdens de migratie. Wij installeren hem in uw winkel om uw data te plaatsen, en daarna kan hij verwijderd worden. Hij maakt geen onderdeel uit van uw winkel voor uw bezoekers."
+      H.p "De app is alleen nodig tijdens de migratie. Wij installeren hem in je winkel om je data te plaatsen, en daarna kan hij verwijderd worden. Hij maakt geen onderdeel uit van je winkel voor je bezoekers."
       H.p $ do
         H.a ! A.href "/migrate-mijnwebwinkel.html" $ "Lees hoe de migratie werkt"
         H.preEscapedToHtml (" &rarr;" :: Text)
 
     H.section ! A.class_ "for-who" ! A.id "meer" $ do
-      H.h2 "Wat we verder voor u kunnen doen"
-      H.p $ H.preEscapedToHtml ("Dezelfde techniek waarmee we uw shop verhuizen, zetten we ook na de migratie voor u in. Enkele voorbeelden van wat we voor andere webwinkels hebben gedaan:" :: Text)
+      H.h2 "Wat we verder voor je kunnen doen"
+      H.p $ H.preEscapedToHtml ("Dezelfde techniek waarmee we je shop verhuizen, zetten we ook na de migratie voor je in. Enkele voorbeelden van wat we voor andere webwinkels hebben gedaan:" :: Text)
       H.ul ! A.class_ "card-grid" $ do
         H.li ! A.class_ "card" $ do
           H.h3 "Massabewerkingen"
@@ -718,20 +741,20 @@ appPage = webwinkelBaseTemplate appMeta $ do
           H.p $ H.preEscapedToHtml ("Alle meta titles en meta descriptions opnieuw opbouwen in &eacute;&eacute;n uniforme stijl, per taal en per categorie." :: Text)
         H.li ! A.class_ "card" $ do
           H.h3 "Thema-uitbreidingen"
-          H.p "Uw Shopify-thema uitbreiden met extra secties of functionaliteit, of de vormgeving verder afstemmen op uw huisstijl."
+          H.p "Je Shopify-thema uitbreiden met extra secties of functionaliteit, of de vormgeving verder afstemmen op je huisstijl."
         H.li ! A.class_ "card" $ do
           H.h3 "Koppelingen en apps"
-          H.p "Uw boekhouding of facturatie koppelen aan Shopify, een verhuur-app inrichten, of een extra taal toevoegen inclusief vertaalde URL's en redirects."
+          H.p "Je boekhouding of facturatie koppelen aan Shopify, een verhuur-app inrichten, of een extra taal toevoegen inclusief vertaalde URL's en redirects."
         H.li ! A.class_ "card" $ do
           H.h3 "Training"
-          H.p $ H.preEscapedToHtml ("Een rondleiding door uw nieuwe shop met beknopte handleiding, of een cursus Shopify van twee uur, &eacute;&eacute;n-op-&eacute;&eacute;n." :: Text)
-      H.p "Alles tegen een vaste prijs per klus, geen uurtarief. U weet vooraf waar u aan toe bent."
-      H.a ! A.href uitbreidingMailto ! A.class_ "cta-button" $ "Bespreek uw idee met ons"
+          H.p $ H.preEscapedToHtml ("Een rondleiding door je nieuwe shop met beknopte handleiding, of een cursus Shopify van twee uur, &eacute;&eacute;n-op-&eacute;&eacute;n." :: Text)
+      H.p "Alles tegen een vaste prijs per klus, geen uurtarief. Je weet vooraf waar je aan toe bent."
+      H.a ! A.href uitbreidingMailto ! A.class_ "cta-button" $ "Bespreek je idee met ons"
   where
     appMeta :: PageMeta
     appMeta = PageMeta
       { pageMetaTitle       = "De migratie-app van Webwinkelverhuis"
-      , pageMetaDescription = "Uitleg over de migratie-app van Webwinkelverhuis: het gereedschap waarmee wij uw webshop naar Shopify overzetten, en wat we na de migratie verder voor uw shop kunnen doen."
+      , pageMetaDescription = "Uitleg over de migratie-app van Webwinkelverhuis: het gereedschap waarmee wij je webshop naar Shopify overzetten, en wat we na de migratie verder voor je shop kunnen doen."
       , pageMetaLang        = "nl"
       , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/app.html"
       , pageMetaOgImage     = Nothing
@@ -750,17 +773,17 @@ prijzenPage = webwinkelBaseTemplate prijzenMeta $
   H.main $ do
     H.section ! A.class_ "hero" $ do
       H.h1 "Prijzen"
-      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Vaste prijzen, vooraf afgesproken. U betaalt pas na een succesvolle migratie. Hieronder ziet u precies waar u aan toe bent." :: Text)
+      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Vaste prijzen, vooraf afgesproken. Je betaalt pas na een succesvolle migratie. Hieronder zie je precies waar je aan toe bent." :: Text)
 
     H.section ! A.class_ "engagement" ! A.id "rekenhulp" $ do
-      H.h2 "Bereken uw richtprijs"
-      H.p "Beantwoord een paar vragen over uw shop en u ziet meteen een indicatie."
+      H.h2 "Bereken je richtprijs"
+      H.p "Beantwoord een paar vragen over je shop en je ziet meteen een indicatie."
       H.div ! A.id "prijs-calculator-mount" $ mempty
-      H.noscript $ H.p "De rekenhulp heeft JavaScript nodig. Hieronder staat de volledige prijslijst zodat u ook zonder JavaScript alles ziet."
+      H.noscript $ H.p "De rekenhulp heeft JavaScript nodig. Hieronder staat de volledige prijslijst zodat je ook zonder JavaScript alles ziet."
       H.div ! A.class_ "calc-footnotes" $ do
         H.h3 "Over de themakeuze"
-        H.p "Kiest u voor zelf inrichten, dan staat uw shop na de migratie op een standaard Shopify-thema dat u zelf verzorgt of door een ontwerper naar keuze laat doen. Theming hoeft niet via ons; wij doen het ook en zijn er inmiddels aardig goed in. Probeer het gerust eerst zelf: uw oude shop blijft gewoon draaien naast de nieuwe, dus u loopt geen risico. Komt u er niet uit, dan helpen we u alsnog."
-        H.p $ H.preEscapedToHtml ("Bij uitstraling overzetten (&euro;749) benaderen we uw huidige uitstraling zo dicht mogelijk; kleine aanpassingen op verzoek zitten erbij." :: Text)
+        H.p "Kies je voor zelf inrichten, dan staat je shop na de migratie op een standaard Shopify-thema dat je zelf verzorgt of door een ontwerper naar keuze laat doen. Theming hoeft niet via ons; wij doen het ook en zijn er inmiddels aardig goed in. Probeer het gerust eerst zelf: je oude shop blijft gewoon draaien naast de nieuwe, dus je loopt geen risico. Kom je er niet uit, dan helpen we je alsnog."
+        H.p $ H.preEscapedToHtml ("Bij uitstraling overzetten (&euro;749) benaderen we je huidige uitstraling zo dicht mogelijk; kleine aanpassingen op verzoek zitten erbij." :: Text)
         H.p "Een volledig nieuw ontwerp is los ontwerpwerk en prijzen we op aanvraag."
 
     H.section ! A.class_ "engagement" $ do
@@ -782,13 +805,13 @@ prijzenPage = webwinkelBaseTemplate prijzenMeta $
 
     H.section ! A.class_ "engagement" $ do
       H.h2 "Modules en extra diensten"
-      H.p "Losse onderdelen die u naar keuze bijschakelt. U betaalt alleen voor wat u meeneemt."
+      H.p "Losse onderdelen die je naar keuze bijschakelt. Je betaalt alleen voor wat je meeneemt."
       H.table ! A.class_ "price-table" $ H.tbody $ do
         H.tr $ do
           H.td "Uitstraling overzetten"
           H.td ! A.class_ "price-cell" $ H.preEscapedToHtml ("&euro;749" :: Text)
         H.tr $ do
-          H.td $ H.preEscapedToHtml ("Klantaccounts meenemen (uw klanten houden hun inlog)" :: Text)
+          H.td $ H.preEscapedToHtml ("Klantaccounts meenemen (je klanten houden hun inlog)" :: Text)
           H.td ! A.class_ "price-cell" $ H.preEscapedToHtml ("&euro;250" :: Text)
         H.tr $ do
           H.td "Bestelgeschiedenis meenemen"
@@ -803,19 +826,19 @@ prijzenPage = webwinkelBaseTemplate prijzenMeta $
           H.td "Reviews / beoordelingen overzetten"
           H.td ! A.class_ "price-cell" $ H.preEscapedToHtml ("&euro;150" :: Text)
         H.tr $ do
-          H.td $ H.preEscapedToHtml ("Domeinverhuizing (uw domeinnaam staat nog bij MijnWebwinkel)" :: Text)
+          H.td $ H.preEscapedToHtml ("Domeinverhuizing (je domeinnaam staat nog bij MijnWebwinkel)" :: Text)
           H.td ! A.class_ "price-cell" $ H.preEscapedToHtml ("&euro;250" :: Text)
         H.tr $ do
           H.td $ H.preEscapedToHtml ("E-mail-setup (mailboxen, SPF/DKIM, doorstuurregels)" :: Text)
           H.td ! A.class_ "price-cell" $ H.preEscapedToHtml ("&euro;150" :: Text)
         H.tr $ do
-          H.td $ H.preEscapedToHtml ("Verzendkoppeling (bijv. DHL: pakketten en labels vanuit uw shop)" :: Text)
+          H.td $ H.preEscapedToHtml ("Verzendkoppeling (bijv. DHL: pakketten en labels vanuit je shop)" :: Text)
           H.td ! A.class_ "price-cell" $ H.preEscapedToHtml ("&euro;150" :: Text)
         H.tr $ do
           H.td $ H.preEscapedToHtml ("B2B-kanaal (aparte prijzen en inlog voor zakelijke klanten)" :: Text)
           H.td ! A.class_ "price-cell" $ H.preEscapedToHtml ("&euro;750" :: Text)
         H.tr $ do
-          H.td $ H.preEscapedToHtml ("Kassa / point-of-sale (Shopify POS in uw fysieke winkel)" :: Text)
+          H.td $ H.preEscapedToHtml ("Kassa / point-of-sale (Shopify POS in je fysieke winkel)" :: Text)
           H.td ! A.class_ "price-cell" $ H.preEscapedToHtml ("&euro;750" :: Text)
         H.tr $ do
           H.td "Volledig nieuw ontwerp"
@@ -823,21 +846,21 @@ prijzenPage = webwinkelBaseTemplate prijzenMeta $
         H.tr $ do
           H.td "Catalogus-brede teksttransformaties"
           H.td ! A.class_ "price-cell" $ "op aanvraag"
-      H.p ! A.class_ "engagement-note" $ H.preEscapedToHtml ("Na de migratie staat uw shop op een standaard Shopify-thema dat u zelf inricht. De vormgeving hoeft niet via ons: u kunt het zelf doen of een ontwerper naar keuze inhuren. Wilt u het uit handen geven, dan benaderen wij uw huidige uitstraling zo dicht mogelijk (&euro;749) of ontwerpen we iets nieuws (op aanvraag)." :: Text)
-      H.p ! A.class_ "engagement-note" $ "Kassa/point-of-sale zetten we bij u op locatie op. Installatie en reiskosten komen daar los bij, op aanvraag."
+      H.p ! A.class_ "engagement-note" $ H.preEscapedToHtml ("Na de migratie staat je shop op een standaard Shopify-thema dat je zelf inricht. De vormgeving hoeft niet via ons: je kunt het zelf doen of een ontwerper naar keuze inhuren. Wil je het uit handen geven, dan benaderen wij je huidige uitstraling zo dicht mogelijk (&euro;749) of ontwerpen we iets nieuws (op aanvraag)." :: Text)
+      H.p ! A.class_ "engagement-note" $ "Kassa/point-of-sale zetten we bij je op locatie op. Installatie en reiskosten komen daar los bij, op aanvraag."
 
     H.section ! A.class_ "results" $ do
       H.h2 "Altijd inbegrepen"
       H.ul $ do
         H.li $ H.preEscapedToHtml ("Producten, afbeeldingen, categorie&euml;n, klantdata en voorraad." :: Text)
-        H.li $ H.preEscapedToHtml ("Uw teksten, meta-titels en informatiepagina&apos;s (zoals over-ons en blog) verhuizen mee." :: Text)
-        H.li "SEO-redirects (301) voor elke oude URL, zodat uw links en opgebouwde SEO meeverhuizen."
-        H.li "Een testshop naast uw draaiende winkel; DNS-overzet met zo min mogelijk downtime."
+        H.li $ H.preEscapedToHtml ("Je teksten, meta-titels en informatiepagina&apos;s (zoals over-ons en blog) verhuizen mee." :: Text)
+        H.li "SEO-redirects (301) voor elke oude URL, zodat je links en opgebouwde SEO meeverhuizen."
+        H.li "Een testshop naast je draaiende winkel; DNS-overzet met zo min mogelijk downtime."
         H.li "Betaling pas na een succesvolle migratie."
 
     H.section ! A.class_ "final-cta" $ do
       H.h2 "Geldt deze prijs voor mij?"
-      H.p "Deze prijzen kunnen we in de toekomst aanpassen, en de hier getoonde bedragen zijn een indicatie, geen garantie. Alleen een offerte legt uw prijs vast. Wilt u tegen deze prijzen verhuizen? Vraag nu een offerte aan, dan staat uw prijs zwart-op-wit."
+      H.p "Deze prijzen kunnen we in de toekomst aanpassen, en de hier getoonde bedragen zijn een indicatie, geen garantie. Alleen een offerte legt je prijs vast. Wil je tegen deze prijzen verhuizen? Vraag nu een offerte aan, dan staat je prijs zwart-op-wit."
       H.div ! A.class_ "cta-row" $ do
         H.a ! A.href offerteMailto ! A.class_ "cta-button" $ "Vraag een offerte aan"
         H.a ! A.href meetLink ! A.class_ "cta-button-secondary" $ "Liever eerst sparren? Plan een gesprek"
@@ -848,7 +871,7 @@ prijzenPage = webwinkelBaseTemplate prijzenMeta $
     prijzenMeta :: PageMeta
     prijzenMeta = PageMeta
       { pageMetaTitle       = "Prijzen \8212 Webwinkelverhuis"
-      , pageMetaDescription = "Vaste prijzen voor uw webshop-migratie naar Shopify: vanaf \8364\&1.999 inclusief 1.000 producten en 1 taal. Domeinverhuizing \8364\&250, e-mail-setup \8364\&150. Betaling na succesvolle migratie."
+      , pageMetaDescription = "Vaste prijzen voor je webshop-migratie naar Shopify: vanaf \8364\&1.999 inclusief 1.000 producten en 1 taal. Domeinverhuizing \8364\&250, e-mail-setup \8364\&150. Betaling na succesvolle migratie."
       , pageMetaLang        = "nl"
       , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/prijzen.html"
       , pageMetaOgImage     = Nothing
@@ -885,7 +908,7 @@ scanPage = webwinkelBaseTemplate scanMeta $
     -- scannerformulier samen in de hero-sectie, die de hele pagina vult.
     H.section ! A.class_ "hero scan-blok" $ do
       H.h1 "Beoordeel mijn webshop"
-      H.p ! A.class_ "subtitle" $ "Vul het adres van uw webshop in. Wij meten hem door en u ziet binnen enkele minuten waar u staat: snelheid, vindbaarheid en de punten die beter kunnen."
+      H.p ! A.class_ "subtitle" $ "Vul het adres van je webshop in. Wij meten hem door en je ziet binnen enkele minuten waar je staat: snelheid, vindbaarheid en de punten die beter kunnen."
       H.div ! A.id "webshop-scanner-mount" $ mempty
       H.noscript $ H.p "De beoordeling heeft JavaScript nodig. Liever direct contact? Plan een gratis gesprek via meet.jappiesoftware.com."
     H.script ! A.src "/scanner-form.js" $ mempty
@@ -894,7 +917,7 @@ scanPage = webwinkelBaseTemplate scanMeta $
     scanMeta :: PageMeta
     scanMeta = PageMeta
       { pageMetaTitle       = "Beoordeel mijn webshop \8212 Webwinkelverhuis"
-      , pageMetaDescription = "Gratis beoordeling van uw webshop: wij meten snelheid en vindbaarheid met Lighthouse en laten zien welke verbeterpunten oplosbaar zijn en welke vastliggen in uw platform."
+      , pageMetaDescription = "Gratis beoordeling van je webshop: wij meten snelheid en vindbaarheid met Lighthouse en laten zien welke verbeterpunten oplosbaar zijn en welke vastliggen in je platform."
       , pageMetaLang        = "nl"
       , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/scan.html"
       , pageMetaOgImage     = Nothing
@@ -912,7 +935,7 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $
       H.div ! A.class_ "hero-grid" $ do
         H.div $ do
           H.h1 "Ontsnap MijnWebwinkel"
-          H.p ! A.class_ "subtitle" $ "Uw webshop is uw broodwinning, en MijnWebwinkel staat al jaren stil. Verhuizen voelt als een grote stap, maar het hoeft geen sprong in het diepe te zijn: wij zetten uw complete shop geautomatiseerd over, zonder dataverlies en met zo min mogelijk downtime. U betaalt pas na een succesvolle migratie."
+          H.p ! A.class_ "subtitle" $ "Je webshop is je broodwinning, en MijnWebwinkel staat al jaren stil. Verhuizen voelt als een grote stap, maar het hoeft geen sprong in het diepe te zijn: wij zetten je complete shop geautomatiseerd over, zonder dataverlies en met zo min mogelijk downtime. Je betaalt pas na een succesvolle migratie."
           -- Decision: de hero-CTA wijst naar de scanner, niet naar de
           -- offerte (Jappie, 3 aug 2026): niemand vraagt een offerte aan
           -- direct na één alinea, maar de webshop-beoordeling is een
@@ -939,34 +962,34 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-redirects.svg"
                 ! A.alt "Pijl die een nieuwe route neemt" ! A.width "56" ! A.height "56"
-          H.h3 "Uw plek in Google"
-          H.p "Elke oude link naar uw shop blijft werken en stuurt bezoekers automatisch naar de juiste nieuwe pagina (301-redirects). Uw opgebouwde positie in Google verhuist mee."
+          H.h3 "Je plek in Google"
+          H.p "Elke oude link naar je shop blijft werken en stuurt bezoekers automatisch naar de juiste nieuwe pagina (301-redirects). Je opgebouwde positie in Google verhuist mee."
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-producten.svg"
                 ! A.alt "Doos met producten" ! A.width "56" ! A.height "56"
           H.h3 "Producten & varianten"
-          H.p "Alle producten inclusief titels, beschrijvingen, prijzen, afbeeldingen, artikelnummers en varianten. Automatisch overgezet naar uw nieuwe platform."
+          H.p "Alle producten inclusief titels, beschrijvingen, prijzen, afbeeldingen, artikelnummers en varianten. Automatisch overgezet naar je nieuwe platform."
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-categorieen.svg"
                 ! A.alt "Categorieboom" ! A.width "56" ! A.height "56"
           H.h3 $ H.preEscapedToHtml ("Categorie&euml;n" :: Text)
-          H.p $ H.preEscapedToHtml ("Uw volledige categorie-indeling en het navigatiemenu verhuizen mee, inclusief vertaalde titels. Ook uw informatiepagina&apos;s (contact, voorwaarden, verzendinformatie) gaan mee." :: Text)
+          H.p $ H.preEscapedToHtml ("Je volledige categorie-indeling en het navigatiemenu verhuizen mee, inclusief vertaalde titels. Ook je informatiepagina&apos;s (contact, voorwaarden, verzendinformatie) gaan mee." :: Text)
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-thema.svg"
                 ! A.alt "Verfpalet" ! A.width "56" ! A.height "56"
           H.h3 "Thema"
-          H.p "Uw nieuwe shop krijgt een thema dat de uitstraling van uw huidige winkel volgt. U begint niet met een kale winkel."
+          H.p "Je nieuwe shop krijgt een thema dat de uitstraling van je huidige winkel volgt. Je begint niet met een kale winkel."
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-talen.svg"
                 ! A.alt "Twee tekstballonnen" ! A.width "56" ! A.height "56"
           H.h3 "Meerdere talen"
-          H.p "Vertalingen worden correct gekoppeld. Uw klanten blijven uw shop in hun eigen taal zien, ook op de vertaalde webadressen van uw pagina's."
+          H.p "Vertalingen worden correct gekoppeld. Je klanten blijven je shop in hun eigen taal zien, ook op de vertaalde webadressen van je pagina's."
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-spaarpunten.svg"
                 ! A.alt "Munt met ster" ! A.width "56" ! A.height "56"
           H.h3 "Klanten & spaarpunten"
-          H.p "Klantaccounts, bestelgeschiedenis en spaarpuntensaldi verhuizen mee. Uw klanten kunnen direct inloggen, met hun spaarpunten in het loyaliteitsprogramma van uw nieuwe platform."
-      H.p ! A.class_ "engagement-note" $ "Ook de rest van uw shop verhuist mee: informatiepagina's zoals over-ons en verzendinformatie, uw blog, reviews, kortingscodes en cadeaubonnen. Als aparte dienst doen we ook grootschalige aanpassingen aan uw productdata tijdens de migratie, zoals prijsaanpassingen, het opschonen van beschrijvingen of beschrijvingen voor Google bij al uw afbeeldingen (alt-teksten)."
+          H.p "Klantaccounts, bestelgeschiedenis en spaarpuntensaldi verhuizen mee. Je klanten kunnen direct inloggen, met hun spaarpunten in het loyaliteitsprogramma van je nieuwe platform."
+      H.p ! A.class_ "engagement-note" $ "Ook de rest van je shop verhuist mee: informatiepagina's zoals over-ons en verzendinformatie, je blog, reviews, kortingscodes en cadeaubonnen. Als aparte dienst doen we ook grootschalige aanpassingen aan je productdata tijdens de migratie, zoals prijsaanpassingen, het opschonen van beschrijvingen of beschrijvingen voor Google bij al je afbeeldingen (alt-teksten)."
 
     -- How it works
     H.section ! A.class_ "audit" $ do
@@ -974,13 +997,13 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $
       H.ol $ do
         H.li $ do
           H.strong "Scan"
-          ": ons programma leest uw MijnWebwinkel-shop volledig uit en bouwt er een testshop mee op, met producten, vertalingen, categorie\235n en doorverwijzingen."
+          ": ons programma leest je MijnWebwinkel-shop volledig uit en bouwt er een testshop mee op, met producten, vertalingen, categorie\235n en doorverwijzingen."
         H.li $ do
           H.strong "Wennen"
-          ": de testshop draait naast uw MijnWebwinkel-shop, die gewoon doordraait. U raakt op uw gemak bekend met uw nieuwe shop."
+          ": de testshop draait naast je MijnWebwinkel-shop, die gewoon doordraait. Je raakt op je gemak bekend met je nieuwe shop."
         H.li $ do
           H.strong "Livegang"
-          ": bent u er klaar voor? Dan wijzen we uw domeinnaam op de nieuwe shop en bent u verhuisd. Uw shop is hooguit 5 tot 30 minuten beperkt bereikbaar, terwijl het beveiligingscertificaat (het slotje in de browser) opnieuw wordt aangemaakt."
+          ": ben je er klaar voor? Dan wijzen we je domeinnaam op de nieuwe shop en ben je verhuisd. Je shop is hooguit 5 tot 30 minuten beperkt bereikbaar, terwijl het beveiligingscertificaat (het slotje in de browser) opnieuw wordt aangemaakt."
 
     -- Recent werk: proof before price, so the number lands on trust.
     recentWerkSection
@@ -993,21 +1016,21 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $
       H.h2 "Waarom via ons?"
       H.div ! A.class_ "testimonials" $ do
         H.blockquote $ do
-          H.p "U weet het al: MijnWebwinkel gaat nergens meer heen. Geen nieuwe features, geen community, trage support. Trage laadtijden schaden uw SEO, en dat is op MijnWebwinkel niet te verbeteren. Gelukkig hoeft u daar niet op te wachten: verhuizen is inmiddels een gebaande weg."
+          H.p "Je weet het al: MijnWebwinkel gaat nergens meer heen. Geen nieuwe features, geen community, trage support. Trage laadtijden schaden je SEO, en dat is op MijnWebwinkel niet te verbeteren. Gelukkig hoef je daar niet op te wachten: verhuizen is inmiddels een gebaande weg."
           H.p $ do
             H.a ! A.href "/waarom-mijnwebwinkel.html" $ "Waarom wordt MijnWebwinkel niet meer doorontwikkeld?"
             H.preEscapedToHtml (" &rarr;" :: Text)
           H.p $ do
             H.a ! A.href "/blog/het-miljard-van-shopify-waarom-geen-nederlands-platform-kan-bijbenen.html" $ "Het miljard van Shopify: waarom geen Nederlands platform kan bijbenen"
             H.preEscapedToHtml (" &rarr;" :: Text)
-      H.p $ H.preEscapedToHtml ("Wij zijn migratie-specialisten, geen verlengstuk van &eacute;&eacute;n platform. U kiest het platform: Shopify, WooCommerce, of iets anders. Wij regelen de techniek." :: Text)
+      H.p $ H.preEscapedToHtml ("Wij zijn migratie-specialisten, geen verlengstuk van &eacute;&eacute;n platform. Je kiest het platform: Shopify, WooCommerce, of iets anders. Wij regelen de techniek." :: Text)
       H.ul $ do
-        H.li $ H.strong "Geen risico" >> ": u betaalt pas na succesvolle migratie"
+        H.li $ H.strong "Geen risico" >> ": je betaalt pas na succesvolle migratie"
         H.li $ H.strong "Geautomatiseerd" >> ": geen handmatig overtypen, geen kopieerfouten"
         H.li $ H.strong "Gecontroleerd" >> ": het programma telt na afloop alles na, van elk product tot elke klant"
-        H.li $ H.strong "SEO-behoud" >> ": elke oude link blijft werken en uw opgebouwde positie in Google verhuist mee"
-        H.li $ H.strong "Meertalig" >> ": vertalingen correct gekoppeld via de offici\235le koppelingen van uw nieuwe platform"
-        H.li $ H.strong "Vaste prijs" >> ": geen uurtarief, u weet vooraf wat het kost"
+        H.li $ H.strong "SEO-behoud" >> ": elke oude link blijft werken en je opgebouwde positie in Google verhuist mee"
+        H.li $ H.strong "Meertalig" >> ": vertalingen correct gekoppeld via de offici\235le koppelingen van je nieuwe platform"
+        H.li $ H.strong "Vaste prijs" >> ": geen uurtarief, je weet vooraf wat het kost"
 
     -- FAQ
     H.section ! A.class_ "about" $ do
@@ -1017,7 +1040,7 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $
     -- CTA
     H.section ! A.class_ "final-cta" $ do
       H.h2 "Klaar om te ontsnappen?"
-      H.p "Plan een gratis, vrijblijvend gesprek. We bekijken samen uw webshop en geven een eerlijke inschatting."
+      H.p "Plan een gratis, vrijblijvend gesprek. We bekijken samen je webshop en geven een eerlijke inschatting."
       H.a ! A.href meetLink ! A.class_ "cta-button" $ "Plan een gratis gesprek"
   where
     migrationMeta :: PageMeta
@@ -1043,46 +1066,46 @@ mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $
 mijnwebwinkelFaq :: [(FaqQuestion, FaqAnswer)]
 mijnwebwinkelFaq =
   [ ( "Hoe lang duurt een migratie?"
-    , faqAnswerText "Het technische overzetten van uw producten duurt maar enkele uren. Maar er komt bij een verhuizing meestal meer kijken: het thema, betaalmethoden, eventuele koppelingen, en rustig wennen aan uw nieuwe shop. Reken daarom op ongeveer een maand van start tot livegang." )
+    , faqAnswerText "Het technische overzetten van je producten duurt maar enkele uren. Maar er komt bij een verhuizing meestal meer kijken: het thema, betaalmethoden, eventuele koppelingen, en rustig wennen aan je nieuwe shop. Reken daarom op ongeveer een maand van start tot livegang." )
   , ( "Wat gebeurt er met bestellingen tijdens de verhuizing?"
     , faqAnswerHtml $ do
-        "Uw MijnWebwinkel-shop blijft gewoon open en verkoopt door terwijl wij de nieuwe shop opbouwen. Vlak voor de livegang zetten we de laatste stand over, zodat ook recente bestellingen en actuele voorraadaantallen meekomen. Bestelgeschiedenis en voorraad kiest u als optie in "
+        "Je MijnWebwinkel-shop blijft gewoon open en verkoopt door terwijl wij de nieuwe shop opbouwen. Vlak voor de livegang zetten we de laatste stand over, zodat ook recente bestellingen en actuele voorraadaantallen meekomen. Bestelgeschiedenis en voorraad kies je als optie in "
         H.a ! A.href "/prijzen.html#rekenhulp" $ "de rekenhulp"
         "." )
   , ( "Kan ik mijn domeinnaam behouden?"
-    , faqAnswerText "Ja, uw webadres blijft gewoon van u. Bij de livegang wijzen we uw domeinnaam op de nieuwe shop, en alle oude links worden automatisch doorgestuurd." )
+    , faqAnswerText "Ja, je webadres blijft gewoon van je. Bij de livegang wijzen we je domeinnaam op de nieuwe shop, en alle oude links worden automatisch doorgestuurd." )
   , ( "Wat gebeurt er met mijn e-mailadres?"
     , faqAnswerHtml $ do
-        "Uw e-mailadres blijft gewoon werken. Loopt uw e-mail nu via MijnWebwinkel, dan zetten we uw mailboxen en doorstuurregels over als losse dienst (e-mail-setup in "
+        "Je e-mailadres blijft gewoon werken. Loopt je e-mail nu via MijnWebwinkel, dan zetten we je mailboxen en doorstuurregels over als losse dienst (e-mail-setup in "
         H.a ! A.href "/prijzen.html#rekenhulp" $ "de rekenhulp"
-        "), zodat u geen bericht mist." )
+        "), zodat je geen bericht mist." )
   , ( "Wat als er iets niet klopt na de migratie?"
     , faqAnswerText "Die kans is klein: de migratie is volledig geautomatiseerd en het programma telt na afloop alles na. Inmiddels hebben we dit ook meermaals gedaan. Maar fouten kunnen gebeuren, en als er toch iets niet klopt, lossen we het gratis op." )
   , ( "Werkt het ook voor meertalige webshops?"
-    , faqAnswerText "Ja. Nederlands, Duits, Engels, Frans of een andere taal: het programma ondersteunt elke taalcombinatie die MijnWebwinkel en uw nieuwe platform beide ondersteunen. Ook de vertaalde webadressen verhuizen mee." )
+    , faqAnswerText "Ja. Nederlands, Duits, Engels, Frans of een andere taal: het programma ondersteunt elke taalcombinatie die MijnWebwinkel en je nieuwe platform beide ondersteunen. Ook de vertaalde webadressen verhuizen mee." )
   , ( "Kan ik ook naar een ander platform dan Shopify migreren?"
     , faqAnswerText "Ja. Shopify wordt het meest gekozen, maar we kunnen ook migreren naar WooCommerce of andere platformen." )
   , ( "Wat kost Shopify zelf per maand?"
     , faqAnswerHtml $ do
         toHtml ("Het Basic-abonnement van Shopify kost \8364" <> shopifyBasicJaarlijksEuroPerMaand
           <> " per maand bij jaarlijkse betaling, of \8364" <> shopifyBasicMaandelijksEuroPerMaand
-          <> " per maand als u per maand betaalt (prijspeil " <> shopifyPrijspeil
-          <> "). Voor de meeste shops die van MijnWebwinkel komen is Basic voldoende. De actuele prijzen vindt u op ")
+          <> " per maand als je per maand betaalt (prijspeil " <> shopifyPrijspeil
+          <> "). Voor de meeste shops die van MijnWebwinkel komen is Basic voldoende. De actuele prijzen vind je op ")
         H.a ! A.href shopifyPrijzenUrl $ "shopify.com/nl/prijzen"
         "." )
   , ( "Kunnen jullie een website importeren naar Shopify?"
-    , faqAnswerText "Ja. Producten, teksten, afbeeldingen, klanten en de categoriestructuur van uw bestaande website worden automatisch naar Shopify overgezet, inclusief automatische doorverwijzingen (301-redirects) van al uw oude links, zodat uw Google-posities meeverhuizen." )
+    , faqAnswerText "Ja. Producten, teksten, afbeeldingen, klanten en de categoriestructuur van je bestaande website worden automatisch naar Shopify overgezet, inclusief automatische doorverwijzingen (301-redirects) van al je oude links, zodat je Google-posities meeverhuizen." )
   , ( "Worden spaarpunten ook overgezet?"
-    , faqAnswerText "Ja. Spaarpuntensaldi van uw klanten worden meegenomen naar het loyaliteitsprogramma van uw nieuwe platform." )
+    , faqAnswerText "Ja. Spaarpuntensaldi van je klanten worden meegenomen naar het loyaliteitsprogramma van je nieuwe platform." )
   , ( "Verhuizen mijn pagina's, reviews en kortingscodes ook?"
     , faqAnswerHtml $ do
-        "Ja. Informatiepagina's zoals over-ons en verzendinformatie en uw blog verhuizen standaard mee. Reviews neemt u als optie mee in "
+        "Ja. Informatiepagina's zoals over-ons en verzendinformatie en je blog verhuizen standaard mee. Reviews neem je als optie mee in "
         H.a ! A.href "/prijzen.html#rekenhulp" $ "de rekenhulp"
-        ", en ook kortingscodes en cadeaubonnen zetten we voor u over. Alles wat in uw shop zit, kan mee." )
+        ", en ook kortingscodes en cadeaubonnen zetten we voor je over. Alles wat in je shop zit, kan mee." )
   , ( "Hoe werken de SEO-redirects precies?"
     , faqAnswerText "MijnWebwinkel bouwt zijn links op uit interne artikelnummers. We hebben uitgezocht hoe dat precies werkt, waardoor we voor elke oude link automatisch de juiste doorverwijzing (301-redirect) kunnen aanmaken, ook voor links met nummers erin." )
   , ( "Kunnen jullie mijn productdata aanpassen tijdens de migratie?"
-    , faqAnswerText "Ja. We kunnen grootschalige wijzigingen doorvoeren, bijvoorbeeld prijzen aanpassen, beschrijvingen opschonen, of beschrijvingen voor Google toevoegen aan al uw afbeeldingen (alt-teksten)." )
+    , faqAnswerText "Ja. We kunnen grootschalige wijzigingen doorvoeren, bijvoorbeeld prijzen aanpassen, beschrijvingen opschonen, of beschrijvingen voor Google toevoegen aan al je afbeeldingen (alt-teksten)." )
   ]
 
 -- =============================================================================
@@ -1109,7 +1132,7 @@ ccvshopMigrationPage = webwinkelBaseTemplate ccvMeta $
           -- functies gebruikt, prikt daar meteen doorheen. Wat blijft is
           -- wat we kunnen aantonen; de Fiserv-passage blijft bewust een
           -- constatering over zwaartepunt, geen EOL-voorspelling.
-          H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Sinds de Amerikaanse betaalreus Fiserv CCV overnam ligt het zwaartepunt bij betalen en kassa: uw webshop is een tweede rang product. Wij verhuizen uw complete shop geautomatiseerd naar Shopify, WooCommerce of een ander platform van uw keuze: zonder dataverlies, met zo min mogelijk downtime." :: Text)
+          H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Sinds de Amerikaanse betaalreus Fiserv CCV overnam ligt het zwaartepunt bij betalen en kassa: je webshop is een tweede rang product. Wij verhuizen je complete shop geautomatiseerd naar Shopify, WooCommerce of een ander platform van je keuze: zonder dataverlies, met zo min mogelijk downtime." :: Text)
           -- Zelfde besluit als de MWW-hero (3 aug 2026): scanner als eerste
           -- stap in plaats van de offerte.
           H.a ! A.href "/scan.html" ! A.class_ "cta-button" $ "Beoordeel mijn webshop"
@@ -1126,22 +1149,22 @@ ccvshopMigrationPage = webwinkelBaseTemplate ccvMeta $
           H.img ! A.class_ "card-icon" ! A.src "/icoon-producten.svg"
                 ! A.alt "Doos met producten" ! A.width "56" ! A.height "56"
           H.h3 "Producten & varianten"
-          H.p "Alle producten inclusief titels, beschrijvingen, prijzen, afbeeldingen, SKU's en varianten. Automatisch overgezet naar het formaat van uw doelplatform."
+          H.p "Alle producten inclusief titels, beschrijvingen, prijzen, afbeeldingen, SKU's en varianten. Automatisch overgezet naar het formaat van je doelplatform."
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-talen.svg"
                 ! A.alt "Twee tekstballonnen" ! A.width "56" ! A.height "56"
           H.h3 "Meerdere talen"
-          H.p $ H.preEscapedToHtml ("Vertalingen worden correct gekoppeld. Uw klanten blijven uw shop in hun eigen taal zien, ook de URL-slugs." :: Text)
+          H.p $ H.preEscapedToHtml ("Vertalingen worden correct gekoppeld. Je klanten blijven je shop in hun eigen taal zien, ook de URL-slugs." :: Text)
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-spaarpunten.svg"
                 ! A.alt "Munt met ster" ! A.width "56" ! A.height "56"
           H.h3 "Klantaccounts"
-          H.p "Klantgegevens en bestelgeschiedenis worden overgezet zodat uw klanten direct kunnen inloggen op de nieuwe shop."
+          H.p "Klantgegevens en bestelgeschiedenis worden overgezet zodat je klanten direct kunnen inloggen op de nieuwe shop."
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-redirects.svg"
                 ! A.alt "Pijl die een nieuwe route neemt" ! A.width "56" ! A.height "56"
           H.h3 "SEO-redirects"
-          H.p "301-redirects van elke oude URL naar de nieuwe URL. Uw backlinks blijven werken en uw opgebouwde SEO verhuist mee."
+          H.p "301-redirects van elke oude URL naar de nieuwe URL. Je backlinks blijven werken en je opgebouwde SEO verhuist mee."
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-categorieen.svg"
                 ! A.alt "Categorieboom" ! A.width "56" ! A.height "56"
@@ -1151,7 +1174,7 @@ ccvshopMigrationPage = webwinkelBaseTemplate ccvMeta $
           H.img ! A.class_ "card-icon" ! A.src "/icoon-bulk.svg"
                 ! A.alt "Stapel dozen" ! A.width "56" ! A.height "56"
           H.h3 "Voorraad & prijzen"
-          H.p "Voorraadinformatie en staffelprijzen worden meegenomen. Per-variant prijzen en voorraadbeheer werken direct in uw nieuwe shop."
+          H.p "Voorraadinformatie en staffelprijzen worden meegenomen. Per-variant prijzen en voorraadbeheer werken direct in je nieuwe shop."
 
     -- How it works
     H.section ! A.class_ "audit" $ do
@@ -1159,13 +1182,13 @@ ccvshopMigrationPage = webwinkelBaseTemplate ccvMeta $
       H.ol $ do
         H.li $ do
           H.strong "Scan"
-          ": ons programma leest uw CCV Shop volledig uit en zet alles over naar een testshop: producten, vertalingen, collections, redirects."
+          ": ons programma leest je CCV Shop volledig uit en zet alles over naar een testshop: producten, vertalingen, collections, redirects."
         H.li $ do
           H.strong "Wennen"
-          ": de testshop draait naast uw CCV Shop, die gewoon doordraait. U raakt op uw gemak bekend met uw nieuwe shop."
+          ": de testshop draait naast je CCV Shop, die gewoon doordraait. Je raakt op je gemak bekend met je nieuwe shop."
         H.li $ do
           H.strong "DNS-overzet"
-          ": bent u er klaar voor? Dan wijzen we uw domein op de nieuwe shop en bent u verhuisd. We houden de downtime zo klein mogelijk; het aanmaken van een nieuw SSL-certificaat kan nog 5 tot 30 minuten duren."
+          ": ben je er klaar voor? Dan wijzen we je domein op de nieuwe shop en ben je verhuisd. We houden de downtime zo klein mogelijk; het aanmaken van een nieuw SSL-certificaat kan nog 5 tot 30 minuten duren."
 
     -- Pricing
     prijzen
@@ -1186,19 +1209,19 @@ ccvshopMigrationPage = webwinkelBaseTemplate ccvMeta $
       -- grootste groep CCV-vertrekkers groeit uit het platform (top-
       -- bestemming is een custom cart, 13 van 28), dus de pagina spreekt
       -- ambitie aan in plaats van angst.
-      H.p $ H.preEscapedToHtml ("De meeste winkeliers verlaten CCV Shop niet omdat het kapot is, maar omdat ze eruit groeien: maatwerk of functies die er niet in zitten. Shopify en WooCommerce groeien w&eacute;l met u mee, van extra verkoopkanalen en talen tot B2B-maatwerk en duizenden apps. En het lastigste deel van uitgroeien, alles heelhuids overzetten, is precies ons vak." :: Text)
+      H.p $ H.preEscapedToHtml ("De meeste winkeliers verlaten CCV Shop niet omdat het kapot is, maar omdat ze eruit groeien: maatwerk of functies die er niet in zitten. Shopify en WooCommerce groeien w&eacute;l met je mee, van extra verkoopkanalen en talen tot B2B-maatwerk en duizenden apps. En het lastigste deel van uitgroeien, alles heelhuids overzetten, is precies ons vak." :: Text)
       H.p $ do
         H.a ! A.href "/blog/het-miljard-van-shopify-waarom-geen-nederlands-platform-kan-bijbenen.html" $ "Het miljard van Shopify: waarom geen Nederlands platform kan bijbenen"
         H.preEscapedToHtml (" &rarr;" :: Text)
-      H.p $ H.preEscapedToHtml ("Wij zijn migratie-specialisten, geen verlengstuk van &eacute;&eacute;n platform. U kiest het platform: Shopify, WooCommerce, of iets anders. Wij regelen de techniek." :: Text)
+      H.p $ H.preEscapedToHtml ("Wij zijn migratie-specialisten, geen verlengstuk van &eacute;&eacute;n platform. Je kiest het platform: Shopify, WooCommerce, of iets anders. Wij regelen de techniek." :: Text)
       H.ul $ do
-        H.li $ H.strong "Geen risico" >> H.preEscapedToHtml (": u betaalt pas na succesvolle migratie" :: Text)
-        H.li $ H.strong "Platformonafhankelijk" >> H.preEscapedToHtml (": u kiest de bestemming, wij migreren naar elk platform" :: Text)
+        H.li $ H.strong "Geen risico" >> H.preEscapedToHtml (": je betaalt pas na succesvolle migratie" :: Text)
+        H.li $ H.strong "Platformonafhankelijk" >> H.preEscapedToHtml (": je kiest de bestemming, wij migreren naar elk platform" :: Text)
         H.li $ H.strong "Geautomatiseerd" >> H.preEscapedToHtml (": geen handmatig overtypen, geen kopieerfouten" :: Text)
-        H.li $ H.strong "SEO-behoud" >> H.preEscapedToHtml (": elke oude link krijgt een 301-redirect en blijft werken, uw opgebouwde SEO verhuist mee" :: Text)
+        H.li $ H.strong "SEO-behoud" >> H.preEscapedToHtml (": elke oude link krijgt een 301-redirect en blijft werken, je opgebouwde SEO verhuist mee" :: Text)
         H.li $ H.strong "Meertalig" >> H.preEscapedToHtml (": vertalingen correct gekoppeld via offici&euml;le APIs" :: Text)
         H.li $ H.strong "Zelfvaliderend" >> H.preEscapedToHtml (": het programma valideert zijn eigen werk" :: Text)
-        H.li $ H.strong "Vaste prijs" >> H.preEscapedToHtml (": geen uurtarief, u weet vooraf wat het kost" :: Text)
+        H.li $ H.strong "Vaste prijs" >> H.preEscapedToHtml (": geen uurtarief, je weet vooraf wat het kost" :: Text)
 
     -- FAQ. Decision: de aparte "Technische details"-kaartensectie is hierin
     -- opgegaan (review Jappie, 8 aug 2026): hij oogde dubbelop met "Wat we
@@ -1210,8 +1233,8 @@ ccvshopMigrationPage = webwinkelBaseTemplate ccvMeta $
     -- CTA
     H.section ! A.class_ "final-cta" $ do
       H.h2 "Klaar om te ontsnappen?"
-      H.p $ H.preEscapedToHtml ("U hoeft niet langer te wachten tot CCV Shop beter wordt. Neem de controle terug over uw webshop." :: Text)
-      H.p "Plan een gratis, vrijblijvend gesprek. We bekijken samen uw webshop en geven direct een inschatting."
+      H.p $ H.preEscapedToHtml ("Je hoeft niet langer te wachten tot CCV Shop beter wordt. Neem de controle terug over je webshop." :: Text)
+      H.p "Plan een gratis, vrijblijvend gesprek. We bekijken samen je webshop en geven direct een inschatting."
       H.a ! A.href meetLink ! A.class_ "cta-button" $ "Ontsnap nu"
   where
     ccvMeta :: PageMeta
@@ -1231,23 +1254,23 @@ ccvshopMigrationPage = webwinkelBaseTemplate ccvMeta $
 ccvshopFaq :: [(FaqQuestion, FaqAnswer)]
 ccvshopFaq =
   [ ( "Hoe lang duurt een migratie?"
-    , faqAnswerText "Het technische overzetten van uw producten duurt maar enkele uren. Maar er komt bij een verhuizing meestal meer kijken: het thema, apps en plugins, betaalmethoden, en rustig wennen aan uw nieuwe shop. Reken daarom op ongeveer een maand van start tot livegang." )
+    , faqAnswerText "Het technische overzetten van je producten duurt maar enkele uren. Maar er komt bij een verhuizing meestal meer kijken: het thema, apps en plugins, betaalmethoden, en rustig wennen aan je nieuwe shop. Reken daarom op ongeveer een maand van start tot livegang." )
   , ( "Kan ik mijn domeinnaam behouden?"
-    , faqAnswerText "Ja. Na de migratie wijst u uw domein naar Shopify. Alle oude URLs worden automatisch doorgestuurd." )
+    , faqAnswerText "Ja. Na de migratie wijs je je domein naar Shopify. Alle oude URLs worden automatisch doorgestuurd." )
   , ( "Wat als er iets niet klopt na de migratie?"
     , faqAnswerText "Die kans is klein: de migratie is volledig geautomatiseerd en het programma valideert zijn eigen werk. Inmiddels hebben we dit ook meermaals gedaan. Maar fouten kunnen gebeuren, en als er toch iets niet klopt, lossen we het gratis op." )
   , ( "Werkt het ook voor meertalige webshops?"
-    , faqAnswerText "Ja. Nederlands, Duits, Engels, Frans of een andere taal: het programma ondersteunt elke taalcombinatie die CCV Shop en uw doelplatform beide ondersteunen." )
+    , faqAnswerText "Ja. Nederlands, Duits, Engels, Frans of een andere taal: het programma ondersteunt elke taalcombinatie die CCV Shop en je doelplatform beide ondersteunen." )
   , ( "Worden mijn klantaccounts overgezet?"
-    , faqAnswerText "Ja. Klantgegevens en bestelgeschiedenis worden meegenomen zodat uw klanten direct verder kunnen." )
+    , faqAnswerText "Ja. Klantgegevens en bestelgeschiedenis worden meegenomen zodat je klanten direct verder kunnen." )
   , ( "Hoe werken de SEO-redirects precies?"
-    , faqAnswerText "We genereren automatisch 301-redirects van elke oude URL naar het nieuwe adres. Uw Google-rankings en backlinks blijven behouden." )
+    , faqAnswerText "We genereren automatisch 301-redirects van elke oude URL naar het nieuwe adres. Je Google-rankings en backlinks blijven behouden." )
   , ( "Worden voorraad en staffelprijzen correct overgezet?"
-    , faqAnswerText "Ja. Per-variant voorraadbeheer en staffelprijzen worden correct overgezet naar uw nieuwe shop, inclusief prijsverschillen per maat of kleur." )
+    , faqAnswerText "Ja. Per-variant voorraadbeheer en staffelprijzen worden correct overgezet naar je nieuwe shop, inclusief prijsverschillen per maat of kleur." )
   , ( "Verhuizen vertaalde URL-slugs ook mee?"
-    , faqAnswerText "Ja. Meertalige content wordt correct gekoppeld via de offici\235le API van uw doelplatform, inclusief de vertaalde URL-slugs van uw pagina's." )
+    , faqAnswerText "Ja. Meertalige content wordt correct gekoppeld via de offici\235le API van je doelplatform, inclusief de vertaalde URL-slugs van je pagina's." )
   , ( "Krijg ik een testshop om te wennen?"
-    , faqAnswerText "Ja. U krijgt een volledige testshop naast uw huidige shop om alvast te wennen. Pas na uw akkoord gaan we live; eventuele correcties zijn inbegrepen." )
+    , faqAnswerText "Ja. Je krijgt een volledige testshop naast je huidige shop om alvast te wennen. Pas na je akkoord gaan we live; eventuele correcties zijn inbegrepen." )
   , ( "Kunnen jullie mijn productdata aanpassen tijdens de migratie?"
     , faqAnswerText "Ja. We kunnen grootschalige wijzigingen doorvoeren tijdens de migratie: alt-teksten genereren, prijzen aanpassen, beschrijvingen opschonen, alles in \233\233n keer." )
   -- Decision: POS-antwoord is bewust eerlijk over de beperking en
@@ -1260,7 +1283,7 @@ ccvshopFaq =
   -- alleen voor wie een geïntegreerde kassa wil. Bron-onderzoek in
   -- jappiesoft/research/ccv-woocommerce-market-onderzoek.org.
   , ( "Ik heb ook een fysieke winkel met een CCV-pinterminal. Kan die mee?"
-    , faqAnswerText $ "Dat hangt af van uw bestemming. Kiest u WooCommerce, dan kan uw CCV-terminal gewoon gekoppeld blijven: Nederlandse kassasoftware verbindt de terminal en synchroniseert de voorraad met uw webshop, en uw pincontract loopt door. Kiest u Shopify, dan koppelt de terminal niet meer met de kassa; hij kan wel als losse pin blijven werken, maar dan typt u elk bedrag over. Wilt u winkel en webshop weer als \233\233n geheel, dan vervangt u hem door een Shopify-terminal. Die overstap is eenmalig en bescheiden (\8364" <> "59 tot \8364" <> "249) en daarna bent u ook voor het pinnen van CCV af. Wij hebben ervaring met het inrichten van kassa's en pinterminals en nemen dit gewoon in het migratietraject mee." )
+    , faqAnswerText $ "Dat hangt af van je bestemming. Kies je WooCommerce, dan kan je CCV-terminal gewoon gekoppeld blijven: Nederlandse kassasoftware verbindt de terminal en synchroniseert de voorraad met je webshop, en je pincontract loopt door. Kies je Shopify, dan koppelt de terminal niet meer met de kassa; hij kan wel als losse pin blijven werken, maar dan typ je elk bedrag over. Wil je winkel en webshop weer als \233\233n geheel, dan vervang je hem door een Shopify-terminal. Die overstap is eenmalig en bescheiden (\8364" <> "59 tot \8364" <> "249) en daarna ben je ook voor het pinnen van CCV af. Wij hebben ervaring met het inrichten van kassa's en pinterminals en nemen dit gewoon in het migratietraject mee." )
   ]
 
 -- =============================================================================
@@ -1275,7 +1298,7 @@ lightspeedMigrationPage = webwinkelBaseTemplate lightspeedMeta $
       H.div ! A.class_ "hero-grid" $ do
         H.div $ do
           H.h1 "Ontsnap Lightspeed"
-          H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Lightspeed duwt u richting hun nieuwe platform of de deur uit. Ondertussen draait uw webshop op verouderde software die steeds minder krijgt. Wij verhuizen uw complete shop naar Shopify: geautomatiseerd, zonder dataverlies, zonder SEO-verlies." :: Text)
+          H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Lightspeed duwt je richting hun nieuwe platform of de deur uit. Ondertussen draait je webshop op verouderde software die steeds minder krijgt. Wij verhuizen je complete shop naar Shopify: geautomatiseerd, zonder dataverlies, zonder SEO-verlies." :: Text)
           -- Zelfde besluit als de MWW-hero (3 aug 2026): scanner als eerste
           -- stap in plaats van de offerte.
           H.a ! A.href "/scan.html" ! A.class_ "cta-button" $ "Beoordeel mijn webshop"
@@ -1292,22 +1315,22 @@ lightspeedMigrationPage = webwinkelBaseTemplate lightspeedMeta $
           H.img ! A.class_ "card-icon" ! A.src "/icoon-producten.svg"
                 ! A.alt "Doos met producten" ! A.width "56" ! A.height "56"
           H.h3 "Producten & varianten"
-          H.p "Alle producten inclusief titels, beschrijvingen, prijzen, afbeeldingen, SKU's en varianten. Automatisch overgezet naar het formaat van uw doelplatform."
+          H.p "Alle producten inclusief titels, beschrijvingen, prijzen, afbeeldingen, SKU's en varianten. Automatisch overgezet naar het formaat van je doelplatform."
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-talen.svg"
                 ! A.alt "Twee tekstballonnen" ! A.width "56" ! A.height "56"
           H.h3 "Meerdere talen"
-          H.p $ H.preEscapedToHtml ("Vertalingen worden correct gekoppeld. Uw klanten blijven uw shop in hun eigen taal zien, ook de URL-slugs." :: Text)
+          H.p $ H.preEscapedToHtml ("Vertalingen worden correct gekoppeld. Je klanten blijven je shop in hun eigen taal zien, ook de URL-slugs." :: Text)
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-spaarpunten.svg"
                 ! A.alt "Munt met ster" ! A.width "56" ! A.height "56"
           H.h3 "Klantaccounts & bestellingen"
-          H.p "Klantgegevens, bestelgeschiedenis en accountdata worden overgezet zodat uw klanten direct kunnen inloggen op de nieuwe shop."
+          H.p "Klantgegevens, bestelgeschiedenis en accountdata worden overgezet zodat je klanten direct kunnen inloggen op de nieuwe shop."
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-redirects.svg"
                 ! A.alt "Pijl die een nieuwe route neemt" ! A.width "56" ! A.height "56"
           H.h3 "SEO-redirects"
-          H.p "301-redirects van elke oude URL naar de nieuwe URL. Uw backlinks blijven werken en uw opgebouwde SEO verhuist mee; bij onbegeleide migraties zagen we verhalen van 70% verkeersverlies."
+          H.p "301-redirects van elke oude URL naar de nieuwe URL. Je backlinks blijven werken en je opgebouwde SEO verhuist mee; bij onbegeleide migraties zagen we verhalen van 70% verkeersverlies."
         H.li ! A.class_ "card" $ do
           H.img ! A.class_ "card-icon" ! A.src "/icoon-categorieen.svg"
                 ! A.alt "Categorieboom" ! A.width "56" ! A.height "56"
@@ -1317,7 +1340,7 @@ lightspeedMigrationPage = webwinkelBaseTemplate lightspeedMeta $
           H.img ! A.class_ "card-icon" ! A.src "/icoon-bulk.svg"
                 ! A.alt "Stapel dozen" ! A.width "56" ! A.height "56"
           H.h3 "Voorraad & prijzen"
-          H.p "Voorraadbeheer, staffelprijzen en per-variant pricing worden correct overgezet. Uw voorraadniveaus kloppen direct in uw nieuwe shop."
+          H.p "Voorraadbeheer, staffelprijzen en per-variant pricing worden correct overgezet. Je voorraadniveaus kloppen direct in je nieuwe shop."
 
     -- How it works
     H.section ! A.class_ "audit" $ do
@@ -1325,13 +1348,13 @@ lightspeedMigrationPage = webwinkelBaseTemplate lightspeedMeta $
       H.ol $ do
         H.li $ do
           H.strong "Scan"
-          ": ons programma leest uw Lightspeed-shop volledig uit en zet alles over naar een testshop: producten, vertalingen, collections, redirects."
+          ": ons programma leest je Lightspeed-shop volledig uit en zet alles over naar een testshop: producten, vertalingen, collections, redirects."
         H.li $ do
           H.strong "Wennen"
-          ": de testshop draait naast uw Lightspeed-shop, die gewoon doordraait. U raakt op uw gemak bekend met uw nieuwe shop."
+          ": de testshop draait naast je Lightspeed-shop, die gewoon doordraait. Je raakt op je gemak bekend met je nieuwe shop."
         H.li $ do
           H.strong "DNS-overzet"
-          ": bent u er klaar voor? Dan wijzen we uw domein op de nieuwe shop en bent u verhuisd. We houden de downtime zo klein mogelijk; het aanmaken van een nieuw SSL-certificaat kan nog 5 tot 30 minuten duren."
+          ": ben je er klaar voor? Dan wijzen we je domein op de nieuwe shop en ben je verhuisd. We houden de downtime zo klein mogelijk; het aanmaken van een nieuw SSL-certificaat kan nog 5 tot 30 minuten duren."
 
     -- Pricing
     prijzen
@@ -1341,19 +1364,19 @@ lightspeedMigrationPage = webwinkelBaseTemplate lightspeedMeta $
       H.h2 "Waarom via ons?"
       H.div ! A.class_ "testimonials" $ do
         H.blockquote $ do
-          H.p $ H.preEscapedToHtml ("U bent niet de enige: 59% van alle Lightspeed-vertrekkers kiest Shopify. Maar zonder begeleiding gaan bij de overstap vaak oude URLs kapot; wij hebben verhalen gezien van 70% verkeersverlies bij een onbegeleide migratie. Wij zorgen dat elke oude URL blijft doorverwijzen (ons programma legt ze allemaal vast, niet een steekproef) en uw opgebouwde SEO meeverhuist." :: Text)
+          H.p $ H.preEscapedToHtml ("Je bent niet de enige: 59% van alle Lightspeed-vertrekkers kiest Shopify. Maar zonder begeleiding gaan bij de overstap vaak oude URLs kapot; wij hebben verhalen gezien van 70% verkeersverlies bij een onbegeleide migratie. Wij zorgen dat elke oude URL blijft doorverwijzen (ons programma legt ze allemaal vast, niet een steekproef) en je opgebouwde SEO meeverhuist." :: Text)
           H.p $ do
             H.a ! A.href "/waarom-lightspeed.html" $ "Waarom verlaten steeds meer webshops Lightspeed?"
             H.preEscapedToHtml (" &rarr;" :: Text)
-      H.p $ H.preEscapedToHtml ("Wij zijn migratie-specialisten, geen verlengstuk van &eacute;&eacute;n platform. U kiest het platform: Shopify, WooCommerce, of iets anders. Wij regelen de techniek." :: Text)
+      H.p $ H.preEscapedToHtml ("Wij zijn migratie-specialisten, geen verlengstuk van &eacute;&eacute;n platform. Je kiest het platform: Shopify, WooCommerce, of iets anders. Wij regelen de techniek." :: Text)
       H.ul $ do
-        H.li $ H.strong "Geen risico" >> H.preEscapedToHtml (": u betaalt pas na succesvolle migratie" :: Text)
-        H.li $ H.strong "Platformonafhankelijk" >> H.preEscapedToHtml (": u kiest de bestemming, wij migreren naar elk platform" :: Text)
-        H.li $ H.strong "SEO-behoud" >> H.preEscapedToHtml (": elke oude link krijgt een 301-redirect en blijft werken, uw opgebouwde SEO verhuist mee" :: Text)
+        H.li $ H.strong "Geen risico" >> H.preEscapedToHtml (": je betaalt pas na succesvolle migratie" :: Text)
+        H.li $ H.strong "Platformonafhankelijk" >> H.preEscapedToHtml (": je kiest de bestemming, wij migreren naar elk platform" :: Text)
+        H.li $ H.strong "SEO-behoud" >> H.preEscapedToHtml (": elke oude link krijgt een 301-redirect en blijft werken, je opgebouwde SEO verhuist mee" :: Text)
         H.li $ H.strong "Geautomatiseerd" >> H.preEscapedToHtml (": geen handmatig overtypen, geen kopieerfouten" :: Text)
         H.li $ H.strong "Meertalig" >> H.preEscapedToHtml (": vertalingen correct gekoppeld via offici&euml;le APIs" :: Text)
         H.li $ H.strong "Zelfvaliderend" >> H.preEscapedToHtml (": het programma valideert zijn eigen werk" :: Text)
-        H.li $ H.strong "Vaste prijs" >> H.preEscapedToHtml (": geen uurtarief, u weet vooraf wat het kost" :: Text)
+        H.li $ H.strong "Vaste prijs" >> H.preEscapedToHtml (": geen uurtarief, je weet vooraf wat het kost" :: Text)
 
     -- FAQ. Decision: de aparte "Technische details"-kaartensectie is hierin
     -- opgegaan (review Jappie, 8 aug 2026), net als op de CCV-pagina.
@@ -1364,8 +1387,8 @@ lightspeedMigrationPage = webwinkelBaseTemplate lightspeedMeta $
     -- CTA
     H.section ! A.class_ "final-cta" $ do
       H.h2 "Klaar om te ontsnappen?"
-      H.p $ H.preEscapedToHtml ("Lightspeed gaat u niet helpen met deze overstap. Wij wel." :: Text)
-      H.p "Plan een gratis, vrijblijvend gesprek. We bekijken samen uw webshop en geven direct een inschatting."
+      H.p $ H.preEscapedToHtml ("Lightspeed ga je niet helpen met deze overstap. Wij wel." :: Text)
+      H.p "Plan een gratis, vrijblijvend gesprek. We bekijken samen je webshop en geven direct een inschatting."
       H.a ! A.href meetLink ! A.class_ "cta-button" $ "Ontsnap nu"
   where
     lightspeedMeta :: PageMeta
@@ -1385,23 +1408,23 @@ lightspeedMigrationPage = webwinkelBaseTemplate lightspeedMeta $
 lightspeedFaq :: [(FaqQuestion, FaqAnswer)]
 lightspeedFaq =
   [ ( "Hoe lang duurt een migratie?"
-    , faqAnswerText "Het technische overzetten van uw producten duurt maar enkele uren. Maar er komt bij een verhuizing meestal meer kijken: het thema, apps en plugins, betaalmethoden, en rustig wennen aan uw nieuwe shop. Reken daarom op ongeveer een maand van start tot livegang." )
+    , faqAnswerText "Het technische overzetten van je producten duurt maar enkele uren. Maar er komt bij een verhuizing meestal meer kijken: het thema, apps en plugins, betaalmethoden, en rustig wennen aan je nieuwe shop. Reken daarom op ongeveer een maand van start tot livegang." )
   , ( "Kan ik mijn domeinnaam behouden?"
-    , faqAnswerText "Ja. Na de migratie wijst u uw domein naar Shopify. Alle oude URLs worden automatisch doorgestuurd." )
+    , faqAnswerText "Ja. Na de migratie wijs je je domein naar Shopify. Alle oude URLs worden automatisch doorgestuurd." )
   , ( "Wat als er iets niet klopt na de migratie?"
     , faqAnswerText "Die kans is klein: de migratie is volledig geautomatiseerd en het programma valideert zijn eigen werk. Inmiddels hebben we dit ook meermaals gedaan. Maar fouten kunnen gebeuren, en als er toch iets niet klopt, lossen we het gratis op." )
   , ( "Verlies ik mijn Google-posities?"
-    , faqAnswerText "Elke oude URL krijgt automatisch een 301-redirect, zodat al uw links en backlinks blijven werken en de opgebouwde SEO meeverhuist. Google kan na elke grote sitewijziging tijdelijk schommelen; het blijvende verlies uit de horrorverhalen komt door ontbrekende redirects, en dat dekken wij volledig af." )
+    , faqAnswerText "Elke oude URL krijgt automatisch een 301-redirect, zodat al je links en backlinks blijven werken en de opgebouwde SEO meeverhuist. Google kan na elke grote sitewijziging tijdelijk schommelen; het blijvende verlies uit de horrorverhalen komt door ontbrekende redirects, en dat dekken wij volledig af." )
   , ( "Werkt het ook voor meertalige webshops?"
     , faqAnswerText "Ja. Nederlands, Duits, Engels, Frans of een andere taal: het programma ondersteunt elke taalcombinatie die Lightspeed en Shopify beide ondersteunen." )
   , ( "Worden mijn klantaccounts overgezet?"
-    , faqAnswerText "Ja. Klantgegevens en bestelgeschiedenis worden meegenomen zodat uw klanten direct verder kunnen." )
+    , faqAnswerText "Ja. Klantgegevens en bestelgeschiedenis worden meegenomen zodat je klanten direct verder kunnen." )
   , ( "Worden voorraad en staffelprijzen correct overgezet?"
-    , faqAnswerText "Ja. Per-variant voorraadbeheer en staffelprijzen worden correct overgezet naar uw nieuwe shop, inclusief prijsverschillen per maat of kleur." )
+    , faqAnswerText "Ja. Per-variant voorraadbeheer en staffelprijzen worden correct overgezet naar je nieuwe shop, inclusief prijsverschillen per maat of kleur." )
   , ( "Verhuizen vertaalde URL-slugs ook mee?"
-    , faqAnswerText "Ja. Meertalige content wordt correct gekoppeld via de offici\235le API van uw doelplatform, inclusief de vertaalde URL-slugs van uw pagina's." )
+    , faqAnswerText "Ja. Meertalige content wordt correct gekoppeld via de offici\235le API van je doelplatform, inclusief de vertaalde URL-slugs van je pagina's." )
   , ( "Krijg ik een testshop om te wennen?"
-    , faqAnswerText "Ja. U krijgt een volledige testshop naast uw huidige shop om alvast te wennen. Pas na uw akkoord gaan we live; eventuele correcties zijn inbegrepen." )
+    , faqAnswerText "Ja. Je krijgt een volledige testshop naast je huidige shop om alvast te wennen. Pas na je akkoord gaan we live; eventuele correcties zijn inbegrepen." )
   , ( "Kunnen jullie mijn productdata aanpassen tijdens de migratie?"
     , faqAnswerText "Ja. We kunnen grootschalige wijzigingen doorvoeren tijdens de migratie: alt-teksten genereren, prijzen aanpassen, beschrijvingen opschonen, alles in \233\233n keer." )
   ]
@@ -1505,7 +1528,7 @@ mijnwebwinkelWaaromPage = webwinkelBaseTemplate waaromMeta $
     -- CTA
     H.section ! A.class_ "final-cta" $ do
       H.h2 "Klaar om te vertrekken?"
-      H.p $ H.preEscapedToHtml ("MijnWebwinkel wordt niet meer beter. Het platform is verkocht, de code is bevroren, en de opvolger kost het dubbele. U kunt wachten tot u <em>gedwongen</em> wordt te migreren naar Acendy, of u kunt nu zelf kiezen waar u naartoe gaat." :: Text)
+      H.p $ H.preEscapedToHtml ("MijnWebwinkel wordt niet meer beter. Het platform is verkocht, de code is bevroren, en de opvolger kost het dubbele. Je kunt wachten tot je <em>gedwongen</em> wordt te migreren naar Acendy, of je kunt nu zelf kiezen waar je naartoe gaat." :: Text)
       H.p $ do
         H.a ! A.href "/migrate-mijnwebwinkel.html" $ "Bekijk onze migratieservice"
         H.preEscapedToHtml (": volledig geautomatiseerd, vaste prijs, betaling na succes." :: Text)
@@ -1546,8 +1569,8 @@ lightspeedWaaromPage = webwinkelBaseTemplate waaromLsMeta $
         H.li $ do
           H.strong "Meer omzet per klant"
           H.preEscapedToHtml (": en d&aacute;t is precies wat er gebeurt" :: Text)
-      H.p $ H.preEscapedToHtml ("Het gevolg: de goedkoopste plannen worden duurder, features worden weggehaald uit lagere tiers, en het hele platform wordt opgeschoven richting grotere winkeliers die meer betalen. <strong>U als kleine webshop bent niet de doelgroep, u bent de ballast.</strong>" :: Text)
-      H.p $ H.preEscapedToHtml ("Wij vinden dat fundamenteel verkeerd. Kleine webshops groeien; dat is het hele punt. De webshop van vandaag met 200 producten is de webshop van volgend jaar met 2.000 producten. Maar als Lightspeed niet in die groei gelooft, hoeft u daar niet op te wachten. Wij helpen u graag naar een platform dat w&eacute;l in u investeert." :: Text)
+      H.p $ H.preEscapedToHtml ("Het gevolg: de goedkoopste plannen worden duurder, features worden weggehaald uit lagere tiers, en het hele platform wordt opgeschoven richting grotere winkeliers die meer betalen. <strong>Je als kleine webshop bent niet de doelgroep, je bent de ballast.</strong>" :: Text)
+      H.p $ H.preEscapedToHtml ("Wij vinden dat fundamenteel verkeerd. Kleine webshops groeien; dat is het hele punt. De webshop van vandaag met 200 producten is de webshop van volgend jaar met 2.000 producten. Maar als Lightspeed niet in die groei gelooft, hoef je daar niet op te wachten. Wij helpen je graag naar een platform dat w&eacute;l in je investeert." :: Text)
 
     -- Timeline
     H.section ! A.class_ "for-who" $ do
@@ -1602,7 +1625,7 @@ lightspeedWaaromPage = webwinkelBaseTemplate waaromLsMeta $
       H.ol $ do
         H.li $ do
           H.strong "Consolideer platforms"
-          H.preEscapedToHtml (": het oude eCom (C-Series) wordt afgebouwd. De opvolger is E-Series, gebaseerd op het opgekochte Ecwid. Uw huidige shop is legacy." :: Text)
+          H.preEscapedToHtml (": het oude eCom (C-Series) wordt afgebouwd. De opvolger is E-Series, gebaseerd op het opgekochte Ecwid. Je huidige shop is legacy." :: Text)
         H.li $ do
           H.strong "Verschuif naar enterprise"
           H.preEscapedToHtml (": het Professional-plan kost &euro;259/maand, Enterprise is op offerte. Lightspeed wil minder klanten die meer betalen." :: Text)
@@ -1640,7 +1663,7 @@ lightspeedWaaromPage = webwinkelBaseTemplate waaromLsMeta $
     -- CTA
     H.section ! A.class_ "final-cta" $ do
       H.h2 "Klaar om te vertrekken?"
-      H.p $ H.preEscapedToHtml ("Lightspeed wordt elk kwartaal duurder en elk kwartaal minder gericht op u. U kunt wachten tot de volgende prijsverhoging, of u kunt nu zelf kiezen waar u naartoe gaat." :: Text)
+      H.p $ H.preEscapedToHtml ("Lightspeed wordt elk kwartaal duurder en elk kwartaal minder gericht op je. Je kunt wachten tot de volgende prijsverhoging, of je kunt nu zelf kiezen waar je naartoe gaat." :: Text)
       H.p $ do
         H.a ! A.href "/migrate-lightspeed.html" $ "Bekijk onze migratieservice"
         H.preEscapedToHtml (": volledig geautomatiseerd, vaste prijs, betaling na succes." :: Text)
@@ -1758,16 +1781,16 @@ webwinkelverhuisSitemap articles = T.unlines $
 -- bump-on-edit rule above.
 webwinkelverhuisStaticPages :: [(Text, Day)]
 webwinkelverhuisStaticPages =
-  [ ("https://webwinkelverhuis.nl/", fromGregorian 2026 8 3)
-  , ("https://webwinkelverhuis.nl/prijzen.html", fromGregorian 2026 8 3)
-  , ("https://webwinkelverhuis.nl/scan.html", fromGregorian 2026 8 3)
-  , ("https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html", fromGregorian 2026 8 3)
-  , ("https://webwinkelverhuis.nl/migrate-ccvshop.html", fromGregorian 2026 8 3)
-  , ("https://webwinkelverhuis.nl/migrate-lightspeed.html", fromGregorian 2026 8 3)
-  , ("https://webwinkelverhuis.nl/waarom-mijnwebwinkel.html", fromGregorian 2026 8 2)
-  , ("https://webwinkelverhuis.nl/waarom-lightspeed.html", fromGregorian 2026 8 2)
-  , ("https://webwinkelverhuis.nl/over-ons.html", fromGregorian 2026 8 4)
-  , ("https://webwinkelverhuis.nl/contact.html", fromGregorian 2026 8 4)
+  [ ("https://webwinkelverhuis.nl/", fromGregorian 2026 8 8)
+  , ("https://webwinkelverhuis.nl/prijzen.html", fromGregorian 2026 8 8)
+  , ("https://webwinkelverhuis.nl/scan.html", fromGregorian 2026 8 8)
+  , ("https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html", fromGregorian 2026 8 8)
+  , ("https://webwinkelverhuis.nl/migrate-ccvshop.html", fromGregorian 2026 8 8)
+  , ("https://webwinkelverhuis.nl/migrate-lightspeed.html", fromGregorian 2026 8 8)
+  , ("https://webwinkelverhuis.nl/waarom-mijnwebwinkel.html", fromGregorian 2026 8 8)
+  , ("https://webwinkelverhuis.nl/waarom-lightspeed.html", fromGregorian 2026 8 8)
+  , ("https://webwinkelverhuis.nl/over-ons.html", fromGregorian 2026 8 8)
+  , ("https://webwinkelverhuis.nl/contact.html", fromGregorian 2026 8 8)
   ]
 
 webwinkelStaticSitemapEntry :: (Text, Day) -> Text
@@ -1812,7 +1835,7 @@ overOnsPage = webwinkelBaseTemplate overOnsMeta $
   H.main $ do
     H.section ! A.class_ "hero" $ do
       H.h1 "Over ons"
-      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Webwinkelverhuis is een dienst van Jappie Software, een klein softwarebedrijf uit Kampen. Met z&rsquo;n twee&euml;n, korte lijnen: u spreekt direct met degene die uw migratie ook echt uitvoert." :: Text)
+      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Webwinkelverhuis is een dienst van Jappie Software, een klein softwarebedrijf uit Kampen. Met z&rsquo;n twee&euml;n, korte lijnen: je spreekt direct met degene die je migratie ook echt uitvoert." :: Text)
 
     H.section ! A.class_ "audit" $ do
       H.h2 "Het verhaal"
@@ -1824,7 +1847,7 @@ overOnsPage = webwinkelBaseTemplate overOnsMeta $
             H.preEscapedToHtml ("Webwinkelverhuis ontstond uit de eerste migratie die we deden: " :: Text)
             H.a ! A.href "/blog/klantverhaal-panzer-shopnl-van-mijnwebwinkel-naar-shopify-in-drie-talen.html" $ "panzer-shop.nl"
             H.preEscapedToHtml (", 2.400 producten in drie talen. In plaats van alles met de hand over te tikken bouwden we er gereedschap voor dat elke link, elk product en elke vertaling controleerbaar overzet. Dat gereedschap is sindsdien met elke verhuizing beter geworden. We hebben er inmiddels zoveel vertrouwen in dat we pas kosten in rekening brengen na een succesvolle verhuizing." :: Text)
-          H.p $ H.preEscapedToHtml ("Na de verhuizing draait uw winkel bovendien op een standaard platform: elke ontwikkelaar kan ermee verder, u bent nooit van ons afhankelijk." :: Text)
+          H.p $ H.preEscapedToHtml ("Na de verhuizing draait je winkel bovendien op een standaard platform: elke ontwikkelaar kan ermee verder, je bent nooit van ons afhankelijk." :: Text)
           H.p $ H.preEscapedToHtml ("Inmiddels doen we dit met z&rsquo;n twee&euml;n. Leana kwam bij het bedrijf om een opdracht voor de Haskell Foundation uit te voeren en is een expert in build-systemen; het migratievak leert ze er in de praktijk bij." :: Text)
         H.div ! A.class_ "portret-beeld" $
           H.img ! A.src "/assets/beeld/jappie-fit.jpg"
@@ -1840,7 +1863,7 @@ overOnsPage = webwinkelBaseTemplate overOnsMeta $
 
     H.section ! A.class_ "cta-section" $ do
       H.h2 "Kennismaken?"
-      H.p "Een gesprek kost niets en u weet meteen met wie u te maken heeft."
+      H.p "Een gesprek kost niets en je weet meteen met wie je te maken heeft."
       H.a ! A.href meetLink ! A.class_ "cta-button" $ "Plan een gesprek"
   where
     overOnsMeta :: PageMeta
@@ -1866,10 +1889,10 @@ contactPage = webwinkelBaseTemplate contactMeta $
   H.main $ do
     H.section ! A.class_ "hero" $ do
       H.h1 "Contact"
-      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Geen helpdesk, geen wachtrij: u krijgt antwoord van degene die uw migratie ook uitvoert." :: Text)
+      H.p ! A.class_ "subtitle" $ H.preEscapedToHtml ("Geen helpdesk, geen wachtrij: je krijgt antwoord van degene die je migratie ook uitvoert." :: Text)
 
     H.section ! A.class_ "audit" $ do
-      H.h2 "Zo bereikt u ons"
+      H.h2 "Zo bereik je ons"
       H.ul $ do
         H.li $ do
           H.strong "E-mail: "
@@ -1886,14 +1909,14 @@ contactPage = webwinkelBaseTemplate contactMeta $
       H.p $ H.preEscapedToHtml ("Webwinkelverhuis is een dienst van Jappie Software B.V.<br>Ooievaarstraat 38, 8262 AN Kampen<br>KvK: 95097872 &middot; BTW: NL867000569B01" :: Text)
 
     H.section ! A.class_ "cta-section" $ do
-      H.h2 "Benieuwd wat uw webshop zou kosten?"
-      H.p "Vraag vrijblijvend een offerte aan; u betaalt pas na een geslaagde migratie."
+      H.h2 "Benieuwd wat je webshop zou kosten?"
+      H.p "Vraag vrijblijvend een offerte aan; je betaalt pas na een geslaagde migratie."
       H.a ! A.href offerteMailto ! A.class_ "cta-button" $ "Vraag een offerte aan"
   where
     contactMeta :: PageMeta
     contactMeta = PageMeta
       { pageMetaTitle       = "Contact \8212 Webwinkelverhuis"
-      , pageMetaDescription = "Neem contact op met Webwinkelverhuis: e-mail, telefoon, WhatsApp of plan direct een gratis gesprek. U spreekt met degene die uw migratie uitvoert."
+      , pageMetaDescription = "Neem contact op met Webwinkelverhuis: e-mail, telefoon, WhatsApp of plan direct een gratis gesprek. Je spreekt met degene die je migratie uitvoert."
       , pageMetaLang        = "nl"
       , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/contact.html"
       , pageMetaOgImage     = Nothing

--- a/shake/shake.cabal
+++ b/shake/shake.cabal
@@ -9,6 +9,7 @@ build-type:         Simple
 executable shake-blog
   main-is:          Shakefile.hs
   other-modules:
+    AssetHash
     Feed
     Metadata
     PageChrome
@@ -44,6 +45,7 @@ test-suite unit
   type:             exitcode-stdio-1.0
   main-is:          Test.hs
   other-modules:
+    AssetHash
     PageChrome
     PenguinTemplates
     Types
@@ -57,6 +59,7 @@ test-suite unit
     , blaze-markup >=0.8 && <0.9
     , bytestring >=0.10 && <0.13
     , http-types >=0.12 && <0.13
+    , SHA >=1.6 && <1.7
     , tasty >=1.4 && <1.6
     , tasty-hunit >=0.10 && <0.11
     , text >=1.2 && <2.2

--- a/shake/shake.cabal
+++ b/shake/shake.cabal
@@ -32,6 +32,7 @@ executable shake-blog
     , filepath >=1.4 && <1.6
     , http-types >=0.12 && <0.13
     , pandoc >=3.0 && <3.8
+    , SHA >=1.6 && <1.7
     , shake >=0.19 && <0.20
     , text >=1.2 && <2.2
     , time >=1.9 && <1.15

--- a/shake/test/Test.hs
+++ b/shake/test/Test.hs
@@ -27,6 +27,9 @@ import Text.Blaze.Html5 ((!))
 import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 
+import AssetHash (GehashteAssets(..), gehashteAssetNaam, herschrijfAssetVerwijzingen)
+import Data.Char (isHexDigit)
+import qualified Data.ByteString.Char8 as BSC
 import PageChrome (faqAnswerHtml, faqPageJsonLd, renderFaqItem)
 import Types (Article(..))
 import PenguinTemplates
@@ -180,7 +183,59 @@ main = defaultMain $
         , blogIndexAdvertisesNewestArticleLastmod
         , articleWithoutModifiedFallsBackToPublicationDate
         ]
+    , testGroup "asset cache-busting"
+        [ assetVerwijzingenWordenHerschreven
+        , gehashteNaamVolgtInhoud
+        ]
     ]
+
+-- | Een herkenbare vaste set gehashte namen voor de herschrijftest.
+testGehashteAssets :: GehashteAssets
+testGehashteAssets = GehashteAssets
+  { gehashteStyleCss = "style-aaaaaaaaaa.css"
+  , gehashteBlogCss = "blog-bbbbbbbbbb.css"
+  , gehashtePrijsCalculatorJs = "prijs-calculator-cccccccccc.js"
+  , gehashteScannerFormJs = "scanner-form-dddddddddd.js"
+  }
+
+-- | Elke logische assetverwijzing in een pagina moet naar zijn gehashte
+-- naam herschreven worden; andere paden moeten met rust gelaten worden.
+assetVerwijzingenWordenHerschreven :: TestTree
+assetVerwijzingenWordenHerschreven = testCase "logische namen worden gehashte namen" $ do
+  let pagina = TL.pack
+        "<link href=\"/style.css\"><link href=\"/blog.css\">\
+        \<script src=\"/prijs-calculator.js\"></script>\
+        \<script src=\"/scanner-form.js\"></script>\
+        \<img src=\"/assets/beeld/logo-breed.png\">"
+      herschreven = herschrijfAssetVerwijzingen testGehashteAssets pagina
+  assertBool "style.css is niet herschreven"
+    (TL.pack "href=\"/style-aaaaaaaaaa.css\"" `TL.isInfixOf` herschreven)
+  assertBool "blog.css is niet herschreven"
+    (TL.pack "href=\"/blog-bbbbbbbbbb.css\"" `TL.isInfixOf` herschreven)
+  assertBool "prijs-calculator.js is niet herschreven"
+    (TL.pack "src=\"/prijs-calculator-cccccccccc.js\"" `TL.isInfixOf` herschreven)
+  assertBool "scanner-form.js is niet herschreven"
+    (TL.pack "src=\"/scanner-form-dddddddddd.js\"" `TL.isInfixOf` herschreven)
+  assertBool "een niet-gehasht pad is aangeraakt"
+    (TL.pack "src=\"/assets/beeld/logo-breed.png\"" `TL.isInfixOf` herschreven)
+  assertBool "er verwijst nog een pagina naar de ongehashte stylesheet"
+    (not (TL.pack "\"/style.css\"" `TL.isInfixOf` herschreven))
+
+-- | De gehashte naam is deterministisch voor dezelfde inhoud, verandert met
+-- de inhoud mee, en volgt het patroon basisnaam-<10 hex>.extensie.
+gehashteNaamVolgtInhoud :: TestTree
+gehashteNaamVolgtInhoud = testCase "gehashte naam volgt de inhoud" $ do
+  let naamA = gehashteAssetNaam "style" "css" (BSC.pack "body { color: red }")
+      naamA' = gehashteAssetNaam "style" "css" (BSC.pack "body { color: red }")
+      naamB = gehashteAssetNaam "style" "css" (BSC.pack "body { color: blue }")
+      hashDeel = take 10 (drop (length ("style-" :: String)) naamA)
+  assertBool "zelfde inhoud geeft niet dezelfde naam" (naamA == naamA')
+  assertBool "andere inhoud geeft niet een andere naam" (naamA /= naamB)
+  assertBool ("naam volgt het patroon niet: " <> naamA)
+    (take 6 naamA == "style-"
+      && length naamA == length ("style-" :: String) + 10 + length (".css" :: String)
+      && all isHexDigit hashDeel
+      && drop (length naamA - 4) naamA == ".css")
 
 -- | An article carrying only the fields the sitemap reads; the rest is
 -- inert filler.

--- a/webwinkel/content/alternatief-voor-acendy.org
+++ b/webwinkel/content/alternatief-voor-acendy.org
@@ -1,15 +1,16 @@
 #+TITLE: Alternatief voor Acendy? Zo zit het met MijnWebwinkel, Mystore en Norvato
 #+DATE: 2026-07-31
+#+MODIFIED: 2026-08-08
 #+CATEGORY: migratie
 #+TAGS: acendy, mijnwebwinkel, migratie
 
-Zoekt u een alternatief voor Acendy? Acendy is de naam waaronder
+Zoek je een alternatief voor Acendy? Acendy is de naam waaronder
 MijnWebwinkel eind 2025 kort verderging na een samenvoeging met het
 Noorse Mystore. Die naamswijziging werd snel teruggedraaid, maar de
 onrust eromheen is begrijpelijk: het platform is de afgelopen jaren
 meerdere keren van eigenaar en naam gewisseld, terwijl de ontwikkeling
 stilstaat. In dit artikel zetten we op een rij wat er precies is
-gebeurd, wat het voor uw webshop betekent, en welke alternatieven u
+gebeurd, wat het voor je webshop betekent, en welke alternatieven je
 heeft.
 
 * Wat is er gebeurd: van MijnWebwinkel naar Acendy naar Norvato
@@ -35,11 +36,11 @@ De korte versie, met bronnen:
    voor en houdt alleen kernproducten aan.
 
 Drie namen in drie maanden dus: MijnWebwinkel, Acendy, en nu een
-plek in de Norvato-portefeuille. Voor u als winkelier is de naam
+plek in de Norvato-portefeuille. Voor je als winkelier is de naam
 het minst belangrijke deel. Belangrijker is wat er ondertussen met
 het product gebeurt.
 
-* Wat dit voor uw webshop betekent
+* Wat dit voor je webshop betekent
 
 Sinds de overname in 2021 is de ontwikkeling van het platform
 feitelijk gestopt, terwijl de prijzen stegen: het goedkoopste plan
@@ -57,28 +58,28 @@ uit februari 2025 en de App Store-pagina geeft inmiddels "niet
 gevonden" (gecontroleerd juli 2026), terwijl de kassa-add-on gewoon
 wordt doorverkocht. Geïnstalleerde exemplaren blijven werken, maar
 een nieuwe of gereset iPad kan de app niet meer installeren: gaat
-uw iPad stuk, dan staat u van de ene op de andere dag zonder kassa.
+je iPad stuk, dan sta je van de ene op de andere dag zonder kassa.
 
 Waarom dat zo loopt, en waarom dit geen incompetentie maar een
 bewuste keuze van de eigenaren is, leggen we uit op onze pagina
 [[https://webwinkelverhuis.nl/waarom-mijnwebwinkel.html][waarom wordt
 MijnWebwinkel niet meer doorontwikkeld]].
 
-* Welke alternatieven heeft u?
+* Welke alternatieven heb je?
 
-Eerlijk is eerlijk: u hoeft niet per se weg. Uw shop blijft
-vooralsnog gewoon draaien, en als uw winkel klein is en u tevreden
-bent, is afwachten een legitieme keuze. U loopt wel het risico dat
-u op een later moment op andermans tijdlijn moet verhuizen, in
+Eerlijk is eerlijk: je hoeft niet per se weg. Je shop blijft
+vooralsnog gewoon draaien, en als je winkel klein is en je tevreden
+bent, is afwachten een legitieme keuze. Je loopt wel het risico dat
+je op een later moment op andermans tijdlijn moet verhuizen, in
 plaats van op de uwe.
 
-Kiest u er wél voor om te vertrekken, dan zijn dit de gangbare
+Kies je er wél voor om te vertrekken, dan zijn dit de gangbare
 bestemmingen:
 
 1. Shopify is het meest gekozen alternatief: van de vertrekkende
    MijnWebwinkel-shops kiest 55 procent hiervoor (StoreLeads, mei
    2026). Groot app-aanbod, actieve doorontwikkeling, en iDEAL werkt
-   gewoon. Hoe de twee platformen zich verhouden leest u in onze
+   gewoon. Hoe de twee platformen zich verhouden lees je in onze
    [[https://webwinkelverhuis.nl/blog/mijnwebwinkel-vs-shopify-een-eerlijke-vergelijking-voor-nederlandse-webshops.html][eerlijke
    vergelijking van MijnWebwinkel en Shopify]].
 2. WooCommerce past bij wie een eigen WordPress-omgeving wil, met
@@ -86,27 +87,27 @@ bestemmingen:
    onderhoud erbij.
 3. Andere platformen zijn net zo goed prima. CCV Shop bijvoorbeeld
    is ook een Nederlands pakket met iDEAL en Nederlandse support,
-   en er zijn er meer. Waar het om gaat is dat het platform bij uw
+   en er zijn er meer. Waar het om gaat is dat het platform bij je
    winkel past, niet dat het een bepaalde naam draagt.
 
-Waar u ook heen gaat, let bij de overstap op drie dingen: krijgt u
-uw data mee (producten, teksten, klanten), blijven uw oude URLs
-werken via 301-redirects, en kan uw huidige shop blijven
+Waar je ook heen gaat, let bij de overstap op drie dingen: krijg je
+je data mee (producten, teksten, klanten), blijven je oude URLs
+werken via 301-redirects, en kan je huidige shop blijven
 doorverkopen terwijl de nieuwe wordt opgebouwd. Vooral dat tweede
 punt wordt vaak vergeten, en dat kost
 [[https://webwinkelverhuis.nl/blog/waarom-de-meeste-mijnwebwinkel-migraties-hun-google-posities-verliezen.html][Google-posities
-die u jaren heeft opgebouwd]].
+die je jaren heeft opgebouwd]].
 
 * Overstappen zonder gedoe
 
-Wij verhuizen webshops van MijnWebwinkel naar het platform van uw
+Wij verhuizen webshops van MijnWebwinkel naar het platform van je
 keuze: producten, vertalingen, afbeeldingen, klanten en de volledige
 categoriestructuur, inclusief automatisch gegenereerde 301-redirects
 voor elke oude URL. Vaste prijs, betaling na een geslaagde migratie.
 Lees hoe [[https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html][onze
 migratieservice]] werkt, of
 [[https://meet.jappiesoftware.com][plan een vrijblijvend gesprek]]:
-we kijken samen naar uw shop en geven een eerlijke inschatting, ook
+we kijken samen naar je shop en geven een eerlijke inschatting, ook
 als die inschatting "blijf voorlopig zitten" is.
 
 * Veelgestelde vragen
@@ -115,31 +116,31 @@ als die inschatting "blijf voorlopig zitten" is.
 
 In de praktijk wel. Acendy was de naam waaronder MijnWebwinkel en
 het Noorse Mystore eind 2025 zouden samengaan; die naamswijziging
-werd kort daarna teruggedraaid. Het onderliggende platform en uw
+werd kort daarna teruggedraaid. Het onderliggende platform en je
 shop zijn dezelfde gebleven.
 
 *Moet ik verplicht overstappen?*
 
-Nee, er is geen aangekondigde einddatum en uw shop blijft gewoon
+Nee, er is geen aangekondigde einddatum en je shop blijft gewoon
 draaien. Wel is de ontwikkeling sinds 2021 feitelijk gestopt en
-wisselt het platform regelmatig van eigenaar, waardoor u het risico
+wisselt het platform regelmatig van eigenaar, waardoor je het risico
 loopt later op andermans voorwaarden te moeten verhuizen.
 
 *Wat is het meest gekozen alternatief voor Acendy/MijnWebwinkel?*
 
 Volgens StoreLeads (mei 2026) kiest 55 procent van de vertrekkende
 MijnWebwinkel-shops voor Shopify. WooCommerce en andere platformen
-kunnen ook; u kiest het platform, wij regelen de techniek.
+kunnen ook; je kiest het platform, wij regelen de techniek.
 
 *Kan ik mijn producten en klanten meenemen?*
 
 Ja. Producten, teksten, afbeeldingen, vertalingen, klanten en de
 categoriestructuur worden bij onze migratie automatisch overgezet,
-en elke oude URL krijgt een 301-redirect zodat uw Google-posities
+en elke oude URL krijgt een 301-redirect zodat je Google-posities
 meeverhuizen.
 
 #+BEGIN_EXPORT html
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Is Acendy hetzelfde als MijnWebwinkel?","acceptedAnswer":{"@type":"Answer","text":"In de praktijk wel. Acendy was de naam waaronder MijnWebwinkel en het Noorse Mystore eind 2025 zouden samengaan; die naamswijziging werd kort daarna teruggedraaid. Het onderliggende platform en uw shop zijn dezelfde gebleven."}},{"@type":"Question","name":"Moet ik verplicht overstappen?","acceptedAnswer":{"@type":"Answer","text":"Nee, er is geen aangekondigde einddatum en uw shop blijft gewoon draaien. Wel is de ontwikkeling sinds 2021 feitelijk gestopt en wisselt het platform regelmatig van eigenaar, waardoor u het risico loopt later op andermans voorwaarden te moeten verhuizen."}},{"@type":"Question","name":"Wat is het meest gekozen alternatief voor Acendy/MijnWebwinkel?","acceptedAnswer":{"@type":"Answer","text":"Volgens StoreLeads (mei 2026) kiest 55 procent van de vertrekkende MijnWebwinkel-shops voor Shopify. WooCommerce en andere platformen kunnen ook; u kiest het platform, wij regelen de techniek."}},{"@type":"Question","name":"Kan ik mijn producten en klanten meenemen?","acceptedAnswer":{"@type":"Answer","text":"Ja. Producten, teksten, afbeeldingen, vertalingen, klanten en de categoriestructuur worden bij onze migratie automatisch overgezet, en elke oude URL krijgt een 301-redirect zodat uw Google-posities meeverhuizen."}}]}
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Is Acendy hetzelfde als MijnWebwinkel?","acceptedAnswer":{"@type":"Answer","text":"In de praktijk wel. Acendy was de naam waaronder MijnWebwinkel en het Noorse Mystore eind 2025 zouden samengaan; die naamswijziging werd kort daarna teruggedraaid. Het onderliggende platform en je shop zijn dezelfde gebleven."}},{"@type":"Question","name":"Moet ik verplicht overstappen?","acceptedAnswer":{"@type":"Answer","text":"Nee, er is geen aangekondigde einddatum en je shop blijft gewoon draaien. Wel is de ontwikkeling sinds 2021 feitelijk gestopt en wisselt het platform regelmatig van eigenaar, waardoor je het risico loopt later op andermans voorwaarden te moeten verhuizen."}},{"@type":"Question","name":"Wat is het meest gekozen alternatief voor Acendy/MijnWebwinkel?","acceptedAnswer":{"@type":"Answer","text":"Volgens StoreLeads (mei 2026) kiest 55 procent van de vertrekkende MijnWebwinkel-shops voor Shopify. WooCommerce en andere platformen kunnen ook; je kiest het platform, wij regelen de techniek."}},{"@type":"Question","name":"Kan ik mijn producten en klanten meenemen?","acceptedAnswer":{"@type":"Answer","text":"Ja. Producten, teksten, afbeeldingen, vertalingen, klanten en de categoriestructuur worden bij onze migratie automatisch overgezet, en elke oude URL krijgt een 301-redirect zodat je Google-posities meeverhuizen."}}]}
 </script>
 #+END_EXPORT

--- a/webwinkel/content/mijnwebwinkel-google-posities-behouden.org
+++ b/webwinkel/content/mijnwebwinkel-google-posities-behouden.org
@@ -1,26 +1,27 @@
 #+TITLE: Waarom de meeste MijnWebwinkel-migraties hun Google-posities verliezen
 #+DATE: 2026-06-14
+#+MODIFIED: 2026-08-08
 #+CATEGORY: migratie
 #+TAGS: mijnwebwinkel, seo, migratie
 
-U heeft jaren in uw vindbaarheid geïnvesteerd. Uw productpagina's staan goed
-in Google, klanten vinden u zonder dat u voor elke klik betaalt. En dan stapt
-u over naar een nieuw webshopplatform, en binnen een paar weken zakt uw
+Je hebt jaren in je vindbaarheid geïnvesteerd. Je productpagina's staan goed
+in Google, klanten vinden je zonder dat je voor elke klik betaalt. En dan stapt
+je over naar een nieuw webshopplatform, en binnen een paar weken zakt je
 verkeer weg. We hebben webshops tot 70% van hun organische bezoekers zien
 verliezen na zo'n overstap.
 
 Dat is geen pech en het is ook geen straf van Google. Het is een
 voorspelbaar gevolg van hoe de meeste migraties worden uitgevoerd. En het
-goede nieuws is dat het te voorkomen is, mits u het vooraf goed regelt.
+goede nieuws is dat het te voorkomen is, mits je het vooraf goed regelt.
 
 * Wat er onder de motorkap misgaat
 
-Google onthoudt uw webshop niet als "die winkel van u", maar als een
+Google onthoudt je webshop niet als "die winkel van je", maar als een
 verzameling vaste webadressen. Elke productpagina, elke categorie en elke
 blogpost staat onder een eigen URL in de zoekresultaten, en aan die URL hangt
-de positie die u heeft opgebouwd.
+de positie die je hebt opgebouwd.
 
-Bij een migratie veranderen al die adressen. Doet u verder niets, dan gebeurt
+Bij een migratie veranderen al die adressen. Doe je verder niets, dan gebeurt
 het volgende: een bezoeker of de Google-bot klikt op het oude adres en belandt
 op een foutpagina. Google ziet een doodlopende weg, concludeert dat de pagina
 niet meer bestaat, en haalt hem uit de index. Weg pagina, en weg positie.
@@ -28,11 +29,11 @@ niet meer bestaat, en haalt hem uit de index. Weg pagina, en weg positie.
 De oplossing is op zich eenvoudig: een 301-redirect. Dat is een bordje "wij
 zijn verhuisd" dat het oude adres permanent doorstuurt naar het nieuwe. Google
 volgt dat bordje, schrijft de positie en de backlinks over naar de nieuwe URL,
-en uw bezoeker merkt niets van de overstap. Eén redirect per oude URL, en uw
+en je bezoeker merkt niets van de overstap. Eén redirect per oude URL, en je
 ranking verhuist gewoon mee.
 
 Het venijn zit hem niet in de techniek van die ene redirect. Het zit hem in
-de schaal, en daar maakt MijnWebwinkel het u niet makkelijk.
+de schaal, en daar maakt MijnWebwinkel het je niet makkelijk.
 
 * Waarom het juist bij MijnWebwinkel lastig is
 
@@ -40,8 +41,8 @@ Drie dingen komen hier samen. Een serieuze webshop heeft al snel duizenden
 URLs, en die stuk voor stuk met de hand omleiden is onbegonnen werk. De
 artikelcodes die MijnWebwinkel in zijn URLs verwerkt zien er bovendien
 willekeurig uit, waardoor het lijkt alsof je onmogelijk kunt bepalen welk oud
-adres bij welke nieuwe pagina hoort. En MijnWebwinkel geeft u geen kant-en-klare
-lijst van uw URLs of redirects mee: die informatie moet u eerst zelf uit de
+adres bij welke nieuwe pagina hoort. En MijnWebwinkel geeft je geen kant-en-klare
+lijst van je URLs of redirects mee: die informatie moet je eerst zelf uit de
 winkel zien te halen.
 
 Het is precies dat handwerk, en de angst om iets te missen, waardoor migraties
@@ -50,13 +51,13 @@ als helemaal geen redirect.
 
 * Hoe wij het aanpakken
 
-Wij laten een programma uw volledige webshop doorlopen en elke URL vastleggen.
+Wij laten een programma je volledige webshop doorlopen en elke URL vastleggen.
 Geen steekproef, geen "de belangrijkste pagina's", maar echt alles. Voor elk
 van die adressen genereren we automatisch een 301-redirect naar de juiste
 nieuwe pagina, zonder kopieerfouten.
 
-Voordat er ook maar iets live gaat krijgt u een testshop en een
-verificatieoverzicht, zodat u zelf kunt controleren dat de adressen kloppen.
+Voordat er ook maar iets live gaat krijg je een testshop en een
+verificatieoverzicht, zodat je zelf kunt controleren dat de adressen kloppen.
 Pas als dat goed staat schakelen we over. Vanaf dag één zijn alle redirects
 actief, dus ook in de weken waarin Google de nieuwe URLs oppikt komt elke
 bezoeker en elke oude link gewoon op de juiste pagina uit.
@@ -65,19 +66,19 @@ bezoeker en elke oude link gewoon op de juiste pagina uit.
 <details><summary>Voor de techneuten: maar die artikelcodes veranderen toch?</summary><p>Klopt, de a-codes in MijnWebwinkel-URLs lijken te veranderen, wat het idee geeft dat een redirectkaart binnen no-time verouderd is. Wij hebben die codes over meerdere weken systematisch geobserveerd en vastgesteld dat ze een vast, eenduidig patroon volgen. Daardoor kunnen we de oude URLs betrouwbaar koppelen aan de nieuwe pagina's, ook de adressen met numerieke product-ID's. De volledige redirectkaart genereren we automatisch, niet met de hand.</p></details>
 #+END_EXPORT
 
-* Wat dat voor u betekent
+* Wat dat voor je betekent
 
 Geen weken werk om met de hand redirects in te kloppen, en geen organisch
-verkeer dat u kwijtraakt aan een foutpagina: uw bezoekers en uw backlinks
+verkeer dat je kwijtraakt aan een foutpagina: je bezoekers en je backlinks
 komen gewoon op de nieuwe shop terecht. Google kan na een grote wijziging
 altijd tijdelijk schommelen; wat wij afdekken is dat er niets kapotgaat.
 
-Wilt u eerst lezen [[https://webwinkelverhuis.nl/waarom-mijnwebwinkel.html][waarom
+Wil je eerst lezen [[https://webwinkelverhuis.nl/waarom-mijnwebwinkel.html][waarom
 MijnWebwinkel niet meer wordt doorontwikkeld]], of meteen weten hoe
 [[https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html][onze migratieservice]]
-werkt? Beide leggen we graag uit. En als u liever direct spart over uw eigen
+werkt? Beide leggen we graag uit. En als je liever direct spart over je eigen
 winkel: [[https://meet.jappiesoftware.com][plan een vrijblijvend
-gesprek]]. We kijken samen naar uw shop en geven een eerlijke inschatting van de
+gesprek]]. We kijken samen naar je shop en geven een eerlijke inschatting van de
 migratie en de redirects.
 
 * Veelgestelde vragen
@@ -86,15 +87,15 @@ migratie en de redirects.
 
 Blijvend verlies ontstaat doordat oude URLs na de overstap niet meer
 bestaan en geen 301-redirect hebben; dat dekken wij volledig af, met een
-redirect voor elke oude URL, zodat al uw links en backlinks blijven werken
+redirect voor elke oude URL, zodat al je links en backlinks blijven werken
 en de opgebouwde SEO meeverhuist. Tijdelijke schommelingen na een grote
 wijziging kunnen altijd bij Google.
 
-*Hoe weet u zeker dat alle URLs worden afgevangen?*
+*Hoe weet je zeker dat alle URLs worden afgevangen?*
 
-Ons programma crawlt uw volledige webshop en legt elke URL vast, niet een
+Ons programma crawlt je volledige webshop en legt elke URL vast, niet een
 steekproef. Elke vastgelegde URL krijgt een redirect, die we voor de overstap
-samen met u verifiëren.
+samen met je verifiëren.
 
 *De artikelcodes lijken te veranderen. Werkt het dan wel?*
 
@@ -109,6 +110,6 @@ komt elke bezoeker in de tussentijd gewoon op de juiste pagina uit.
 
 #+BEGIN_EXPORT html
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Verlies ik mijn Google-posities als ik van MijnWebwinkel migreer?","acceptedAnswer":{"@type":"Answer","text":"Blijvend verlies ontstaat door oude URLs zonder 301-redirect; dat dekken wij volledig af met een redirect voor elke oude URL, zodat alle links en backlinks blijven werken en de opgebouwde SEO meeverhuist. Tijdelijke schommelingen na een grote wijziging kunnen altijd bij Google."}},{"@type":"Question","name":"Hoe weet u zeker dat alle URLs worden afgevangen?","acceptedAnswer":{"@type":"Answer","text":"Ons programma crawlt uw volledige webshop en legt elke URL vast, niet een steekproef. Elke vastgelegde URL krijgt een redirect, die we voor de overstap samen met u verifiëren."}},{"@type":"Question","name":"De artikelcodes lijken te veranderen. Werkt het dan wel?","acceptedAnswer":{"@type":"Answer","text":"Ja. We hebben die codes over meerdere weken geobserveerd en vastgesteld dat ze een vast, eenduidig patroon volgen. Daardoor kunnen we elke oude URL betrouwbaar naar de juiste nieuwe URL doorsturen."}},{"@type":"Question","name":"Hoe lang duurt het voordat Google de nieuwe URLs oppikt?","acceptedAnswer":{"@type":"Answer","text":"Doorgaans enkele weken. Doordat de redirects vanaf dag een actief zijn, komt elke bezoeker in de tussentijd gewoon op de juiste pagina uit."}}]}
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Verlies ik mijn Google-posities als ik van MijnWebwinkel migreer?","acceptedAnswer":{"@type":"Answer","text":"Blijvend verlies ontstaat door oude URLs zonder 301-redirect; dat dekken wij volledig af met een redirect voor elke oude URL, zodat alle links en backlinks blijven werken en de opgebouwde SEO meeverhuist. Tijdelijke schommelingen na een grote wijziging kunnen altijd bij Google."}},{"@type":"Question","name":"Hoe weet je zeker dat alle URLs worden afgevangen?","acceptedAnswer":{"@type":"Answer","text":"Ons programma crawlt je volledige webshop en legt elke URL vast, niet een steekproef. Elke vastgelegde URL krijgt een redirect, die we voor de overstap samen met je verifiëren."}},{"@type":"Question","name":"De artikelcodes lijken te veranderen. Werkt het dan wel?","acceptedAnswer":{"@type":"Answer","text":"Ja. We hebben die codes over meerdere weken geobserveerd en vastgesteld dat ze een vast, eenduidig patroon volgen. Daardoor kunnen we elke oude URL betrouwbaar naar de juiste nieuwe URL doorsturen."}},{"@type":"Question","name":"Hoe lang duurt het voordat Google de nieuwe URLs oppikt?","acceptedAnswer":{"@type":"Answer","text":"Doorgaans enkele weken. Doordat de redirects vanaf dag een actief zijn, komt elke bezoeker in de tussentijd gewoon op de juiste pagina uit."}}]}
 </script>
 #+END_EXPORT

--- a/webwinkel/content/mijnwebwinkel-vs-shopify.org
+++ b/webwinkel/content/mijnwebwinkel-vs-shopify.org
@@ -1,9 +1,10 @@
 #+TITLE: MijnWebwinkel vs Shopify: een eerlijke vergelijking voor Nederlandse webshops
 #+DATE: 2026-07-18
+#+MODIFIED: 2026-08-08
 #+CATEGORY: migratie
 #+TAGS: mijnwebwinkel, shopify, vergelijking
 
-Twijfelt u tussen MijnWebwinkel en Shopify, of overweegt u de
+Twijfel je tussen MijnWebwinkel en Shopify, of overweeg je de
 overstap? Wij migreren webshops voor de kost en zien beide platformen
 dus dagelijks van binnen. Dit is onze eerlijke vergelijking: waar
 MijnWebwinkel nog steeds prima voldoet, waar Shopify wint, en wat de
@@ -23,14 +24,14 @@ overstap in de praktijk betekent.
 De abonnementsprijzen van Shopify komen van de eigen
 [[https://www.shopify.com/nl/prijzen][prijzenpagina van Shopify]]
 (juli 2026, tarief bij jaarbetaling; per maand betalen is duurder).
-Bij beide platformen betaalt u daarnaast per bestelling
+Bij beide platformen betaal je daarnaast per bestelling
 transactiekosten aan de betaalprovider.
 
 * Waar MijnWebwinkel goed in was, en deels nog is
 
-MijnWebwinkel is niet voor niets groot geworden: u zet er zonder
+MijnWebwinkel is niet voor niets groot geworden: je zet er zonder
 technische kennis in een middag een nette Nederlandse webshop mee
-neer, alles in het Nederlands, inclusief iDEAL. Heeft u een klein
+neer, alles in het Nederlands, inclusief iDEAL. Heb je een klein
 assortiment, weinig groeiambitie en een shop die gewoon doet wat hij
 moet doen, dan is er geen acute reden om te vertrekken. Dat zeggen we
 er eerlijk bij, want een migratie kost geld en aandacht.
@@ -40,7 +41,7 @@ overname door Visma in 2021 is de ontwikkeling feitelijk gestopt,
 zijn de prijzen verhoogd, en rolt het platform van reorganisatie
 naar reorganisatie: kortstondig omgedoopt tot Acendy (snel weer
 teruggedraaid) en begin 2026 ondergebracht in het nieuwe vehikel
-Norvato. Wat er precies is gebeurd leest u in
+Norvato. Wat er precies is gebeurd lees je in
 [[https://webwinkelverhuis.nl/blog/alternatief-voor-acendy-zo-zit-het-met-mijnwebwinkel-mystore-en-norvato.html][ons
 artikel over Acendy, Mystore en Norvato]] en op de pagina
 [[https://webwinkelverhuis.nl/waarom-mijnwebwinkel.html][waarom wordt
@@ -54,23 +55,23 @@ procent, en van de vertrekkers kiest 55 procent voor Shopify.
 
 Shopify is het grootste webshopplatform ter wereld en e-commerce is
 er het kernproduct, niet een bijvangst in een portefeuille. Dat
-merkt u vooral op drie punten.
+merk je vooral op drie punten.
 
 Het platform wordt actief doorontwikkeld. Functionaliteit die er nu
-niet is, komt er vaak alsnog; bij een bevroren platform is wat u
-ziet wat u houdt.
+niet is, komt er vaak alsnog; bij een bevroren platform is wat je
+ziet wat je houdt.
 
 Het app-aanbod is enorm. Reviews, spaarpunten, verzendkoppelingen,
 boekhoudkoppelingen: voor vrijwel elke wens bestaat een app, vaak
-meerdere. Bij MijnWebwinkel bent u beperkt tot wat het platform
+meerdere. Bij MijnWebwinkel ben je beperkt tot wat het platform
 zelf aanbiedt.
 
-Uw shop groeit mee. Meer talen, meer verkoopkanalen, B2B, een
+Je shop groeit mee. Meer talen, meer verkoopkanalen, B2B, een
 fysiek verkooppunt erbij: het kan zonder platformwissel. De
-grootste valkuil van een beginnersplatform is dat u er pas achter
-komt dat u eruit gegroeid bent als de verhuizing het duurst is.
+grootste valkuil van een beginnersplatform is dat je er pas achter
+komt dat je eruit gegroeid bent als de verhuizing het duurst is.
 
-Heeft u ook een fysieke winkel, dan telt de kassa mee. De
+Heb je ook een fysieke winkel, dan telt de kassa mee. De
 Mijnwebwinkel Kassa App is begin 2026 uit de App Store verdwenen
 (de pagina geeft "niet gevonden", gecontroleerd juli 2026): wie
 zijn iPad reset of vervangt, kan de app niet opnieuw installeren.
@@ -80,7 +81,7 @@ QR-code.
 
 Eerlijkheidshalve: Shopify is geen automatisch feest. Per maand
 betalen is duurder dan de jaartarieven hierboven, sommige apps
-kosten extra, en u moet bij de inrichting meer keuzes maken dan bij
+kosten extra, en je moet bij de inrichting meer keuzes maken dan bij
 MijnWebwinkel. Wie alleen de allergoedkoopste optie zoekt en onder
 de 25 producten blijft, is bij het 20-europlan van MijnWebwinkel
 vandaag goedkoper uit.
@@ -91,19 +92,19 @@ De overstap zelf is ons vak, dus daar kunnen we concreet over zijn.
 Bij onze migratie worden producten, teksten, afbeeldingen,
 vertalingen, klanten en de categoriestructuur automatisch overgezet,
 en krijgt elke oude URL een 301-redirect zodat
-[[https://webwinkelverhuis.nl/blog/waarom-de-meeste-mijnwebwinkel-migraties-hun-google-posities-verliezen.html][uw
-Google-posities meeverhuizen]]. Uw huidige shop blijft gewoon
+[[https://webwinkelverhuis.nl/blog/waarom-de-meeste-mijnwebwinkel-migraties-hun-google-posities-verliezen.html][je
+Google-posities meeverhuizen]]. Je huidige shop blijft gewoon
 doorverkopen terwijl de nieuwe wordt opgebouwd; reken op ongeveer
 een maand van start tot livegang. De prijzen zijn vast en staan op
 [[https://webwinkelverhuis.nl/prijzen.html][onze prijzenpagina]];
-u betaalt na een geslaagde migratie.
+je betaalt na een geslaagde migratie.
 
 En moet het per se Shopify zijn? Nee. Shopify is het meest gekozen
 doelplatform en daar hebben wij de meeste ervaring mee, maar we
-migreren ook naar WooCommerce of een ander platform. U kiest, wij
-regelen de techniek. Benieuwd wat dat voor uw shop betekent?
+migreren ook naar WooCommerce of een ander platform. Je kiest, wij
+regelen de techniek. Benieuwd wat dat voor je shop betekent?
 [[https://meet.jappiesoftware.com][Plan een vrijblijvend gesprek]],
-dan kijken we samen naar uw winkel en krijgt u een eerlijke
+dan kijken we samen naar je winkel en krijg je een eerlijke
 inschatting, ook als die "blijven zitten" is.
 
 * Veelgestelde vragen
@@ -119,7 +120,7 @@ kunnen extra kosten.
 *Werkt iDEAL op Shopify?*
 
 Ja. iDEAL en andere Nederlandse betaalmethoden werken gewoon op
-Shopify; per bestelling betaalt u transactiekosten aan de
+Shopify; per bestelling betaal je transactiekosten aan de
 betaalprovider, net als bij MijnWebwinkel.
 
 *Kan ik mijn producten en klanten meenemen naar Shopify?*
@@ -136,6 +137,6 @@ wijziging kunnen altijd bij Google.
 
 #+BEGIN_EXPORT html
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Is Shopify duurder dan MijnWebwinkel?","acceptedAnswer":{"@type":"Answer","text":"Vaak niet. Shopify Basic kost 21 euro per maand bij jaarbetaling, terwijl serieuze shops bij MijnWebwinkel 40 tot 70 euro per maand betalen; alleen het 20-europlan met maximaal 25 producten is goedkoper. Per maand betalen bij Shopify is wel duurder, en apps kunnen extra kosten."}},{"@type":"Question","name":"Werkt iDEAL op Shopify?","acceptedAnswer":{"@type":"Answer","text":"Ja. iDEAL en andere Nederlandse betaalmethoden werken gewoon op Shopify; per bestelling betaalt u transactiekosten aan de betaalprovider, net als bij MijnWebwinkel."}},{"@type":"Question","name":"Kan ik mijn producten en klanten meenemen naar Shopify?","acceptedAnswer":{"@type":"Answer","text":"Ja. Producten, teksten, afbeeldingen, vertalingen, klanten en de categoriestructuur worden bij onze migratie automatisch overgezet."}},{"@type":"Question","name":"Verlies ik mijn Google-posities bij de overstap?","acceptedAnswer":{"@type":"Answer","text":"Niet als elke oude URL een 301-redirect krijgt, en dat regelen wij automatisch voor alle URLs. Blijvend verlies ontstaat door ontbrekende redirects; tijdelijke schommelingen na een grote wijziging kunnen altijd bij Google."}}]}
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Is Shopify duurder dan MijnWebwinkel?","acceptedAnswer":{"@type":"Answer","text":"Vaak niet. Shopify Basic kost 21 euro per maand bij jaarbetaling, terwijl serieuze shops bij MijnWebwinkel 40 tot 70 euro per maand betalen; alleen het 20-europlan met maximaal 25 producten is goedkoper. Per maand betalen bij Shopify is wel duurder, en apps kunnen extra kosten."}},{"@type":"Question","name":"Werkt iDEAL op Shopify?","acceptedAnswer":{"@type":"Answer","text":"Ja. iDEAL en andere Nederlandse betaalmethoden werken gewoon op Shopify; per bestelling betaal je transactiekosten aan de betaalprovider, net als bij MijnWebwinkel."}},{"@type":"Question","name":"Kan ik mijn producten en klanten meenemen naar Shopify?","acceptedAnswer":{"@type":"Answer","text":"Ja. Producten, teksten, afbeeldingen, vertalingen, klanten en de categoriestructuur worden bij onze migratie automatisch overgezet."}},{"@type":"Question","name":"Verlies ik mijn Google-posities bij de overstap?","acceptedAnswer":{"@type":"Answer","text":"Niet als elke oude URL een 301-redirect krijgt, en dat regelen wij automatisch voor alle URLs. Blijvend verlies ontstaat door ontbrekende redirects; tijdelijke schommelingen na een grote wijziging kunnen altijd bij Google."}}]}
 </script>
 #+END_EXPORT

--- a/webwinkel/content/panzer-shop-klantverhaal.org
+++ b/webwinkel/content/panzer-shop-klantverhaal.org
@@ -1,5 +1,6 @@
 #+TITLE: Klantverhaal: Panzer-ShopNL van MijnWebwinkel naar Shopify in drie talen
 #+DATE: 2026-08-01
+#+MODIFIED: 2026-08-08
 #+CATEGORY: migratie
 #+TAGS: mijnwebwinkel, shopify, klantverhaal
 
@@ -77,7 +78,7 @@ We hebben bijvoorbeeld het mysterie van de artikel codes opgelost
 in de URLs.
 De nieuwe URLs werden geen productnummers,
 maar beschrijvende slugs met de producttitel
-erin, per taal vertaald. Waarom dat zoveel uitmaakt leest u in
+erin, per taal vertaald. Waarom dat zoveel uitmaakt lees je in
 [[https://webwinkelverhuis.nl/blog/waarom-de-meeste-mijnwebwinkel-migraties-hun-google-posities-verliezen.html][ons stuk over Google-posities bij migraties]].
 
 Die eis van Kevin is in het programma blijven zitten. Elke migratie
@@ -105,7 +106,7 @@ het spannendste stuk van elke migratie. We zochten elke stap vooraf
 grondig uit, maar een domeinverhuizing kent haar verrassingen pas
 op het moment zelf: wat de oude registrar precies doet, zie je pas
 als de overdracht echt loopt. En gaat het dan mis, dan is de winkel
-plat, voor iedereen. Precies daarom wilt u dit laten doen door
+plat, voor iedereen. Precies daarom wil je dit laten doen door
 iemand die het vaker heeft gedaan.
 
 Ook hier ging niet alles in één keer vlekkeloos.
@@ -157,8 +158,8 @@ En het programma dat dit deed is sindsdien alleen maar vaker
 gebruikt: elke nieuwe migratie voegt randgevallen toe die we daarna
 automatisch goed doen.
 
-Staat uw winkel ook al jaren "bijna" op het punt te verhuizen?
+Staat je winkel ook al jaren "bijna" op het punt te verhuizen?
 [[https://meet.jappiesoftware.com][Plan een vrijblijvend gesprek]],
 of bekijk eerst
 [[https://webwinkelverhuis.nl/prijzen.html][wat een migratie kost]].
-U betaalt pas na een geslaagde migratie.
+Je betaalt pas na een geslaagde migratie.

--- a/webwinkel/content/shopify-catalogus-bulk-aanpassen.org
+++ b/webwinkel/content/shopify-catalogus-bulk-aanpassen.org
@@ -1,9 +1,10 @@
 #+TITLE: Duizenden Shopify-producten in bulk aanpassen, zonder brokken
 #+DATE: 2026-07-25
+#+MODIFIED: 2026-08-08
 #+CATEGORY: shopify
 #+TAGS: shopify, bulk, productteksten
 
-Sommige klussen zijn te groot voor handwerk. Alle meta-titels van uw
+Sommige klussen zijn te groot voor handwerk. Alle meta-titels van je
 webshop herschrijven. Een leveranciersnaam die overal uit de teksten
 moet. Prijzen die per categorie anders omhoog moeten. Bij een paar
 honderd producten is dat dagen klikwerk; bij duizenden begint niemand
@@ -21,7 +22,7 @@ volle werkweek, en ergens halverwege sluipt de eerste kopieerfout
 erin. Niemand houdt dat foutloos vol, en een half aangepaste catalogus
 oogt slordiger dan een ongemoeide.
 
-Er bestaan apps die zoeken-en-vervangen over uw producten heen leggen,
+Er bestaan apps die zoeken-en-vervangen over je producten heen leggen,
 en voor een simpele woordwissel zijn die prima. Maar echte klussen
 hebben volgorde en uitzonderingen: "de categorienaam wint van de
 merknaam, behalve bij cadeausets". Zulke regels passen niet in een
@@ -29,7 +30,7 @@ zoek-en-vervangveldje.
 
 Bij meertalige shops komt daar nog een laag bij: elke taal heeft zijn
 eigen velden, en een aanpassing die alleen het Nederlands raakt laat
-uw Duitse winkel achter met de oude tekst.
+je Duitse winkel achter met de oude tekst.
 
 En het grootste risico is onzichtbaar: geen reservekopie en geen
 controle achteraf. Wie merkt het als product 1800 verkeerd is
@@ -37,16 +38,16 @@ overgeschreven?
 
 * Hoe wij het aanpakken
 
-Eerst worden uw wensen expliciete regels. Die leggen we ter
-goedkeuring aan u voor, met voorbeelden uit uw eigen catalogus, zodat
-u vooraf ziet wat er met echte producten gebeurt.
+Eerst worden je wensen expliciete regels. Die leggen we ter
+goedkeuring aan je voor, met voorbeelden uit je eigen catalogus, zodat
+je vooraf ziet wat er met echte producten gebeurt.
 
 Daarna maken we een volledige reservekopie van elk veld dat we gaan
 raken, in alle talen. Pas dan voert ons programma de regels uit over
 de hele catalogus.
 
 Als laatste stap controleren we het resultaat op de winkel zelf, niet
-alleen in het beheer: wat uw klant ziet is de maatstaf.
+alleen in het beheer: wat je klant ziet is de maatstaf.
 
 #+BEGIN_EXPORT html
 <details><summary>Voor de techneuten: waarom is dit moeilijker dan het klinkt?</summary><p>Webshops laten maar een beperkt aantal wijzigingen per seconde toe, en meertalige velden hebben elk een eigen schrijfroute. Het echte werk zit niet in het schrijven maar in het bewijzen dat elke wijziging is aangekomen: onze tooling draait daarom een controlelus die elk product per taal naleest, tot op de storefront.</p></details>
@@ -59,16 +60,16 @@ webshop, ook als wij die niet zelf hebben opgezet; de meeste ervaring
 hebben we met Shopify-shops, andere webshoptypes ondersteunen we op
 aanvraag.
 
-* Wat dat voor u betekent
+* Wat dat voor je betekent
 
 Eén afgesproken prijs, één run, en een catalogus die van product 1 tot
 product 2270 dezelfde stijl volgt. Geen weken klikwerk, geen half
-aangepaste winkel, en een reservekopie voor het geval u toch terug
+aangepaste winkel, en een reservekopie voor het geval je toch terug
 wilt.
 
-Benieuwd wat er met uw catalogus kan? [[https://meet.jappiesoftware.com][Plan
-een vrijblijvend gesprek]], dan kijken we samen naar uw shop en de
-regels die u nodig heeft.
+Benieuwd wat er met je catalogus kan? [[https://meet.jappiesoftware.com][Plan
+een vrijblijvend gesprek]], dan kijken we samen naar je shop en de
+regels die je nodig heeft.
 
 * Veelgestelde vragen
 
@@ -86,7 +87,7 @@ velden, zodat elke taal zijn eigen correcte tekst krijgt.
 
 *Wat kost zo'n catalogus-brede aanpassing?*
 
-U krijgt vooraf een vaste prijs op basis van de regels die u nodig
+Je krijgt vooraf een vaste prijs op basis van de regels die je nodig
 heeft, geen uurtarief. Eenvoudige regelsets beginnen rond de €750.
 
 *Moet mijn shop daarvoor door jullie gemigreerd zijn?*
@@ -97,6 +98,6 @@ aanvraag.
 
 #+BEGIN_EXPORT html
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Wat als er iets misgaat?","acceptedAnswer":{"@type":"Answer","text":"Voor we ook maar een veld aanraken maken we een volledige reservekopie van alles wat we gaan wijzigen, in alle talen. Elk veld kan daardoor worden teruggezet, en na afloop controleren we het resultaat op de winkelpagina zelf."}},{"@type":"Question","name":"Werkt dit ook bij meertalige shops?","acceptedAnswer":{"@type":"Answer","text":"Ja. De regels worden per taal uitgevoerd, inclusief de vertaalde velden, zodat elke taal zijn eigen correcte tekst krijgt."}},{"@type":"Question","name":"Wat kost zo'n catalogus-brede aanpassing?","acceptedAnswer":{"@type":"Answer","text":"U krijgt vooraf een vaste prijs op basis van de regels die u nodig heeft, geen uurtarief. Eenvoudige regelsets beginnen rond de 750 euro."}},{"@type":"Question","name":"Moet mijn shop daarvoor door jullie gemigreerd zijn?","acceptedAnswer":{"@type":"Answer","text":"Nee, en hij hoeft ook geen Shopify-shop te zijn: daar hebben we de meeste ervaring mee, maar andere webshoptypes ondersteunen we op aanvraag."}}]}
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Wat als er iets misgaat?","acceptedAnswer":{"@type":"Answer","text":"Voor we ook maar een veld aanraken maken we een volledige reservekopie van alles wat we gaan wijzigen, in alle talen. Elk veld kan daardoor worden teruggezet, en na afloop controleren we het resultaat op de winkelpagina zelf."}},{"@type":"Question","name":"Werkt dit ook bij meertalige shops?","acceptedAnswer":{"@type":"Answer","text":"Ja. De regels worden per taal uitgevoerd, inclusief de vertaalde velden, zodat elke taal zijn eigen correcte tekst krijgt."}},{"@type":"Question","name":"Wat kost zo'n catalogus-brede aanpassing?","acceptedAnswer":{"@type":"Answer","text":"Je krijgt vooraf een vaste prijs op basis van de regels die je nodig heeft, geen uurtarief. Eenvoudige regelsets beginnen rond de 750 euro."}},{"@type":"Question","name":"Moet mijn shop daarvoor door jullie gemigreerd zijn?","acceptedAnswer":{"@type":"Answer","text":"Nee, en hij hoeft ook geen Shopify-shop te zijn: daar hebben we de meeste ervaring mee, maar andere webshoptypes ondersteunen we op aanvraag."}}]}
 </script>
 #+END_EXPORT

--- a/webwinkel/content/shopify-miljard.org
+++ b/webwinkel/content/shopify-miljard.org
@@ -1,5 +1,6 @@
 #+TITLE: Het miljard van Shopify: waarom geen Nederlands platform kan bijbenen
 #+DATE: 2026-08-04
+#+MODIFIED: 2026-08-08
 #+CATEGORY: shopify
 #+TAGS: shopify, ccv, mijnwebwinkel, achtergrond
 
@@ -7,7 +8,7 @@ Shopify gaf in 2025 ruim anderhalf miljard dollar uit aan
 productontwikkeling. Nederlandse webshopplatformen zijn niet lui of
 onkundig; ze spelen een spel waarin de tegenstander per werkdag meer
 uitgeeft dan zij in een jaar kunnen. Dit is wat dat geld oplevert,
-jaar voor jaar, en wat het betekent voor uw shop.
+jaar voor jaar, en wat het betekent voor je shop.
 
 * Wat Shopify per jaar uitgeeft
 
@@ -26,7 +27,7 @@ de Amerikaanse beurswaakhond SEC deponeert (bronnen onderaan).
 
 Opgeteld: $7,9 miljard in zeven jaar. Eén platform.
 
-* Waar dat geld heenging, en wat u ervan terugziet
+* Waar dat geld heenging, en wat je ervan terugziet
 
 In 2020 verwerkte het platform de coronagolf: de Shop-app, een
 volledig vernieuwd kassasysteem en de uitbouw van Shop Pay.
@@ -64,13 +65,13 @@ Nederlandse standaardthema's.
 
 * De rekensom die alles zegt
 
-Deel $1.536 miljoen door ongeveer 250 werkdagen en u komt op ruim
+Deel $1.536 miljoen door ongeveer 250 werkdagen en je komt op ruim
 $6 miljoen per werkdag. Dat is meer per dag dan een Nederlands
 nicheplatform redelijkerwijs per jaar aan ontwikkeling kan besteden.
 
-Gaat al dat geld naar uw soort webshop? Nee, natuurlijk niet:
+Gaat al dat geld naar je soort webshop? Nee, natuurlijk niet:
 Shopify bouwt ook voor miljardenmerken, fysieke kassa's en markten
-waar u nooit komt. Maar stel dat maar een tiende landt bij wat een
+waar je nooit komt. Maar stel dat maar een tiende landt bij wat een
 Nederlandse mkb-shop dagelijks gebruikt: thema's, checkout,
 productbeheer. Dan is dat nog altijd zo'n $150 miljoen per jaar,
 elk jaar opnieuw. Meer dan een platform als CCV Shop of
@@ -86,21 +87,21 @@ een paar miljoen per jaar kan uitgeven, kan geen wedstrijd winnen van
 iemand die per werkdag zes miljoen uitgeeft. Het is geen kwestie van
 niet willen; meedoen is simpelweg geen optie.
 
-Het gevolg ziet u in uw eigen shop: thema's die al jaren dezelfde
+Het gevolg zie je in je eigen shop: thema's die al jaren dezelfde
 zijn, functies die maar niet komen, en een kloof die elk half jaar
 met ruim honderd functies groeit. Waarom dat bij MijnWebwinkel zo
-gelopen is leest u in
+gelopen is lees je in
 [[https://webwinkelverhuis.nl/waarom-mijnwebwinkel.html][ons artikel over MijnWebwinkel]].
 
-* Wat betekent dit voor uw shop?
+* Wat betekent dit voor je shop?
 
-Dat de overstap meestal groter voelt dan hij is: draait uw shop op
+Dat de overstap meestal groter voelt dan hij is: draait je shop op
 een standaardthema van MijnWebwinkel of CCV Shop, dan is alleen al
-het standaardthema van uw nieuwe platform doorgaans een zichtbare
-opknapbeurt. U lift vanaf dag één mee op dat miljard per jaar, en
-elke Editions-release daarna is er ook voor uw shop.
+het standaardthema van je nieuwe platform doorgaans een zichtbare
+opknapbeurt. Je lift vanaf dag één mee op dat miljard per jaar, en
+elke Editions-release daarna is er ook voor je shop.
 
-Overweegt u de overstap? Bekijk onze
+Overweeg je de overstap? Bekijk onze
 [[https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html][migratie vanaf MijnWebwinkel]]
 of
 [[https://webwinkelverhuis.nl/migrate-ccvshop.html][migratie vanaf CCV Shop]]:

--- a/webwinkel/content/webshop-migreren-stappenplan.org
+++ b/webwinkel/content/webshop-migreren-stappenplan.org
@@ -1,97 +1,98 @@
 #+TITLE: Webshop migreren: stappenplan, kosten en valkuilen
 #+DATE: 2026-07-10
+#+MODIFIED: 2026-08-08
 #+CATEGORY: migratie
 #+TAGS: migratie, stappenplan, shopify
 
-Uw webshop migreren naar een ander platform: laten we er eerlijk
+Je webshop migreren naar een ander platform: laten we er eerlijk
 over zijn, het ís een berg werk. Maar het is goed beheersbaar werk
-als u het in de juiste volgorde aanpakt en vooraf weet welke
+als je het in de juiste volgorde aanpakt en vooraf weet welke
 stappen technisch lastig worden. Dit is het stappenplan dat wij
 zelf gebruiken bij elke verhuizing, of die nu van MijnWebwinkel,
 CCV Shop of Lightspeed komt en naar Shopify, WooCommerce of een
 ander platform gaat, plus de valkuilen die we in de praktijk het
 vaakst zien.
 
-* Stap 1: kies uw nieuwe platform
+* Stap 1: kies je nieuwe platform
 
-Kies uw platform op de toekomst van uw shop, niet op de laagste
-maandprijs van vandaag. Kijk naar wat het platform kan als u
+Kies je platform op de toekomst van je shop, niet op de laagste
+maandprijs van vandaag. Kijk naar wat het platform kan als je
 groeit (meer talen, meer kanalen, koppelingen), wat het per maand
-kost op het niveau dat ú nodig heeft, en hoe makkelijk u uw data er
+kost op het niveau dat jíj nodig hebt, en hoe makkelijk je je data er
 later weer uit krijgt. Shopify is in de praktijk de meest gekozen
 bestemming en daar hebben wij de meeste ervaring mee, maar het hoeft
 niet: wij zijn geen verlengstuk van één platform.
 
 * Stap 2: inventariseer wat er mee moet
 
-Maak een lijst voordat u iets aanraakt. Denk aan producten met
+Maak een lijst voordat je iets aanraakt. Denk aan producten met
 varianten en afbeeldingen, categorieën, teksten en
-informatiepagina's, vertalingen, klantgegevens, uw
+informatiepagina's, vertalingen, klantgegevens, je
 nieuwsbrieflijst, kortingscodes, spaarpunten, de mailadressen op
-uw domein, en niet te vergeten: al uw URLs. Alles wat niet op de
+je domein, en niet te vergeten: al je URLs. Alles wat niet op de
 lijst staat, gaat verloren zonder dat iemand het merkt, tot een
 klant erover mailt.
 
 * Stap 3: bouw de nieuwe shop naast de oude
 
 Zet de nieuwe shop op terwijl de oude gewoon doorverkoopt. Er is
-geen moment waarop uw winkel dicht hoeft: de overzetting gebeurt op
-de achtergrond, u controleert het resultaat in een testshop, en pas
-bij de livegang wijst u uw domein om. Uw klanten merken van het
+geen moment waarop je winkel dicht hoeft: de overzetting gebeurt op
+de achtergrond, je controleert het resultaat in een testshop, en pas
+bij de livegang wijs je je domein om. Je klanten merken van het
 hele traject niets.
 
 * Stap 4: zet de data over
 
 Bij een handvol producten kan dit met de hand of met een
-CSV-export. Daarboven wilt u het geautomatiseerd doen, want
+CSV-export. Daarboven wil je het geautomatiseerd doen, want
 handwerk op schaal betekent kopieerfouten, en een half overgezette
 catalogus oogt slordiger dan een ongemoeide. Onze eigen migraties
 zijn volledig geautomatiseerd, inclusief varianten, afbeeldingen en
 vertalingen, en het programma valideert zijn eigen werk.
 
-* Stap 5: richt uw thema in
+* Stap 5: richt je thema in
 
-Uw producten staan er nu, maar de winkel ziet er nog niet uit als
-úw winkel. Logo, kleuren, banners, de indeling van de voorpagina:
-alles wat in de oude shop "gewoon zo was" moet u nu opnieuw kiezen
+Je producten staan er nu, maar de winkel ziet er nog niet uit als
+jóuw winkel. Logo, kleuren, banners, de indeling van de voorpagina:
+alles wat in de oude shop "gewoon zo was" moet je nu opnieuw kiezen
 en instellen. Onderschat deze stap niet; hier gaat voor de meeste
-eigenaren de meeste tijd in zitten, en het is ook de stap waar u
+eigenaren de meeste tijd in zitten, en het is ook de stap waar je
 het vaakst hulp bij nodig heeft.
 
-* Stap 6: installeer uw apps en koppelingen
+* Stap 6: installeer je apps en koppelingen
 
 Betaalmethoden, verzendkoppelingen, reviews, de boekhouding: wat
 op het oude platform ingebouwd zat, komt op het nieuwe vaak uit
 losse apps of plugins. Elke koppeling moet apart worden ingesteld
 én getest, het liefst met een echte proefbestelling.
 
-* Stap 7: zet uw klantbestanden en nieuwsbrieven over
+* Stap 7: zet je klantbestanden en nieuwsbrieven over
 
 Klantaccounts, de nieuwsbrieflijst en waar mogelijk de
 bestelhistorie verhuizen mee, zodat vaste klanten niet opnieuw
-hoeven te beginnen en u uw mailinglijst niet kwijtraakt.
+hoeven te beginnen en je je mailinglijst niet kwijtraakt.
 
 * Stap 8: regel de 301-redirects
 
 Dit is de stap die het vaakst wordt overgeslagen en het meeste
 kost. Elke oude URL moet permanent doorsturen naar de juiste nieuwe
-pagina, anders raakt u
+pagina, anders raak je
 [[https://webwinkelverhuis.nl/blog/waarom-de-meeste-mijnwebwinkel-migraties-hun-google-posities-verliezen.html][de
-Google-posities kwijt die u jaren heeft opgebouwd]]. Eén redirect
+Google-posities kwijt die je jaren heeft opgebouwd]]. Eén redirect
 per URL, voor álle URLs, actief vanaf dag één.
 
-* Stap 9: verhuis uw domein en uw e-mail
+* Stap 9: verhuis je domein en je e-mail
 
-Staat uw domeinnaam geregistreerd bij uw oude webshopplatform, zet
-hem dan over naar een eigen registrar, zodat u hem zelf in handen
-heeft en niet afhankelijk blijft van het platform dat u net
+Staat je domeinnaam geregistreerd bij je oude webshopplatform, zet
+hem dan over naar een eigen registrar, zodat je hem zelf in handen
+heeft en niet afhankelijk blijft van het platform dat je net
 verlaat. Vergeet daarbij de mailboxen op dat domein niet: wie
 alleen het domein omzet, staat de volgende ochtend zonder e-mail.
 Voor veel eigenaren is dit technisch de spannendste stap.
 
 * Stap 10: controleer, ga live, en houd de eerste weken in de gaten
 
-Loop de testshop na met uw inventarislijst uit stap 2, controleer
+Loop de testshop na met je inventarislijst uit stap 2, controleer
 een steekproef van redirects, en zet dan pas het domein om. Houd na
 de livegang Google Search Console in de gaten: tijdelijke
 schommelingen zijn normaal, structureel wegzakkende pagina's wijzen
@@ -108,13 +109,13 @@ de eerste bestellingen binnenkomen.
 
 * Zelf doen of uitbesteden?
 
-Heeft u enkele tientallen producten, één taal en weinig opgebouwde
-Google-posities, dan kunt u een migratie zelf doen, maar reken
+Heb je enkele tientallen producten, één taal en weinig opgebouwde
+Google-posities, dan kun je een migratie zelf doen, maar reken
 eerder in weekenden dan in avonden: tien stappen is geen middagje
 werk. De stappen waar de meeste eigenaren op vastlopen zijn het
 thema (stap 5), de koppelingen (stap 6), de klantbestanden (stap
 7) en de domein- en mailverhuizing (stap 9); dat zijn precies de
-stappen waar een fout ook meteen zichtbaar is voor uw klanten. Bij
+stappen waar een fout ook meteen zichtbaar is voor je klanten. Bij
 honderden of duizenden producten, meerdere talen of een shop die
 goed vindbaar is, komt daar het handwerk-probleem bij: dan is
 automatiseren geen luxe maar de enige manier om het foutloos te
@@ -123,23 +124,23 @@ doen. Dat is precies wat wij leveren, met een vaste prijs vanaf
 prijzenpagina]]) en betaling na een geslaagde migratie. Reken van
 start tot livegang op ongeveer een maand.
 
-Per platform leest u de details op onze migratiepagina's voor
+Per platform lees je de details op onze migratiepagina's voor
 [[https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html][MijnWebwinkel]],
 [[https://webwinkelverhuis.nl/migrate-ccvshop.html][CCV Shop]] en
 [[https://webwinkelverhuis.nl/migrate-lightspeed.html][Lightspeed]].
 Liever direct overleggen?
 [[https://meet.jappiesoftware.com][Plan een vrijblijvend gesprek]],
-dan kijken we samen naar uw shop.
+dan kijken we samen naar je shop.
 
 * Veelgestelde vragen
 
 *Kun je een website importeren naar Shopify?*
 
 Ja. Producten, teksten, afbeeldingen, klanten en de
-categoriestructuur van uw bestaande webshop kunnen naar Shopify
+categoriestructuur van je bestaande webshop kunnen naar Shopify
 worden overgezet. Bij een klein assortiment kan dat met een
 CSV-export; bij grotere of meertalige shops doen wij dit volledig
-geautomatiseerd, inclusief 301-redirects van uw oude URLs.
+geautomatiseerd, inclusief 301-redirects van je oude URLs.
 
 *Hoe lang duurt een webshop-migratie?*
 
@@ -149,18 +150,18 @@ betaalmethoden en rustig wennen aan de nieuwe shop bij kijken.
 
 *Wat kost een webshop-migratie?*
 
-Doet u het zelf, dan kost het vooral tijd. Laat u het door ons
+Doe je het zelf, dan kost het vooral tijd. Laat je het door ons
 doen, dan geldt een vaste prijs vanaf 1.999 euro, afhankelijk van
 het aantal producten en talen, met betaling na een geslaagde
 migratie.
 
 *Kan mijn shop blijven doorverkopen tijdens de migratie?*
 
-Ja. De nieuwe shop wordt naast de oude opgebouwd en uw winkel hoeft
-geen moment dicht; pas bij de livegang wijst u uw domein om.
+Ja. De nieuwe shop wordt naast de oude opgebouwd en je winkel hoeft
+geen moment dicht; pas bij de livegang wijs je je domein om.
 
 #+BEGIN_EXPORT html
 <script type="application/ld+json">
-{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Kun je een website importeren naar Shopify?","acceptedAnswer":{"@type":"Answer","text":"Ja. Producten, teksten, afbeeldingen, klanten en de categoriestructuur van uw bestaande webshop kunnen naar Shopify worden overgezet. Bij een klein assortiment kan dat met een CSV-export; bij grotere of meertalige shops doen wij dit volledig geautomatiseerd, inclusief 301-redirects van uw oude URLs."}},{"@type":"Question","name":"Hoe lang duurt een webshop-migratie?","acceptedAnswer":{"@type":"Answer","text":"Het technische overzetten duurt maar enkele uren, maar reken van start tot livegang op ongeveer een maand: er komt ook een thema, betaalmethoden en rustig wennen aan de nieuwe shop bij kijken."}},{"@type":"Question","name":"Wat kost een webshop-migratie?","acceptedAnswer":{"@type":"Answer","text":"Doet u het zelf, dan kost het vooral tijd. Laat u het door ons doen, dan geldt een vaste prijs vanaf 1.999 euro, afhankelijk van het aantal producten en talen, met betaling na een geslaagde migratie."}},{"@type":"Question","name":"Kan mijn shop blijven doorverkopen tijdens de migratie?","acceptedAnswer":{"@type":"Answer","text":"Ja. De nieuwe shop wordt naast de oude opgebouwd en uw winkel hoeft geen moment dicht; pas bij de livegang wijst u uw domein om."}}]}
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Kun je een website importeren naar Shopify?","acceptedAnswer":{"@type":"Answer","text":"Ja. Producten, teksten, afbeeldingen, klanten en de categoriestructuur van je bestaande webshop kunnen naar Shopify worden overgezet. Bij een klein assortiment kan dat met een CSV-export; bij grotere of meertalige shops doen wij dit volledig geautomatiseerd, inclusief 301-redirects van je oude URLs."}},{"@type":"Question","name":"Hoe lang duurt een webshop-migratie?","acceptedAnswer":{"@type":"Answer","text":"Het technische overzetten duurt maar enkele uren, maar reken van start tot livegang op ongeveer een maand: er komt ook een thema, betaalmethoden en rustig wennen aan de nieuwe shop bij kijken."}},{"@type":"Question","name":"Wat kost een webshop-migratie?","acceptedAnswer":{"@type":"Answer","text":"Doe je het zelf, dan kost het vooral tijd. Laat je het door ons doen, dan geldt een vaste prijs vanaf 1.999 euro, afhankelijk van het aantal producten en talen, met betaling na een geslaagde migratie."}},{"@type":"Question","name":"Kan mijn shop blijven doorverkopen tijdens de migratie?","acceptedAnswer":{"@type":"Answer","text":"Ja. De nieuwe shop wordt naast de oude opgebouwd en je winkel hoeft geen moment dicht; pas bij de livegang wijs je je domein om."}}]}
 </script>
 #+END_EXPORT

--- a/webwinkel/style.css
+++ b/webwinkel/style.css
@@ -126,10 +126,10 @@ body > header {
 
 .hoofdnav { display: flex; align-items: center; gap: 1.4rem; }
 .hoofdnav ul { display: flex; gap: 1.3rem; list-style: none; }
-.hoofdnav a:not(.cta-button) {
+.hoofdnav a:not(.cta-button):not(.cta-button-secondary) {
   color: var(--inkt); text-decoration: none; font-weight: 500; font-size: 0.99rem;
 }
-.hoofdnav a:not(.cta-button):hover { color: var(--groen-tekst); }
+.hoofdnav a:not(.cta-button):not(.cta-button-secondary):hover { color: var(--groen-tekst); }
 .hoofdnav .cta-button, .hoofdnav .cta-button-secondary { padding: 0.55rem 1.2rem; font-size: 0.95rem; }
 
 /* De Offerte-knop promoveert zichzelf: na 3 minuten leestijd morft hij in

--- a/webwinkel/style.css
+++ b/webwinkel/style.css
@@ -251,7 +251,9 @@ main > section > ul:not([class]), main > section > ol { max-width: var(--maat-sm
    Elke regel verschijnt uitgelicht in het midden van de band, daar faden
    het vinkje en het resultaatwoord in, en daarna schuift de regel naar zijn
    eigen plek in de tabel en blijft staan. Zo vult de tabel zich regel voor
-   regel; na een rustpauze dooft alles en begint de cyclus opnieuw.
+   regel, en daarna rust hij: de animatie speelt precies een keer, gestart
+   zodra de band in beeld scrolt (bandSpeelScript zet dan de klasse "speel";
+   zonder JavaScript blijft de tabel gewoon statisch compleet).
 
    Techniek: de gedeelde 18s-tijdlijn geeft regel N het venster
    (2 + 13*(N-1))% .. +11%. De podiumpositie (het midden van de band) staat
@@ -275,133 +277,116 @@ main > section > ul:not([class]), main > section > ol { max-width: var(--maat-sm
 .inpaklijst li:nth-child(n+5)  { --podium-y: -105%; }
 
 .inpaklijst .status svg path { stroke-dasharray: 24; stroke-dashoffset: 0; }
-.inpaklijst li:nth-child(1) { animation: inpak-rij-1 18s ease-in-out infinite; }
-.inpaklijst li:nth-child(2) { animation: inpak-rij-2 18s ease-in-out infinite; }
-.inpaklijst li:nth-child(3) { animation: inpak-rij-3 18s ease-in-out infinite; }
-.inpaklijst li:nth-child(4) { animation: inpak-rij-4 18s ease-in-out infinite; }
-.inpaklijst li:nth-child(5) { animation: inpak-rij-5 18s ease-in-out infinite; }
-.inpaklijst li:nth-child(6) { animation: inpak-rij-6 18s ease-in-out infinite; }
-.inpaklijst li:nth-child(1) .status { animation: inpak-status-1 18s ease-in-out infinite; }
-.inpaklijst li:nth-child(2) .status { animation: inpak-status-2 18s ease-in-out infinite; }
-.inpaklijst li:nth-child(3) .status { animation: inpak-status-3 18s ease-in-out infinite; }
-.inpaklijst li:nth-child(4) .status { animation: inpak-status-4 18s ease-in-out infinite; }
-.inpaklijst li:nth-child(5) .status { animation: inpak-status-5 18s ease-in-out infinite; }
-.inpaklijst li:nth-child(6) .status { animation: inpak-status-6 18s ease-in-out infinite; }
-.inpaklijst li:nth-child(1) .status svg path { animation: inpak-vink-1 18s linear infinite; }
-.inpaklijst li:nth-child(2) .status svg path { animation: inpak-vink-2 18s linear infinite; }
-.inpaklijst li:nth-child(3) .status svg path { animation: inpak-vink-3 18s linear infinite; }
-.inpaklijst li:nth-child(4) .status svg path { animation: inpak-vink-4 18s linear infinite; }
-.inpaklijst li:nth-child(5) .status svg path { animation: inpak-vink-5 18s linear infinite; }
-.inpaklijst li:nth-child(6) .status svg path { animation: inpak-vink-6 18s linear infinite; }
+.band.speel .inpaklijst li:nth-child(1) { animation: inpak-rij-1 18s ease-in-out 1 forwards; }
+.band.speel .inpaklijst li:nth-child(2) { animation: inpak-rij-2 18s ease-in-out 1 forwards; }
+.band.speel .inpaklijst li:nth-child(3) { animation: inpak-rij-3 18s ease-in-out 1 forwards; }
+.band.speel .inpaklijst li:nth-child(4) { animation: inpak-rij-4 18s ease-in-out 1 forwards; }
+.band.speel .inpaklijst li:nth-child(5) { animation: inpak-rij-5 18s ease-in-out 1 forwards; }
+.band.speel .inpaklijst li:nth-child(6) { animation: inpak-rij-6 18s ease-in-out 1 forwards; }
+.band.speel .inpaklijst li:nth-child(1) .status { animation: inpak-status-1 18s ease-in-out 1 forwards; }
+.band.speel .inpaklijst li:nth-child(2) .status { animation: inpak-status-2 18s ease-in-out 1 forwards; }
+.band.speel .inpaklijst li:nth-child(3) .status { animation: inpak-status-3 18s ease-in-out 1 forwards; }
+.band.speel .inpaklijst li:nth-child(4) .status { animation: inpak-status-4 18s ease-in-out 1 forwards; }
+.band.speel .inpaklijst li:nth-child(5) .status { animation: inpak-status-5 18s ease-in-out 1 forwards; }
+.band.speel .inpaklijst li:nth-child(6) .status { animation: inpak-status-6 18s ease-in-out 1 forwards; }
+.band.speel .inpaklijst li:nth-child(1) .status svg path { animation: inpak-vink-1 18s linear 1 forwards; }
+.band.speel .inpaklijst li:nth-child(2) .status svg path { animation: inpak-vink-2 18s linear 1 forwards; }
+.band.speel .inpaklijst li:nth-child(3) .status svg path { animation: inpak-vink-3 18s linear 1 forwards; }
+.band.speel .inpaklijst li:nth-child(4) .status svg path { animation: inpak-vink-4 18s linear 1 forwards; }
+.band.speel .inpaklijst li:nth-child(5) .status svg path { animation: inpak-vink-5 18s linear 1 forwards; }
+.band.speel .inpaklijst li:nth-child(6) .status svg path { animation: inpak-vink-6 18s linear 1 forwards; }
 
 /* Per regel: onzichtbaar tot het eigen venster, opkomen op het podium,
    even vasthouden terwijl vinkje en woord verschijnen, dan naar de eigen
    plek schuiven. Het podiumvlak is dekkend (#23425f: navy-diep met ~10%
    wit, de dekkende evenknie van de eerdere rgba-overlay met alpha 0.10)
    met een zweefschaduw: de laatste regels zweven over al gedockte tekst
-   heen en moeten die afdekken om leesbaar te blijven. Vanaf ~93% dooft
-   de hele tabel voor de herstart. */
+   heen en moeten die afdekken om leesbaar te blijven. De laatste frame is
+   gelijk aan de basisstijl (gedockt en zichtbaar), dus na de ene run staat
+   de tabel er rustig bij. */
 @keyframes inpak-rij-1 {
   0%, 2% { opacity: 0; transform: translate(var(--podium-x), var(--podium-y)) scale(1.06); background: #23425f; border-color: transparent; box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35); }
   4% { opacity: 1; }
   9% { opacity: 1; transform: translate(var(--podium-x), var(--podium-y)) scale(1.06); background: #23425f; border-color: transparent; box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35); }
-  13%, 93% { opacity: 1; transform: none; background: rgba(255, 255, 255, 0); border-color: rgba(255, 255, 255, 0.14); box-shadow: none; }
-  97%, 100% { opacity: 0; transform: none; }
+  13%, 100% { opacity: 1; transform: none; background: rgba(255, 255, 255, 0); border-color: rgba(255, 255, 255, 0.14); box-shadow: none; }
 }
 @keyframes inpak-status-1 {
   0%, 5% { opacity: 0; }
-  8%, 93% { opacity: 1; }
-  97%, 100% { opacity: 0; }
+  8%, 100% { opacity: 1; }
 }
 @keyframes inpak-vink-1 {
   0%, 5% { stroke-dashoffset: 24; }
-  8%, 93% { stroke-dashoffset: 0; }
-  97%, 100% { stroke-dashoffset: 24; }
+  8%, 100% { stroke-dashoffset: 0; }
 }
 @keyframes inpak-rij-2 {
   0%, 15% { opacity: 0; transform: translate(var(--podium-x), var(--podium-y)) scale(1.06); background: #23425f; border-color: transparent; box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35); }
   17% { opacity: 1; }
   22% { opacity: 1; transform: translate(var(--podium-x), var(--podium-y)) scale(1.06); background: #23425f; border-color: transparent; box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35); }
-  26%, 93% { opacity: 1; transform: none; background: rgba(255, 255, 255, 0); border-color: rgba(255, 255, 255, 0.14); box-shadow: none; }
-  97%, 100% { opacity: 0; transform: none; }
+  26%, 100% { opacity: 1; transform: none; background: rgba(255, 255, 255, 0); border-color: rgba(255, 255, 255, 0.14); box-shadow: none; }
 }
 @keyframes inpak-status-2 {
   0%, 18% { opacity: 0; }
-  21%, 93% { opacity: 1; }
-  97%, 100% { opacity: 0; }
+  21%, 100% { opacity: 1; }
 }
 @keyframes inpak-vink-2 {
   0%, 18% { stroke-dashoffset: 24; }
-  21%, 93% { stroke-dashoffset: 0; }
-  97%, 100% { stroke-dashoffset: 24; }
+  21%, 100% { stroke-dashoffset: 0; }
 }
 @keyframes inpak-rij-3 {
   0%, 28% { opacity: 0; transform: translate(var(--podium-x), var(--podium-y)) scale(1.06); background: #23425f; border-color: transparent; box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35); }
   30% { opacity: 1; }
   35% { opacity: 1; transform: translate(var(--podium-x), var(--podium-y)) scale(1.06); background: #23425f; border-color: transparent; box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35); }
-  39%, 93% { opacity: 1; transform: none; background: rgba(255, 255, 255, 0); border-color: rgba(255, 255, 255, 0.14); box-shadow: none; }
-  97%, 100% { opacity: 0; transform: none; }
+  39%, 100% { opacity: 1; transform: none; background: rgba(255, 255, 255, 0); border-color: rgba(255, 255, 255, 0.14); box-shadow: none; }
 }
 @keyframes inpak-status-3 {
   0%, 31% { opacity: 0; }
-  34%, 93% { opacity: 1; }
-  97%, 100% { opacity: 0; }
+  34%, 100% { opacity: 1; }
 }
 @keyframes inpak-vink-3 {
   0%, 31% { stroke-dashoffset: 24; }
-  34%, 93% { stroke-dashoffset: 0; }
-  97%, 100% { stroke-dashoffset: 24; }
+  34%, 100% { stroke-dashoffset: 0; }
 }
 @keyframes inpak-rij-4 {
   0%, 41% { opacity: 0; transform: translate(var(--podium-x), var(--podium-y)) scale(1.06); background: #23425f; border-color: transparent; box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35); }
   43% { opacity: 1; }
   48% { opacity: 1; transform: translate(var(--podium-x), var(--podium-y)) scale(1.06); background: #23425f; border-color: transparent; box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35); }
-  52%, 93% { opacity: 1; transform: none; background: rgba(255, 255, 255, 0); border-color: rgba(255, 255, 255, 0.14); box-shadow: none; }
-  97%, 100% { opacity: 0; transform: none; }
+  52%, 100% { opacity: 1; transform: none; background: rgba(255, 255, 255, 0); border-color: rgba(255, 255, 255, 0.14); box-shadow: none; }
 }
 @keyframes inpak-status-4 {
   0%, 44% { opacity: 0; }
-  47%, 93% { opacity: 1; }
-  97%, 100% { opacity: 0; }
+  47%, 100% { opacity: 1; }
 }
 @keyframes inpak-vink-4 {
   0%, 44% { stroke-dashoffset: 24; }
-  47%, 93% { stroke-dashoffset: 0; }
-  97%, 100% { stroke-dashoffset: 24; }
+  47%, 100% { stroke-dashoffset: 0; }
 }
 @keyframes inpak-rij-5 {
   0%, 54% { opacity: 0; transform: translate(var(--podium-x), var(--podium-y)) scale(1.06); background: #23425f; border-color: transparent; box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35); }
   56% { opacity: 1; }
   61% { opacity: 1; transform: translate(var(--podium-x), var(--podium-y)) scale(1.06); background: #23425f; border-color: transparent; box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35); }
-  65%, 93% { opacity: 1; transform: none; background: rgba(255, 255, 255, 0); border-color: rgba(255, 255, 255, 0.14); box-shadow: none; }
-  97%, 100% { opacity: 0; transform: none; }
+  65%, 100% { opacity: 1; transform: none; background: rgba(255, 255, 255, 0); border-color: rgba(255, 255, 255, 0.14); box-shadow: none; }
 }
 @keyframes inpak-status-5 {
   0%, 57% { opacity: 0; }
-  60%, 93% { opacity: 1; }
-  97%, 100% { opacity: 0; }
+  60%, 100% { opacity: 1; }
 }
 @keyframes inpak-vink-5 {
   0%, 57% { stroke-dashoffset: 24; }
-  60%, 93% { stroke-dashoffset: 0; }
-  97%, 100% { stroke-dashoffset: 24; }
+  60%, 100% { stroke-dashoffset: 0; }
 }
 @keyframes inpak-rij-6 {
   0%, 67% { opacity: 0; transform: translate(var(--podium-x), var(--podium-y)) scale(1.06); background: #23425f; border-color: transparent; box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35); }
   69% { opacity: 1; }
   74% { opacity: 1; transform: translate(var(--podium-x), var(--podium-y)) scale(1.06); background: #23425f; border-color: transparent; box-shadow: 0 12px 28px rgba(0, 0, 0, 0.35); }
-  78%, 93% { opacity: 1; transform: none; background: rgba(255, 255, 255, 0); border-color: rgba(255, 255, 255, 0.14); box-shadow: none; }
-  97%, 100% { opacity: 0; transform: none; }
+  78%, 100% { opacity: 1; transform: none; background: rgba(255, 255, 255, 0); border-color: rgba(255, 255, 255, 0.14); box-shadow: none; }
 }
 @keyframes inpak-status-6 {
   0%, 70% { opacity: 0; }
-  73%, 93% { opacity: 1; }
-  97%, 100% { opacity: 0; }
+  73%, 100% { opacity: 1; }
 }
 @keyframes inpak-vink-6 {
   0%, 70% { stroke-dashoffset: 24; }
-  73%, 93% { stroke-dashoffset: 0; }
-  97%, 100% { stroke-dashoffset: 24; }
+  73%, 100% { stroke-dashoffset: 0; }
 }
 
 /* Op mobiel staat alles in 1 kolom: de regel licht op zijn eigen plek op. */


### PR DESCRIPTION
Vervolg op #131 (dat gemerged werd terwijl deze ronde nog liep); dit zijn de commits die daarna op de branch kwamen.

## Wat er in zit

- Cache-busting: de Shake-build hasht style.css, blog.css en de twee Elm-bundels (sha256, eerste 10 tekens in de bestandsnaam) en herschrijft de verwijzingen in elke pagina; de ongehashte originelen blijven staan voor bezoekers met een oude gecachte HTML-pagina. De pure kant staat in een nieuwe module `AssetHash` met twee tests (herschrijving raakt precies de vier assets, en de gehashte naam is deterministisch en volgt de inhoud). Nieuwe dependency: `SHA`.
- Hele site in de je-vorm: alle pagina's, de rekenhulp, de scanner en de zeven blogartikelen, met handmatig gecatalogiseerde werkwoordsinversies (bent u → ben je, heeft u → heb je, maar duwt u → duwt je). Sitemap-lastmods en artikel-MODIFIED-datums bijgewerkt; geen titels of slugs veranderd.
- Menu geslankt naar Prijzen, Blog, Over ons, Contact + Offerte; de platformpagina's staan nu in de footer. De Offerte-knop wordt niet langer door de navigatielinkregel geraakt (tekst weer navy).
- De band-animatie speelt precies één keer en blijft dan gevuld staan, gestart via een IntersectionObserver zodra de band in beeld scrolt. Zonder JavaScript of met reduced motion: statisch complete tabel.

## Verificatie

- `nix-build nix/ci.nix` groen: 65 Elm-tests, 34 template-tests (waaronder de nieuwe asset-tests), SEO-analyzer schoon.
- Visueel geverifieerd op de lokale serve: gehashte assetnamen in de pagina's, je-vorm copy, slanke navigatie, band die één run speelt en rust.

Bevat één lege commit (59edd0c) die de vastgelopen PR-synchronisatie van #131 probeerde te triggeren voordat duidelijk was dat die PR al gemerged was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)