### PR TITLE
Prijscalculator: cursus Shopify als publieke module (€300)

### DIFF
--- a/elm/src/PrijsCalculator.elm
+++ b/elm/src/PrijsCalculator.elm
@@ -142,6 +142,11 @@ pointOfSaleCenten =
     75000
 
 
+cursusCenten : Int
+cursusCenten =
+    30000
+
+
 
 -- MODEL
 
@@ -196,6 +201,7 @@ type alias Model =
     , verzendkoppeling : Bool
     , b2bKanaal : Bool
     , pointOfSale : Bool
+    , cursus : Bool
     , naam : String
     , webshopDomein : String
     , offertePoging : Bool
@@ -220,6 +226,7 @@ initieelModel =
     , verzendkoppeling = False
     , b2bKanaal = False
     , pointOfSale = False
+    , cursus = False
     , naam = ""
     , webshopDomein = ""
     , offertePoging = False
@@ -252,6 +259,7 @@ type Msg
     | VerzendkoppelingGewijzigd Bool
     | B2bKanaalGewijzigd Bool
     | PointOfSaleGewijzigd Bool
+    | CursusGewijzigd Bool
     | NaamGewijzigd String
     | WebshopDomeinGewijzigd String
     | OfferteGepoogd
@@ -464,6 +472,9 @@ update msg model =
         ReviewsGewijzigd aan ->
             markeerEngagement { model | reviews = aan }
 
+        CursusGewijzigd aan ->
+            markeerEngagement { model | cursus = aan }
+
         DomeinGewijzigd aan ->
             markeerEngagement { model | domeinBijMijnwebwinkel = aan }
 
@@ -635,6 +646,7 @@ totaalCenten model =
         + indienAan model.verzendkoppeling verzendkoppelingCenten
         + indienAan model.b2bKanaal b2bKanaalCenten
         + indienAan model.pointOfSale pointOfSaleCenten
+        + indienAan model.cursus cursusCenten
 
 
 
@@ -871,6 +883,7 @@ prijsRegels model =
         ++ optioneleRegel model.verzendkoppeling "Verzendkoppeling (bijv. DHL)" verzendkoppelingCenten
         ++ optioneleRegel model.b2bKanaal "B2B-kanaal (zakelijke prijzen)" b2bKanaalCenten
         ++ optioneleRegel model.pointOfSale "Kassa / point-of-sale" pointOfSaleCenten
+        ++ optioneleRegel model.cursus "Cursus Shopify (2 uur, 1-op-1)" cursusCenten
 
 
 regelNaarHtml : PrijsRegel -> Html Msg
@@ -995,6 +1008,7 @@ view model =
                     ++ [ aanvinkVeld "Verzendkoppeling (bijv. DHL)" "Pakketten en labels rechtstreeks vanuit je shop" model.verzendkoppeling VerzendkoppelingGewijzigd
                        , aanvinkVeld "B2B-kanaal (zakelijke klanten)" "Aparte prijzen en inlog voor zakelijke klanten" model.b2bKanaal B2bKanaalGewijzigd
                        , aanvinkVeld "Kassa / point-of-sale voor mijn fysieke winkel" "Verkopen in de winkel \u{00E9}n online met \u{00E9}\u{00E9}n systeem (Shopify POS)" model.pointOfSale PointOfSaleGewijzigd
+                       , aanvinkVeld "Cursus Shopify (2 uur, 1-op-1)" "Samen door je nieuwe shop, zodat je hem daarna zelf beheert" model.cursus CursusGewijzigd
                        ]
             ]
         , div [ Attr.class "calc-result" ] <|

--- a/elm/tests/PricingTest.elm
+++ b/elm/tests/PricingTest.elm
@@ -107,6 +107,10 @@ suite =
             \_ ->
                 Expect.equal 274900
                     (totaalCenten { initieelModel | pointOfSale = True })
+        , test "cursus Shopify voegt 300 toe" <|
+            \_ ->
+                Expect.equal 229900
+                    (totaalCenten { initieelModel | cursus = True })
         , test "alle overzet-modules samen tellen 4 x 250 op" <|
             \_ ->
                 Expect.equal 299900

--- a/shake/WebwinkelTemplates.hs
+++ b/shake/WebwinkelTemplates.hs
@@ -924,6 +924,9 @@ prijzenPage = webwinkelBaseTemplate prijzenMeta $
           H.td $ H.preEscapedToHtml ("Kassa / point-of-sale (Shopify POS in je fysieke winkel)" :: Text)
           H.td ! A.class_ "price-cell" $ H.preEscapedToHtml ("&euro;750" :: Text)
         H.tr $ do
+          H.td $ H.preEscapedToHtml ("Cursus Shopify (2 uur, 1-op-1, samen door je nieuwe shop)" :: Text)
+          H.td ! A.class_ "price-cell" $ H.preEscapedToHtml ("&euro;300" :: Text)
+        H.tr $ do
           H.td "Volledig nieuw ontwerp"
           H.td ! A.class_ "price-cell" $ "op aanvraag"
         H.tr $ do


### PR DESCRIPTION
## Samenvatting
- De 2-uurs 1-op-1-cursus uit de interne prijslijst wordt publiek: aanvinkbare module in de rekenhulp en rij in de prijzentabel op /prijzen, €300.
- Aanleiding: Bjørke vroeg er spontaan om ("Cursus Shopify zeer welkom"), dus de vraag bestaat; publiek maken laat de rekenhulp hetzelfde vertellen als de offertes.

## Testplan
- [x] Nieuwe test "cursus Shopify voegt 300 toe" (68/68 groen; op master compileert de test niet eens, dus aantoonbaar aan de implementatie gebonden)
- [x] nix-build nix/ci.nix slaagt lokaal
- [ ] Na deploy: cursus aanvinken op /prijzen telt €300 op

🤖 Generated with [Claude Code](https://claude.com/claude-code)