### PR TITLE
Kruidje-klantverhaal: iDEAL-tussenoplossing afgerond na drie dagen

### DIFF
--- a/webwinkel/content/kruidje-klantverhaal.org
+++ b/webwinkel/content/kruidje-klantverhaal.org
@@ -103,12 +103,13 @@ winkel al om moet. En wachten was geen optie: dan had een draaiende,
 verkopende winkel wekenlang zonder iDEAL gestaan.
 
 Dat lost geen wachten op; dat lost een tweede betaalprovider op.
-iDEAL loopt voorlopig via Mollie naast de rest. Dat kost tijdelijk
-wel iets: op het Basic-abonnement rekent Shopify twee procentpunt
-extra per bestelling wanneer de betaling buiten het eigen
-betaalsysteem loopt. Zodra
-Shopify de winkel heeft beoordeeld schuift iDEAL over, vervallen
-die procentpunten en vervalt de tussenoplossing.
+iDEAL liep de eerste dagen via Mollie naast de rest. Dat kostte
+tijdelijk wel iets: op het Basic-abonnement rekent Shopify twee
+procentpunt extra per bestelling wanneer de betaling buiten het
+eigen betaalsysteem loopt. Drie dagen na de livegang was Shopify's
+beoordeling er al: Elizabeth zette iDEAL met één klik over naar
+Shopify zelf, de procentpunten vervielen en de tussenoplossing kon
+weg. De winkel heeft geen dag zonder iDEAL gestaan.
 
 * De overstap zelf
 


### PR DESCRIPTION
Elizabeths mail van 13 aug: Shopify's beoordeling kwam drie dagen na de livegang, zij zette iDEAL zelf over naar Shopify en schakelde Mollie uit. De iDEAL-sectie van het klantverhaal staat nu in de verleden tijd en eindigt op "De winkel heeft geen dag zonder iDEAL gestaan", wat de tussenoplossing achteraf bewijst als wat hij beloofde te zijn: begrensd, met eigen exit.

Gebouwd en gerenderde pagina geverifieerd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)