### PR TITLE
Webwinkel: eigen 404-pagina en beeldoptimalisatie voor alle drie de sites

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -87,9 +87,10 @@ pkgs.stdenv.mkDerivation {
     xmllint --noout _penguin-site/sitemap.xml
     xmllint --noout _webwinkelverhuis-site/sitemap.xml
 
-    # Optimize images
-    find _site -name '*.png' -exec optipng -quiet {} \;
-    find _site \( -name '*.jpg' -o -name '*.jpeg' \) -exec jpegtran -copy none -optimize -progressive -outfile {} {} \;
+    # Optimize images for all three sites (this long covered only _site,
+    # shipping the commercial sites' photos unoptimized)
+    find _site _penguin-site _webwinkelverhuis-site -name '*.png' -exec optipng -quiet {} \;
+    find _site _penguin-site _webwinkelverhuis-site \( -name '*.jpg' -o -name '*.jpeg' \) -exec jpegtran -copy none -optimize -progressive -outfile {} {} \;
   '';
   installPhase = ''
     mkdir -p $out/jappieklooster.nl $out/jappiesoftware.com $out/webwinkelverhuis.nl

--- a/shake/Shakefile.hs
+++ b/shake/Shakefile.hs
@@ -46,6 +46,7 @@ import WebwinkelTemplates
   ( webwinkelIndexPage
   , prijzenPage
   , scanPage
+  , vierNulVierPagina
   , webwinkelBlogIndexPage
   , webwinkelArticlePage
   , appPage
@@ -768,6 +769,10 @@ generateWebwinkelverhuisSite config articles gehashteAssets = do
   writeWebwinkelHtmlFile gehashteAssets "_webwinkelverhuis-site/waarom-lightspeed.html" lightspeedWaaromPage
   writeWebwinkelHtmlFile gehashteAssets "_webwinkelverhuis-site/over-ons.html" overOnsPage
   writeWebwinkelHtmlFile gehashteAssets "_webwinkelverhuis-site/contact.html" contactPage
+
+  -- Foutpagina: nginx serveert deze via error_page bij onbekende URL's.
+  -- Bewust niet in webwinkelverhuisStaticPages en dus niet in de sitemap.
+  writeWebwinkelHtmlFile gehashteAssets "_webwinkelverhuis-site/404.html" vierNulVierPagina
 
   -- Individual blog article pages
   mapM_ (\art ->

--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -10,6 +10,7 @@ module WebwinkelTemplates
   ( webwinkelIndexPage
   , prijzenPage
   , scanPage
+  , vierNulVierPagina
   , webwinkelBlogIndexPage
   , webwinkelArticlePage
   , appPage
@@ -987,6 +988,34 @@ scanPage = webwinkelBaseTemplate scanMeta $
       , pageMetaSwitchUrl   = Nothing
       , pageMetaExtraHead   = mempty
       }
+
+-- =============================================================================
+-- 404-pagina (404.html)
+-- =============================================================================
+
+-- | De foutpagina die nginx via error_page serveert bij elke onbekende URL,
+-- in plaats van de kale standaard-404. noindex: een foutpagina hoort niet in
+-- de zoekindex, maar de links erop mogen gewoon gevolgd worden.
+vierNulVierPagina :: Html
+vierNulVierPagina = webwinkelBaseTemplate vierNulVierMeta $
+  H.main $
+    H.section ! A.class_ "hero scan-blok" $ do
+      H.h1 "Pagina niet gevonden"
+      H.p ! A.class_ "subtitle" $ "Deze pagina bestaat niet (meer). Alles wat wij verhuizen krijgt een doorverwijzing, maar deze link leidde nergens heen."
+      H.div ! A.class_ "hero-knoppen" $ do
+        H.a ! A.href "/" ! A.class_ "cta-button" $ "Naar de homepagina"
+        H.a ! A.href "/contact.html" ! A.class_ "cta-button-secondary" $ "Neem contact op"
+
+vierNulVierMeta :: PageMeta
+vierNulVierMeta = PageMeta
+  { pageMetaTitle       = "Pagina niet gevonden \8212 Webwinkelverhuis"
+  , pageMetaDescription = "Deze pagina bestaat niet op webwinkelverhuis.nl. Ga naar de homepagina of neem contact op."
+  , pageMetaLang        = "nl"
+  , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/404.html"
+  , pageMetaOgImage     = Nothing
+  , pageMetaSwitchUrl   = Nothing
+  , pageMetaExtraHead   = H.meta ! A.name "robots" ! A.content "noindex, follow"
+  }
 
 mijnwebwinkelMigrationPage :: Html
 mijnwebwinkelMigrationPage = webwinkelBaseTemplate migrationMeta $

--- a/shake/test/Test.hs
+++ b/shake/test/Test.hs
@@ -43,6 +43,7 @@ import PenguinTemplates
 import WebwinkelTemplates
   ( webwinkelIndexPage
   , scanPage
+  , vierNulVierPagina
   , mijnwebwinkelMigrationPage
   , ccvshopMigrationPage
   , lightspeedMigrationPage
@@ -190,8 +191,20 @@ main = defaultMain $
         ]
     , testGroup "taxonomiepagina's zijn noindex"
         [ taxonomieKrijgtNoindexIndexNiet
+        , vierNulVierNoindexEnBuitenSitemap
         ]
     ]
+
+-- | De 404-pagina draagt noindex (een foutpagina hoort niet in de index) en
+-- ontbreekt in de sitemap. Dit faalt wanneer iemand de pagina per ongeluk
+-- aan webwinkelverhuisStaticPages toevoegt of de robots-directive schrapt.
+vierNulVierNoindexEnBuitenSitemap :: TestTree
+vierNulVierNoindexEnBuitenSitemap = testCase "404-pagina noindex en buiten sitemap" $ do
+  let pagina = TL.toStrict (renderHtml vierNulVierPagina)
+  assertBool "404-pagina mist de noindex, follow-directive"
+    ("<meta name=\"robots\" content=\"noindex, follow\">" `T.isInfixOf` pagina)
+  assertBool "404-pagina belandde in de sitemap"
+    (not ("404" `T.isInfixOf` sitemapUnderTest))
 
 -- | De dunne taxonomiepagina's (tags/categorieen) dragen "noindex, follow";
 -- de indexpagina moet gewoon indexeerbaar blijven. Dit faalt zowel wanneer

--- a/webwinkel/style.css
+++ b/webwinkel/style.css
@@ -704,6 +704,7 @@ footer small a:hover { color: var(--wit); }
 main { display: flex; flex-direction: column; }
 .scan-blok { flex: 1; text-align: center; border-bottom: 0; }
 .scan-blok .subtitle { margin-inline: auto; }
+.scan-blok .hero-knoppen { justify-content: center; }
 .scan-blok .webshop-scanner {
   margin: 2.2rem auto 0; text-align: left; max-width: 34rem;
 }


### PR DESCRIPTION
Twee punten uit de kritische audit van de live site.

## 404-pagina

De live site serveert nu de kale nginx-standaard-404 (146 bytes wit). Deze PR bouwt een `404.html` in de huisstijl mee in `_webwinkelverhuis-site`: kop, korte uitleg en knoppen naar de homepagina en contact. De pagina draagt `noindex, follow` en staat bewust niet in `webwinkelverhuisStaticPages`, dus ook niet in de sitemap. De `error_page 404 /404.html`-regel staat in de bijbehorende megavid-PR; zolang de blog-pin deze pagina nog niet heeft valt nginx vanzelf terug op zijn eigen 404, dus de volgorde van uitrollen maakt niet uit.

## Beeldoptimalisatie voor alle drie de sites

`default.nix` draaide optipng/jpegtran alleen over `_site` (jappie.me), waardoor de commerciele sites hun afbeeldingen ongeoptimaliseerd meekregen. Nu over `_site`, `_penguin-site` en `_webwinkelverhuis-site`. Eerlijk gemeten resultaat: op de huidige webwinkelfoto's scheelt jpegtran vrijwel niets (joepa's exports waren al geoptimaliseerd, hero-inpakken.jpg wordt 18 bytes kleiner), dus dit is vooral een vangnet voor toekomstige afbeeldingen. Echte winst op de foto's vergt responsive formaten (srcset), dat is een aparte klus.

Test toegevoegd: de 404-pagina draagt de noindex-directive en belandt niet in de sitemap. Volledige `nix-build` (SEO-analyzer incluis) slaagt lokaal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)