### PR TITLE
Prijscalculator: productvertalingen tellen mee in de 1.000-basisruimte

### DIFF
--- a/elm/src/PrijsCalculator.elm
+++ b/elm/src/PrijsCalculator.elm
@@ -13,9 +13,10 @@ port module PrijsCalculator exposing
 {-| Interactieve prijsindicatie voor een webshop-migratie op webwinkelverhuis.nl.
 
 De prijslogica is een 1-op-1 kopie van de standaard prijslijst (jappiesoft
-strategy/standaard-prijslijst.org) en de tabel op /prijzen: basismigratie t/m
-1.000 producten en 1 taal, daarboven een staffel per product en per extra taal,
-plus de losse modules (thema, klantaccounts, orderhistorie, nieuwsbrief,
+strategy/standaard-prijslijst.org) en de tabel op /prijzen: basismigratie met
+1.000 inbegrepen productvertalingen (producten maal talen tellen samen tegen
+die ruimte), daarboven €0,25 per productvertaling, plus €250 configuratie per
+extra taal, de losse modules (thema, klantaccounts, orderhistorie, nieuwsbrief,
 voorraad) en de diensten domeinverhuizing en e-mail-setup. Alle bedragen worden
 intern in hele centen gerekend zodat er geen afrondingsfouten op de komma
 ontstaan; pas bij het tonen zetten we centen om naar euro's.
@@ -523,24 +524,36 @@ aantalTalen model =
     Basics.max 1 (leesGetal model.talenInvoer)
 
 
-extraProducten : Model -> Int
-extraProducten model =
-    Basics.max 0 (aantalProducten model - inbegrepenProducten)
-
-
 extraTalen : Model -> Int
 extraTalen model =
     aantalTalen model - 1
 
 
-extraProductenCenten : Model -> Int
-extraProductenCenten model =
-    extraProducten model * perProductCenten
+-- Decision: productvertalingen tellen samen tegen de 1.000 inbegrepen
+-- producten van de basismigratie (besluit Jappie 2026-08-08, n.a.v. de
+-- bybjor-offerte). Elk product telt per taal één keer mee: 160 producten
+-- in 3 talen zijn 480 productvertalingen en passen dus in de basisruimte,
+-- terwijl het oude model elke extra taal over de hele catalogus liet
+-- betalen zonder die ruimte. Voor catalogi vanaf 1.000 producten is de
+-- uitkomst wiskundig gelijk aan het oude model; kleinere catalogi met
+-- meerdere talen worden er goedkoper van. Alternatief was de oude
+-- twee-staffels-opzet houden; afgewezen omdat die kleine meertalige
+-- shops liet betalen voor ruimte die ze al gekocht hadden.
 
 
-extraTaalProductenCenten : Model -> Int
-extraTaalProductenCenten model =
-    extraTalen model * aantalProducten model * perProductCenten
+productVertalingen : Model -> Int
+productVertalingen model =
+    aantalProducten model * aantalTalen model
+
+
+extraProductVertalingen : Model -> Int
+extraProductVertalingen model =
+    Basics.max 0 (productVertalingen model - inbegrepenProducten)
+
+
+extraProductVertalingenCenten : Model -> Int
+extraProductVertalingenCenten model =
+    extraProductVertalingen model * perProductCenten
 
 
 extraTaalConfiguratieCenten : Model -> Int
@@ -609,8 +622,7 @@ indienAan aan centen =
 totaalCenten : Model -> Int
 totaalCenten model =
     basisMigratieCenten
-        + extraProductenCenten model
-        + extraTaalProductenCenten model
+        + extraProductVertalingenCenten model
         + extraTaalConfiguratieCenten model
         + themaCenten model
         + indienAan model.klantaccounts klantaccountsCenten
@@ -839,15 +851,11 @@ de uitsplitsing op het scherm als de vooringevulde offerte-mail, zodat die twee
 nooit uit elkaar lopen. -}
 prijsRegels : Model -> List PrijsRegel
 prijsRegels model =
-    [ PrijsRegel "Basismigratie (t/m 1.000 producten, 1 taal)" basisMigratieCenten ]
+    [ PrijsRegel "Basismigratie (1.000 producten inbegrepen, over alle talen samen)" basisMigratieCenten ]
         ++ optioneleRegel
-            (extraProducten model > 0)
-            (aantalLabel (extraProducten model) "extra product \u{00D7} \u{20AC}0,25" "extra producten \u{00D7} \u{20AC}0,25")
-            (extraProductenCenten model)
-        ++ optioneleRegel
-            (extraTalen model > 0)
-            (aantalLabel (extraTalen model) "extra taal: vertaalwerk per product" "extra talen: vertaalwerk per product")
-            (extraTaalProductenCenten model)
+            (extraProductVertalingen model > 0)
+            (aantalLabel (extraProductVertalingen model) "product boven de 1.000 inbegrepen (over alle talen) \u{00D7} \u{20AC}0,25" "producten boven de 1.000 inbegrepen (over alle talen) \u{00D7} \u{20AC}0,25")
+            (extraProductVertalingenCenten model)
         ++ optioneleRegel
             (extraTalen model > 0)
             (aantalLabel (extraTalen model) "extra taal: configuratie \u{00D7} \u{20AC}250" "extra talen: configuratie \u{00D7} \u{20AC}250")

--- a/elm/src/PrijsCalculator.elm
+++ b/elm/src/PrijsCalculator.elm
@@ -978,7 +978,7 @@ view model =
             [ legend [] [ text "Je webshop" ]
             , bronVeld model.bron
             , doelVeld model.doel
-            , getalVeld "Hoeveel producten heeft je webshop ongeveer?" model.productenInvoer "t/m 1.000 zit in de basisprijs" ProductenGewijzigd
+            , getalVeld "Hoeveel producten heeft je webshop ongeveer?" model.productenInvoer "1.000 zit in de basisprijs, geteld over alle talen samen" ProductenGewijzigd
             , getalVeld "In hoeveel talen staat je webshop?" model.talenInvoer "1 taal zit in de basisprijs" TalenGewijzigd
             , themaVeld model.thema
             , div [ Attr.class "calc-check-group" ]

--- a/elm/src/PrijsCalculator.elm
+++ b/elm/src/PrijsCalculator.elm
@@ -978,7 +978,7 @@ view model =
             [ legend [] [ text "Je webshop" ]
             , bronVeld model.bron
             , doelVeld model.doel
-            , getalVeld "Hoeveel producten heeft je webshop ongeveer?" model.productenInvoer "1.000 zit in de basisprijs, geteld over alle talen samen" ProductenGewijzigd
+            , getalVeld "Hoeveel producten heeft je webshop ongeveer?" model.productenInvoer "1.000 zit in de basisprijs" ProductenGewijzigd
             , getalVeld "In hoeveel talen staat je webshop?" model.talenInvoer "1 taal zit in de basisprijs" TalenGewijzigd
             , themaVeld model.thema
             , div [ Attr.class "calc-check-group" ]

--- a/elm/tests/PricingTest.elm
+++ b/elm/tests/PricingTest.elm
@@ -44,6 +44,14 @@ suite =
             \_ ->
                 Expect.equal 404900
                     (totaalCenten (metProducten 2400 3 initieelModel))
+        , test "160 producten, 3 talen: vertalingen passen in de basisruimte, alleen 2 x 250 configuratie = 2.499 (bybjor-regel)" <|
+            \_ ->
+                Expect.equal 249900
+                    (totaalCenten (metProducten 160 3 initieelModel))
+        , test "700 producten, 2 talen: alleen de 400 vertalingen boven de 1.000 tellen = 2.349" <|
+            \_ ->
+                Expect.equal 234900
+                    (totaalCenten (metProducten 700 2 initieelModel))
         , test "Panzer + thema overzetten + domeinverhuizing = 5.048" <|
             \_ ->
                 let

--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -429,7 +429,7 @@ prijzen = H.section ! A.class_ "prijs-sectie" ! A.id "prijzen" $
     H.p ! A.class_ "prijs" $ do
       H.preEscapedToHtml ("vanaf &euro;" <> migratieBasisprijsEuro <> " ")
       H.small "eenmalig"
-    H.p ! A.class_ "inbegrepen" $ H.preEscapedToHtml ("Inclusief 1.000 producten en &eacute;&eacute;n taal: producten, afbeeldingen, categorie&euml;n, klantdata, voorraad en SEO-redirects." :: Text)
+    H.p ! A.class_ "inbegrepen" $ H.preEscapedToHtml ("Inclusief 1.000 producten, geteld over alle talen samen: producten, afbeeldingen, categorie&euml;n, klantdata, voorraad en SEO-redirects." :: Text)
     H.p ! A.class_ "meerprijs" $ H.preEscapedToHtml ("Grotere catalogi, extra talen en losse diensten (e-mail-setup, en domeinverhuizing als je domein nog bij je huidige platform staat) hebben een vaste meerprijs." :: Text)
     H.hr
     H.p ! A.class_ "abonnement" $ do

--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -429,7 +429,7 @@ prijzen = H.section ! A.class_ "prijs-sectie" ! A.id "prijzen" $
     H.p ! A.class_ "prijs" $ do
       H.preEscapedToHtml ("vanaf &euro;" <> migratieBasisprijsEuro <> " ")
       H.small "eenmalig"
-    H.p ! A.class_ "inbegrepen" $ H.preEscapedToHtml ("Inclusief 1.000 producten, geteld over alle talen samen: producten, afbeeldingen, categorie&euml;n, klantdata, voorraad en SEO-redirects." :: Text)
+    H.p ! A.class_ "inbegrepen" $ H.preEscapedToHtml ("Inclusief 1.000 producten: producten, afbeeldingen, categorie&euml;n, klantdata, voorraad en SEO-redirects." :: Text)
     H.p ! A.class_ "meerprijs" $ H.preEscapedToHtml ("Grotere catalogi, extra talen en losse diensten (e-mail-setup, en domeinverhuizing als je domein nog bij je huidige platform staat) hebben een vaste meerprijs." :: Text)
     H.hr
     H.p ! A.class_ "abonnement" $ do
@@ -876,7 +876,7 @@ prijzenPage = webwinkelBaseTemplate prijzenMeta $
       H.h2 "De migratie"
       H.table ! A.class_ "price-table" $ H.tbody $ do
         H.tr $ do
-          H.td "Basismigratie: 1.000 producten inbegrepen, geteld over alle talen samen"
+          H.td "Basismigratie: 1.000 producten inbegrepen"
           H.td ! A.class_ "price-cell" $ H.preEscapedToHtml ("&euro;1.999" :: Text)
         H.tr $ do
           H.td "Extra producten boven die 1.000 (elk product telt per taal \233\233n keer mee)"
@@ -954,7 +954,7 @@ prijzenPage = webwinkelBaseTemplate prijzenMeta $
     prijzenMeta :: PageMeta
     prijzenMeta = PageMeta
       { pageMetaTitle       = "Prijzen \8212 Webwinkelverhuis"
-      , pageMetaDescription = "Vaste prijzen voor je webshop-migratie naar Shopify: vanaf \8364\&1.999 inclusief 1.000 producten, geteld over alle talen samen. Domeinverhuizing \8364\&250, e-mail-setup \8364\&150. Betaling na succesvolle migratie."
+      , pageMetaDescription = "Vaste prijzen voor je webshop-migratie naar Shopify: vanaf \8364\&1.999 inclusief 1.000 producten. Domeinverhuizing \8364\&250, e-mail-setup \8364\&150. Betaling na succesvolle migratie."
       , pageMetaLang        = "nl"
       , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/prijzen.html"
       , pageMetaOgImage     = Nothing

--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -876,13 +876,10 @@ prijzenPage = webwinkelBaseTemplate prijzenMeta $
       H.h2 "De migratie"
       H.table ! A.class_ "price-table" $ H.tbody $ do
         H.tr $ do
-          H.td "Basismigratie: t/m 1.000 producten, 1 taal"
+          H.td "Basismigratie: 1.000 producten inbegrepen, geteld over alle talen samen"
           H.td ! A.class_ "price-cell" $ H.preEscapedToHtml ("&euro;1.999" :: Text)
         H.tr $ do
-          H.td "Extra producten, boven de 1.000 (eerste taal)"
-          H.td ! A.class_ "price-cell" $ H.preEscapedToHtml ("&euro;0,25 per product" :: Text)
-        H.tr $ do
-          H.td "Extra taal: per product over de hele catalogus"
+          H.td "Extra producten boven die 1.000 (elk product telt per taal \233\233n keer mee)"
           H.td ! A.class_ "price-cell" $ H.preEscapedToHtml ("&euro;0,25 per product" :: Text)
         H.tr $ do
           H.td "Extra taal: configuratie, per taal"
@@ -957,7 +954,7 @@ prijzenPage = webwinkelBaseTemplate prijzenMeta $
     prijzenMeta :: PageMeta
     prijzenMeta = PageMeta
       { pageMetaTitle       = "Prijzen \8212 Webwinkelverhuis"
-      , pageMetaDescription = "Vaste prijzen voor je webshop-migratie naar Shopify: vanaf \8364\&1.999 inclusief 1.000 producten en 1 taal. Domeinverhuizing \8364\&250, e-mail-setup \8364\&150. Betaling na succesvolle migratie."
+      , pageMetaDescription = "Vaste prijzen voor je webshop-migratie naar Shopify: vanaf \8364\&1.999 inclusief 1.000 producten, geteld over alle talen samen. Domeinverhuizing \8364\&250, e-mail-setup \8364\&150. Betaling na succesvolle migratie."
       , pageMetaLang        = "nl"
       , pageMetaCanonical   = Just "https://webwinkelverhuis.nl/prijzen.html"
       , pageMetaOgImage     = Nothing


### PR DESCRIPTION
## Samenvatting
- Nieuwe telregel (besluit 8 aug, n.a.v. de bybjor-offerte): de 1.000 inbegrepen producten van de basismigratie gelden over alle talen samen; elk product telt per taal één keer mee.
- Wiskundig gelijk aan de oude twee-staffels voor catalogi vanaf 1.000 producten (Panzer-voorbeeld blijft €4.049); kleine meertalige catalogi betalen niet langer vertaalwerk-per-product voor ruimte die al in de basis zat (160 producten x 3 talen = alleen 2 x €250 configuratie).
- Calculator, uitsplitsingsregels, statische prijzentabel en meta-description lopen weer gelijk.

## Testplan
- [x] Nieuwe tests falen op de oude implementatie (65 passed / 2 failed) en zijn groen op de nieuwe (67/67)
- [x] nix-build nix/ci.nix slaagt lokaal
- [ ] Na deploy: rekenhulp op /prijzen geeft voor 160 producten + 3 talen €2.499

🤖 Generated with [Claude Code](https://claude.com/claude-code)