### PR TITLE
Twee blogposts: Kassa App-delisting en de Acendy-prijzenfactcheck

### DIFF
--- a/webwinkel/content/mijnwebwinkel-kassa-app-verdwenen.org
+++ b/webwinkel/content/mijnwebwinkel-kassa-app-verdwenen.org
@@ -69,7 +69,7 @@ een kaartlezer van 59 euro. En
 omdat webshop en kassa op dezelfde voorraad draaien, is er geen
 synchronisatielaag die stuk kan.
 
-Eerlijk is eerlijk: ook aan een overstap zitten randvoorwaarden.
+Ook aan een overstap zitten randvoorwaarden.
 Geïntegreerd pinnen op Shopify vereist Shopify Payments, en wie
 zijn bestaande pinterminal van een andere aanbieder wil houden,
 moet bedragen handmatig overtikken, precies de foutbron die je

--- a/webwinkel/content/mijnwebwinkel-kassa-app-verdwenen.org
+++ b/webwinkel/content/mijnwebwinkel-kassa-app-verdwenen.org
@@ -18,8 +18,9 @@ webshop. Ergens tussen half januari 2026 en juli 2026 is de app uit
 de App Store gehaald: de productpagina geeft "niet gevonden", een
 zoekopdracht in de Nederlandse en Belgische App Store levert niets
 op, en de ontwikkelaar heeft er geen apps meer staan. De laatste
-versie stamt uit februari 2025. Wij controleerden dit op 18 juli en
-opnieuw op 31 juli 2026.
+versie stamt uit februari 2025. Wij controleerden dit op 18 juli,
+op 31 juli en opnieuw op 17 augustus 2026: nog steeds nergens te
+vinden, ook niet in de Belgische of Amerikaanse App Store.
 
 Belangrijk om te weten: een app die uit de App Store is gehaald
 blijft gewoon werken op de iPad waar hij al op staat. Er valt dus

--- a/webwinkel/content/mijnwebwinkel-kassa-app-verdwenen.org
+++ b/webwinkel/content/mijnwebwinkel-kassa-app-verdwenen.org
@@ -36,13 +36,27 @@ aangekondigde opvolger voor Nederland, en Mijnwebwinkel heeft geen
 termijn genoemd waarop de app terugkomt.
 
 Daar komt bij dat de app ook vóór de verdwijning al een moeizame
-geschiedenis had. In het eigen gebruikersforum van Mijnwebwinkel
-zijn onder meer gedocumenteerd: bestellingen die dubbel op de bon
-aanslaan, een btw-splitsing die uit het dagrapport verdween, en
-jarenlang geen mogelijkheid om deels contant en deels met pin af te
-rekenen. De App Store-beoordeling stond op 3,1 van 5, en een
-moderator van Mijnwebwinkel schreef zelf: "De Kassa App is dan ook
-nooit af."
+geschiedenis had. In het eigen gebruikersforum van Mijnwebwinkel en
+in App Store-reviews zijn onder meer gedocumenteerd:
+
+- Bestellingen die dubbel (of driedubbel) op de bon aanslaan, met
+  klanten die ermee terug de winkel in komen.
+- Jarenlang geen mogelijkheid om deels contant en deels met pin af
+  te rekenen; wie alles maar als pin boekte, kreeg een dagstaat die
+  niet klopte.
+- Een update die de 9%/21%-btw-splitsing stilletjes uit het
+  dagrapport haalde, terwijl producten met 0% btw in het financieel
+  rapport ontbraken.
+- Terugbetalen kon alleen contant, niet terug naar de pinpas.
+- Geen echte kasopmaak: geen beginsaldo, geen kastelling, geen
+  verschillenregistratie, dus elke afwijking eindigt bij de
+  boekhouder.
+- Kleinere ergernissen als een scanner die zijn
+  Bluetooth-verbinding verliest, geen verkoop op gewicht (decimale
+  aantallen) en geen aparte medewerker-accounts.
+
+De App Store-beoordeling stond op 3,1 van 5, en een moderator van
+Mijnwebwinkel schreef zelf: "De Kassa App is dan ook nooit af."
 
 * Wat je nu kunt doen
 
@@ -50,11 +64,19 @@ Ten eerste: reset of vervang je iPad niet zomaar. Zolang de app op
 je huidige apparaat staat, blijft je kassa werken. Behandel die
 iPad als wat hij nu is: het enige exemplaar van je kassa.
 
-Ten tweede: reken na wat je betaalt. Een winkel met kassa betaalt
-bij Mijnwebwinkel het Pro- of Premium-abonnement (40 tot 70 euro
-per maand) plus 39 euro per maand voor de kassa-add-on, samen 79
-tot 109 euro per maand, voor een app die niet meer onderhouden
-lijkt te worden en niet opnieuw te installeren is.
+Ten tweede: reken na wat je betaalt. Voor een winkel met kassa
+betaal je bij Mijnwebwinkel twee dingen: het Pro- of
+Premium-abonnement van 40 tot 70 euro per maand, en daarbovenop de
+kassa-add-on van 39 euro per maand. Samen is dat 79 tot 109 euro
+per maand voor een app die niet meer onderhouden lijkt te worden en
+niet opnieuw te installeren is.
+
+Wil je bij Mijnwebwinkel blijven, dan is er wel een tussenweg: een
+losstaande kassa naast je webshop, zoals een Zettle- of
+SumUp-reader zonder abonnement. Dat werkt en is goedkoop, maar je
+verliest er precies het voordeel mee waarvoor veel winkels de Kassa
+App aanhielden: de voorraadkoppeling met je webshop. Elke verkoop
+aan de balie moet je dan zelf in de webshopvoorraad bijwerken.
 
 Ten derde: kijk wat een overstap je zou opleveren. Wie toch al
 overweegt om met de webshop van Mijnwebwinkel weg te gaan, lost met
@@ -69,6 +91,14 @@ Shopify-abonnement; een winkel plus webshop draait daarmee vanaf
 een kaartlezer van 59 euro. En
 omdat webshop en kassa op dezelfde voorraad draaien, is er geen
 synchronisatielaag die stuk kan.
+
+Kies je voor WooCommerce, dan heeft het platform zelf geen kassa,
+maar is er een volwassen Nederlands aanbod omheen: kassasystemen
+als MplusKASSA en SW-Retail hebben officiële
+WooCommerce-koppelingen met voorraadsynchronisatie, en er zijn
+POS-oplossingen zoals ForgePOS die in de browser draaien. Welke
+pin-terminals en bonprinters daarmee samenwerken verschilt per
+koppeling, dus dat zoeken we per winkel uit.
 
 Ook aan een overstap zitten randvoorwaarden.
 Geïntegreerd pinnen op Shopify vereist Shopify Payments, en wie

--- a/webwinkel/content/mijnwebwinkel-kassa-app-verdwenen.org
+++ b/webwinkel/content/mijnwebwinkel-kassa-app-verdwenen.org
@@ -67,16 +67,13 @@ iPad als wat hij nu is: het enige exemplaar van je kassa.
 Ten tweede: reken na wat je betaalt. Voor een winkel met kassa
 betaal je bij Mijnwebwinkel twee dingen: het Pro- of
 Premium-abonnement van 40 tot 70 euro per maand, en daarbovenop de
-kassa-add-on van 39 euro per maand. Samen is dat 79 tot 109 euro
-per maand voor een app die niet meer onderhouden lijkt te worden en
-niet opnieuw te installeren is.
-
-Wil je bij Mijnwebwinkel blijven, dan is er wel een tussenweg: een
-losstaande kassa naast je webshop, zoals een Zettle- of
-SumUp-reader zonder abonnement. Dat werkt en is goedkoop, maar je
-verliest er precies het voordeel mee waarvoor veel winkels de Kassa
-App aanhielden: de voorraadkoppeling met je webshop. Elke verkoop
-aan de balie moet je dan zelf in de webshopvoorraad bijwerken.
+kassa-add-on van 39 euro per maand; samen 79 tot 109 euro per
+maand voor een app die niet meer onderhouden lijkt te worden en
+niet opnieuw te installeren is. Wil je bij Mijnwebwinkel blijven,
+dan is de tussenweg een losstaande kassa zoals een Zettle- of
+SumUp-reader zonder abonnement; goedkoop, maar dan verlies je de
+voorraadkoppeling met je webshop en werk je elke baliverkoop zelf
+in de webshopvoorraad bij.
 
 Ten derde: kijk wat een overstap je zou opleveren. Wie toch al
 overweegt om met de webshop van Mijnwebwinkel weg te gaan, lost met
@@ -90,15 +87,13 @@ Shopify-abonnement; een winkel plus webshop draait daarmee vanaf
 21 euro per maand (Shopify Basic bij jaarbetaling), plus eenmalig
 een kaartlezer van 59 euro. En
 omdat webshop en kassa op dezelfde voorraad draaien, is er geen
-synchronisatielaag die stuk kan.
-
-Kies je voor WooCommerce, dan heeft het platform zelf geen kassa,
-maar is er een volwassen Nederlands aanbod omheen: kassasystemen
-als MplusKASSA en SW-Retail hebben officiële
-WooCommerce-koppelingen met voorraadsynchronisatie, en er zijn
-POS-oplossingen zoals ForgePOS die in de browser draaien. Welke
-pin-terminals en bonprinters daarmee samenwerken verschilt per
-koppeling, dus dat zoeken we per winkel uit.
+synchronisatielaag die stuk kan. Kies je liever WooCommerce, dan
+heeft het platform zelf geen kassa, maar zijn er Nederlandse
+kassasystemen met officiële WooCommerce-koppelingen en
+voorraadsynchronisatie (MplusKASSA, SW-Retail) en browser-POS'en
+zoals ForgePOS; welke pin-terminals en bonprinters daarmee
+samenwerken verschilt per koppeling, dus dat zoeken we per winkel
+uit.
 
 Ook aan een overstap zitten randvoorwaarden.
 Geïntegreerd pinnen op Shopify vereist Shopify Payments, en wie

--- a/webwinkel/content/mijnwebwinkel-kassa-app-verdwenen.org
+++ b/webwinkel/content/mijnwebwinkel-kassa-app-verdwenen.org
@@ -1,0 +1,129 @@
+#+TITLE: De Mijnwebwinkel Kassa App is uit de App Store: wat nu?
+#+DATE: 2026-08-17
+#+CATEGORY: migratie
+#+TAGS: mijnwebwinkel, kassa, pos, shopify
+
+Draait je fysieke winkel op de Mijnwebwinkel Kassa App? Dan is dit
+goed om te weten: de app is begin 2026 stilletjes uit de App Store
+verdwenen, terwijl Mijnwebwinkel de kassa-add-on gewoon blijft
+verkopen voor 39 euro per maand (nagekeken op hun prijzenpagina,
+17 augustus 2026). In dit artikel zetten we op een rij wat er aan de
+hand is, wat het voor je winkel betekent, en welke opties je hebt.
+
+* Wat er is gebeurd
+
+De Mijnwebwinkel Kassa is een iPad- en iPhone-app uit 2017 waarmee
+je in je fysieke winkel afrekent op dezelfde voorraad als je
+webshop. Ergens tussen half januari 2026 en juli 2026 is de app uit
+de App Store gehaald: de productpagina geeft "niet gevonden", een
+zoekopdracht in de Nederlandse en Belgische App Store levert niets
+op, en de ontwikkelaar heeft er geen apps meer staan. De laatste
+versie stamt uit februari 2025. Wij controleerden dit op 18 juli en
+opnieuw op 31 juli 2026.
+
+Belangrijk om te weten: een app die uit de App Store is gehaald
+blijft gewoon werken op de iPad waar hij al op staat. Er valt dus
+niet morgen iets uit.
+
+* Waarom dit toch een probleem is
+
+Het probleem zit in wat er daarna gebeurt. Een app die niet meer in
+de App Store staat, kan niet opnieuw geïnstalleerd worden. Gaat je
+iPad stuk, wordt hij gestolen, of moet hij een keer gereset worden,
+dan sta je van de ene op de andere dag zonder kassa. Er is geen
+aangekondigde opvolger voor Nederland, en Mijnwebwinkel heeft geen
+termijn genoemd waarop de app terugkomt.
+
+Daar komt bij dat de app ook vóór de verdwijning al een moeizame
+geschiedenis had. In het eigen gebruikersforum van Mijnwebwinkel
+zijn onder meer gedocumenteerd: bestellingen die dubbel op de bon
+aanslaan, een btw-splitsing die uit het dagrapport verdween, en
+jarenlang geen mogelijkheid om deels contant en deels met pin af te
+rekenen. De App Store-beoordeling stond op 3,1 van 5, en een
+moderator van Mijnwebwinkel schreef zelf: "De Kassa App is dan ook
+nooit af."
+
+* Wat je nu kunt doen
+
+Ten eerste: reset of vervang je iPad niet zomaar. Zolang de app op
+je huidige apparaat staat, blijft je kassa werken. Behandel die
+iPad als wat hij nu is: het enige exemplaar van je kassa.
+
+Ten tweede: reken na wat je betaalt. Een winkel met kassa betaalt
+bij Mijnwebwinkel het Pro- of Premium-abonnement (40 tot 70 euro
+per maand) plus 39 euro per maand voor de kassa-add-on, samen 79
+tot 109 euro per maand, voor een app die niet meer onderhouden
+lijkt te worden en niet opnieuw te installeren is.
+
+Ten derde: kijk wat een overstap je zou opleveren. Wie toch al
+overweegt om met de webshop van Mijnwebwinkel weg te gaan, lost met
+één beweging ook het kassa-probleem op. Shopify heeft bijvoorbeeld
+een eigen kassasysteem (Shopify POS) dat in Nederland volwassen is:
+geïntegreerd pinnen met de Nederlandse pinpas, splitbetaling
+(deels contant, deels pin) als standaardfunctie, retour naar de
+pinpas, en een kasopmaak per sessie met telling en
+verschillenregistratie. De instapversie zit gratis bij elk
+Shopify-abonnement; een winkel plus webshop draait daarmee vanaf
+21 euro per maand (Shopify Basic bij jaarbetaling), plus eenmalig
+een kaartlezer van 59 euro. En
+omdat webshop en kassa op dezelfde voorraad draaien, is er geen
+synchronisatielaag die stuk kan.
+
+Eerlijk is eerlijk: ook aan een overstap zitten randvoorwaarden.
+Geïntegreerd pinnen op Shopify vereist Shopify Payments, en wie
+zijn bestaande pinterminal van een andere aanbieder wil houden,
+moet bedragen handmatig overtikken, precies de foutbron die je
+kwijt wilt. Laat je dus goed voorlichten over wat er met jouw
+huidige pin-oplossing, bonprinter en scanner kan.
+
+* Overstappen zonder gedoe
+
+Wij verhuizen webshops van Mijnwebwinkel naar Shopify of
+WooCommerce: producten, klanten, categorieën en de volledige
+inhoud, met automatische 301-redirects zodat je Google-posities
+meeverhuizen. Voor winkels met een kassa nemen we de inrichting van
+Shopify POS mee in het advies, inclusief welke hardware je nodig
+hebt en wat herbruikbaar is. Vaste prijs, betaling na een geslaagde
+migratie. Lees hoe
+[[https://webwinkelverhuis.nl/migrate-mijnwebwinkel.html][onze
+migratieservice]] werkt, of
+[[https://meet.jappiesoftware.com][plan een vrijblijvend gesprek]].
+
+* Veelgestelde vragen
+
+*Stopt mijn Mijnwebwinkel Kassa App er nu mee?*
+
+Nee. Een app die uit de App Store is gehaald blijft werken op het
+apparaat waar hij al op staat. Het risico zit bij een kapotte,
+gestolen of gereset iPad: dan kan de app niet opnieuw
+geïnstalleerd worden en sta je zonder kassa.
+
+*Kan ik de Kassa App nog op een nieuwe iPad zetten?*
+
+Nee. De app staat sinds begin 2026 niet meer in de Nederlandse en
+Belgische App Store, dus een verse installatie is niet mogelijk.
+Mijnwebwinkel verkoopt de kassa-add-on van 39 euro per maand
+intussen wel gewoon door.
+
+*Wat is het beste alternatief voor de Mijnwebwinkel Kassa App?*
+
+Voor de meeste winkels met een webshop: het kassasysteem van het
+platform waar je naartoe verhuist, zoals Shopify POS. Dat rekent af
+op dezelfde voorraad als je webshop, ondersteunt splitbetaling en
+kasopmaak, en de instapversie zit gratis bij elk
+Shopify-abonnement. Een losse externe kassa naast je webshop
+betekent twee systemen en een synchronisatielaag die stuk kan.
+
+*Kan mijn bestaande pin-apparatuur mee?*
+
+Dat hangt af van wat je nu gebruikt. Geïntegreerd pinnen op Shopify
+loopt via Shopify Payments met eigen kaartlezers (vanaf 59 euro
+eenmalig); bonprinters en scanners zijn per merk en model
+verschillend herbruikbaar. Dit checken we per winkel in het
+migratie-advies.
+
+#+BEGIN_EXPORT html
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Stopt mijn Mijnwebwinkel Kassa App er nu mee?","acceptedAnswer":{"@type":"Answer","text":"Nee. Een app die uit de App Store is gehaald blijft werken op het apparaat waar hij al op staat. Het risico zit bij een kapotte, gestolen of gereset iPad: dan kan de app niet opnieuw geïnstalleerd worden en sta je zonder kassa."}},{"@type":"Question","name":"Kan ik de Kassa App nog op een nieuwe iPad zetten?","acceptedAnswer":{"@type":"Answer","text":"Nee. De app staat sinds begin 2026 niet meer in de Nederlandse en Belgische App Store, dus een verse installatie is niet mogelijk. Mijnwebwinkel verkoopt de kassa-add-on van 39 euro per maand intussen wel gewoon door."}},{"@type":"Question","name":"Wat is het beste alternatief voor de Mijnwebwinkel Kassa App?","acceptedAnswer":{"@type":"Answer","text":"Voor de meeste winkels met een webshop: het kassasysteem van het platform waar je naartoe verhuist, zoals Shopify POS. Dat rekent af op dezelfde voorraad als je webshop, ondersteunt splitbetaling en kasopmaak, en de instapversie zit gratis bij elk Shopify-abonnement."}},{"@type":"Question","name":"Kan mijn bestaande pin-apparatuur mee?","acceptedAnswer":{"@type":"Answer","text":"Dat hangt af van wat je nu gebruikt. Geïntegreerd pinnen op Shopify loopt via Shopify Payments met eigen kaartlezers; bonprinters en scanners zijn per merk en model verschillend herbruikbaar. Dit checken we per winkel in het migratie-advies."}}]}
+</script>
+#+END_EXPORT

--- a/webwinkel/content/wordt-mijnwebwinkel-duurder.org
+++ b/webwinkel/content/wordt-mijnwebwinkel-duurder.org
@@ -1,0 +1,124 @@
+#+TITLE: Wordt MijnWebwinkel fors duurder door Acendy? De feiten, augustus 2026
+#+DATE: 2026-08-17
+#+CATEGORY: migratie
+#+TAGS: mijnwebwinkel, acendy, prijzen
+
+Er circuleren stevige verhalen: MijnWebwinkel zou opgaan in Acendy
+en "fors duurder" worden, met genoemde bedragen tot 150 euro per
+maand. Wij verhuizen webshops wég van MijnWebwinkel, dus je zou
+verwachten dat we die verhalen graag doorvertellen. Toch zetten we
+liever op een rij wat er op dit moment feitelijk te controleren
+valt, want een overstap plan je beter op feiten dan op geruchten.
+
+* Wat er vandaag te controleren valt
+
+We hebben het op 17 augustus 2026 nagekeken bij de bron:
+
+1. Op de eigen prijzenpagina van mijnwebwinkel.nl staan de
+   abonnementen op 20, 40 en 70 euro per maand exclusief btw (bij
+   een jaarabonnement), met het spaarprogramma als extra van 19
+   euro per maand en de kassa-add-on van 39 euro per maand. Dat
+   zijn dezelfde bedragen als eerder dit jaar; van een doorgevoerde
+   verhoging naar 150 euro is op de Nederlandse site niets te zien.
+2. De aankondiging van de Acendy-samenvoeging is van het
+   Mijnwebwinkel-blog gehaald; de pagina geeft nu "geen
+   toegangsrechten". De naamswijziging van eind 2025 werd begin
+   2026 teruggedraaid en mijnwebwinkel.nl werft gewoon nieuwe
+   klanten onder de eigen naam.
+3. Wat wél vaststaat: het platform is sinds de overname door Visma
+   in 2021 meerdere keren van eigenaar en naam gewisseld
+   (MijnWebwinkel, kort Acendy, inmiddels ondergebracht in de
+   Norvato-portefeuille), en de ontwikkeling staat feitelijk stil.
+   De hele geschiedenis met bronnen staat in ons artikel over
+   [[https://webwinkelverhuis.nl/blog/alternatief-voor-acendy-zo-zit-het-met-mijnwebwinkel-mystore-en-norvato.html][de
+   Acendy-kwestie]].
+
+Kortom: de bewering "het is nu fors duurder geworden" klopt vandaag
+niet met wat het bedrijf zelf publiceert. De genoemde hoge bedragen
+komen uit de prijsstelling van het Noorse Mystore/Acendy-aanbod,
+niet uit de Nederlandse tarieven.
+
+* Waarom de zorg toch terecht is
+
+Dat de verhoging er vandaag niet is, betekent niet dat de zorg
+onzin is. Drie dingen zijn wél feitelijk:
+
+1. De prijzen zijn de afgelopen jaren al gestegen terwijl het
+   product stilstond: het goedkoopste plan van 20 euro is beperkt
+   tot 25 producten, een serieuze shop zit op 40 tot 70 euro per
+   maand, en functies als het spaarprogramma en de kassa kosten
+   extra.
+2. De onderhoudsstaat is zichtbaar: de
+   [[https://webwinkelverhuis.nl/blog/de-mijnwebwinkel-kassa-app-is-uit-de-app-store-wat-nu.html][Kassa
+   App is uit de App Store verdwenen]] terwijl de add-on gewoon
+   wordt doorverkocht, en het aantal shops op het platform daalde
+   volgens StoreLeads sinds 2022 met zo'n 35 procent.
+3. Een eigenaar die het platform in een verkoop-portefeuille heeft
+   zitten, beslist over jouw tarieven en jouw toekomst. Bij de
+   volgende strategiewijziging verhuis je op andermans tijdlijn in
+   plaats van op de jouwe.
+
+Het echte risico is dus niet de prijs van vandaag, maar de richting
+van het platform. Wie nu rustig een exit voorbereidt, hoeft nooit
+in paniek te vertrekken.
+
+* Wat wij zouden doen
+
+Geen paniek, wel een plan. Concreet:
+
+1. Zet op een rij wat je shop gebruikt: producten, klantaccounts,
+   spaarprogramma, kassa, e-mailadres op je domein. Dat bepaalt wat
+   er bij een overstap mee moet.
+2. Let op je contractdatum. MijnWebwinkel werkt met
+   jaarabonnementen; bij beëindiging stoppen ook de domeinhosting
+   en de mailbox op de einddatum. Wie te laat begint, verliest
+   e-mailgeschiedenis en moet onder tijdsdruk verhuizen.
+3. Lees ons
+   [[https://webwinkelverhuis.nl/blog/webshop-migreren-stappenplan-kosten-en-valkuilen.html][stappenplan
+   voor een webshop-migratie]], ook als je (nog) niet met ons in
+   zee gaat: de valkuilen zijn voor iedereen dezelfde.
+
+Wil je het uitbesteden: wij verhuizen je shop naar Shopify of
+WooCommerce voor een vaste prijs, met automatische 301-redirects
+voor je Google-posities en betaling na een geslaagde migratie.
+[[https://meet.jappiesoftware.com][Plan een vrijblijvend gesprek]],
+dan kijken we samen naar je shop; ook als de uitkomst "blijf
+voorlopig zitten" is.
+
+* Veelgestelde vragen
+
+*Is MijnWebwinkel al duurder geworden door Acendy?*
+
+Nee. Op 17 augustus 2026 staan de Nederlandse tarieven op 20, 40 en
+70 euro per maand exclusief btw, dezelfde bedragen als eerder dit
+jaar. De hogere bedragen die circuleren horen bij het Noorse
+Mystore/Acendy-aanbod, niet bij de Nederlandse prijzen.
+
+*Bestaat Acendy nog?*
+
+De naamswijziging van MijnWebwinkel naar Acendy (eind 2025) is
+begin 2026 teruggedraaid; de aankondiging is van het blog gehaald
+en mijnwebwinkel.nl werft weer onder de eigen naam. Het platform is
+inmiddels ondergebracht in de Norvato-portefeuille van
+investeerder Hg.
+
+*Moet ik nu overstappen?*
+
+Niet per se nu, wel voorbereid. Je shop draait gewoon door, maar de
+ontwikkeling staat stil en het platform wisselt regelmatig van
+eigenaar. Wie zijn contractdatum kent en een exit-plan klaar heeft,
+kan op eigen voorwaarden vertrekken in plaats van op die van de
+eigenaar.
+
+*Wat gebeurt er met mijn e-mailadres als ik wegga?*
+
+Een mailbox op je domein bij MijnWebwinkel stopt op de einddatum
+van je abonnement, samen met de domeinhosting. Regel vóór die
+datum een nieuwe mailbox en zet je e-mailgeschiedenis over; daarna
+is die onherroepelijk weg.
+
+#+BEGIN_EXPORT html
+<script type="application/ld+json">
+{"@context":"https://schema.org","@type":"FAQPage","mainEntity":[{"@type":"Question","name":"Is MijnWebwinkel al duurder geworden door Acendy?","acceptedAnswer":{"@type":"Answer","text":"Nee. Op 17 augustus 2026 staan de Nederlandse tarieven op 20, 40 en 70 euro per maand exclusief btw, dezelfde bedragen als eerder dit jaar. De hogere bedragen die circuleren horen bij het Noorse Mystore/Acendy-aanbod, niet bij de Nederlandse prijzen."}},{"@type":"Question","name":"Bestaat Acendy nog?","acceptedAnswer":{"@type":"Answer","text":"De naamswijziging van MijnWebwinkel naar Acendy (eind 2025) is begin 2026 teruggedraaid; de aankondiging is van het blog gehaald en mijnwebwinkel.nl werft weer onder de eigen naam. Het platform is inmiddels ondergebracht in de Norvato-portefeuille van investeerder Hg."}},{"@type":"Question","name":"Moet ik nu overstappen?","acceptedAnswer":{"@type":"Answer","text":"Niet per se nu, wel voorbereid. Je shop draait gewoon door, maar de ontwikkeling staat stil en het platform wisselt regelmatig van eigenaar. Wie zijn contractdatum kent en een exit-plan klaar heeft, kan op eigen voorwaarden vertrekken."}},{"@type":"Question","name":"Wat gebeurt er met mijn e-mailadres als ik wegga?","acceptedAnswer":{"@type":"Answer","text":"Een mailbox op je domein bij MijnWebwinkel stopt op de einddatum van je abonnement, samen met de domeinhosting. Regel vóór die datum een nieuwe mailbox en zet je e-mailgeschiedenis over; daarna is die onherroepelijk weg."}}]}
+</script>
+#+END_EXPORT


### PR DESCRIPTION
Contentplan #11 plus de verse factcheck-post, allebei in huisstijl (FAQ + JSON-LD, je-vorm, bronnen inline, cross-links naar bestaande posts en de migrate-pagina's).

De kassa-post is geankerd op het onderzoeksdoc in jappiesoft (research/mww-kassa-vs-shopify-pos.org): delisting geverifieerd op 18 en 31 jul, de add-on wordt op de MWW-prijzenpagina nog steeds voor €39 p.m. verkocht (nagekeken 17 aug), plus de forum-gedocumenteerde bugs-historie, het niet-resetten-advies en het Shopify POS-alternatief (Basic €21 p.m. bij jaarbetaling, conform de bestaande vergelijkingspost).

De factcheck-post pakt de "fors duurder door Acendy"-verhalen van concurrenten (tot €150 p.m.) en zet er de primaire bronnen naast: MWW's eigen prijzenpagina toont op 17 aug €20/€40/€70 excl. btw, de Acendy-aankondiging staat achter een 403, en mijnwebwinkel.nl werft onder eigen naam. Daarna eerlijk waarom de zorg toch terecht is en een rustig exit-plan als CTA. Slugs geverifieerd tegen Slug.hs; nix-build nix/ci.nix groen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)