### PR TITLE
Strip script and style blocks from article summaries

### DIFF
--- a/shake/ArticleSummary.hs
+++ b/shake/ArticleSummary.hs
@@ -1,0 +1,132 @@
+-- | Turns an article's rendered HTML into the short summary shown on the
+-- index, tag, and category pages and in the atom feed.
+module ArticleSummary (truncateHtml) where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+
+-- | Truncate rendered HTML to ~N words, closing any unclosed tags.
+-- Counts only visible text words, skips inside tags and entities.
+--
+-- @\<style\>@ and @\<script\>@ blocks are dropped entirely (tags and
+-- content). Summaries are embedded many-per-page: on the index a summary's
+-- inline script actually executed, and because both coin-flip posts mount
+-- into the same @#coin-flip-game@ id, the level-1 game hijacked the
+-- hidden-rewards slot. A summary is a teaser, not a running app.
+truncateHtml :: Int -> Text -> Text
+truncateHtml maxWords html =
+  let (result, openTags) = walkHtml maxWords 0 [] (T.unpack html)
+      closingTags = concatMap (\tagName -> "</" ++ tagName ++ ">") openTags
+  in T.pack result <> T.pack closingTags
+
+-- | Walk the HTML character by character, emitting output until the word
+-- limit is reached. Returns the emitted output and the stack of tags still
+-- open at the cut, newest first, so the caller can close them.
+walkHtml :: Int -> Int -> [String] -> String -> (String, [String])
+walkHtml maxWords wordCount openTags input =
+  if wordCount >= maxWords
+    then ([], openTags)
+    else case input of
+      [] ->
+        ([], openTags)
+      ('<' : '/' : rest) ->
+        walkClosingTag maxWords wordCount openTags rest
+      ('<' : rest) ->
+        walkOpeningTag maxWords wordCount openTags rest
+      ('&' : rest) ->
+        walkEntity maxWords wordCount openTags rest
+      (currentChar : rest) ->
+        if isHtmlWhitespace currentChar
+          then
+            let (remainder, finalTags) = walkHtml maxWords wordCount openTags rest
+            in (currentChar : remainder, finalTags)
+          else walkWord maxWords wordCount openTags currentChar rest
+
+-- | A closing tag: emit it and pop its name off the open-tag stack.
+-- The leading @"</"@ has already been consumed by 'walkHtml'.
+walkClosingTag :: Int -> Int -> [String] -> String -> (String, [String])
+walkClosingTag maxWords wordCount openTags input =
+  let (tagContent, after) = span (/= '>') input
+      tagName = takeWhile (\c -> c /= ' ' && c /= '>') tagContent
+      closeStr = "</" ++ tagContent ++ ">"
+      remainingTags = dropFirstTag tagName openTags
+      (remainder, finalTags) = walkHtml maxWords wordCount remainingTags (drop 1 after)
+  in (closeStr ++ remainder, finalTags)
+
+-- | An opening tag: push it on the stack unless it is void or
+-- self-closing, or drop the whole block when it is a style/script tag.
+-- The leading @"<"@ has already been consumed by 'walkHtml'.
+walkOpeningTag :: Int -> Int -> [String] -> String -> (String, [String])
+walkOpeningTag maxWords wordCount openTags input =
+  let (tagContent, after) = span (/= '>') input
+      tagName = takeWhile (\c -> c /= ' ' && c /= '>' && c /= '/') tagContent
+      isSelfClosing = not (null tagContent) && last tagContent == '/'
+      isVoid = tagName `elem` voidElements
+      tagStr = "<" ++ tagContent ++ ">"
+  in if tagName == "style" || tagName == "script"
+       then -- Drop the whole block: nothing emitted, nothing counted.
+         let (_droppedBody, afterClose) = skipUntilClose tagName (drop 1 after)
+         in walkHtml maxWords wordCount openTags afterClose
+       else
+         let newTags =
+               if isSelfClosing || isVoid || null tagName
+                 then openTags
+                 else tagName : openTags
+             (remainder, finalTags) = walkHtml maxWords wordCount newTags (drop 1 after)
+         in (tagStr ++ remainder, finalTags)
+
+-- | An HTML entity ("&amp;"): emit it without counting it as a word.
+-- The leading @"&"@ has already been consumed by 'walkHtml'.
+walkEntity :: Int -> Int -> [String] -> String -> (String, [String])
+walkEntity maxWords wordCount openTags input =
+  let (entity, after) = span (/= ';') input
+      entityStr = "&" ++ entity ++ ";"
+      (remainder, finalTags) = walkHtml maxWords wordCount openTags (drop 1 after)
+  in (entityStr ++ remainder, finalTags)
+
+-- | A visible word: emit it up to the next whitespace, tag, or entity,
+-- and count it toward the limit.
+walkWord :: Int -> Int -> [String] -> Char -> String -> (String, [String])
+walkWord maxWords wordCount openTags firstChar input =
+  let (word, after) = span (not . isWordBoundary) input
+      fullWord = firstChar : word
+      (remainder, finalTags) = walkHtml maxWords (wordCount + 1) openTags after
+  in (fullWord ++ remainder, finalTags)
+
+isHtmlWhitespace :: Char -> Bool
+isHtmlWhitespace c = c == ' ' || c == '\n' || c == '\t' || c == '\r'
+
+-- | Where a visible word stops: whitespace, a tag start, or an entity.
+isWordBoundary :: Char -> Bool
+isWordBoundary c = isHtmlWhitespace c || c == '<' || c == '&'
+
+-- | Pop the first occurrence of a tag name from the open-tag stack.
+dropFirstTag :: String -> [String] -> [String]
+dropFirstTag _ [] = []
+dropFirstTag name (tagName : rest) =
+  if name == tagName
+    then rest
+    else tagName : dropFirstTag name rest
+
+-- | Tags that never take a closing counterpart, per the HTML spec.
+voidElements :: [String]
+voidElements =
+  [ "br", "img", "hr", "input", "meta", "link", "area"
+  , "base", "col", "embed", "source", "track", "wbr"
+  ]
+
+-- | Consume everything up to and including the named closing tag,
+-- returning the consumed content (with closing tag) and the remainder.
+skipUntilClose :: String -> String -> (String, String)
+skipUntilClose _ [] = ([], [])
+skipUntilClose name ('<' : '/' : rest) =
+  let (tagContent, after) = span (/= '>') rest
+      closeName = takeWhile (\c -> c /= ' ' && c /= '>') tagContent
+  in if closeName == name
+       then ("</" ++ tagContent ++ ">", drop 1 after)
+       else
+         let (body, remaining) = skipUntilClose name (drop 1 after)
+         in ("</" ++ tagContent ++ ">" ++ body, remaining)
+skipUntilClose name (currentChar : rest) =
+  let (body, remaining) = skipUntilClose name rest
+  in (currentChar : body, remaining)

--- a/shake/Shakefile.hs
+++ b/shake/Shakefile.hs
@@ -38,6 +38,7 @@ import Text.Pandoc
 import Text.Pandoc.Highlighting (pygments)
 import WaiAppStatic.Types (ssIndices, unsafeToPiece, ssAddTrailingSlash)
 
+import ArticleSummary (truncateHtml)
 import AssetHash (GehashteAssets(..), gehashteAssetNaam, herschrijfAssetVerwijzingen)
 import Feed (generateAtomFeed)
 import Metadata (parseMarkdownMeta, parseOrgMeta, parseDateField, parseTags, isDraft)
@@ -421,87 +422,6 @@ splitFootnotes html =
     (before, after)
       | T.null after -> (html, Nothing)
       | otherwise    -> (before, Just after)
-
--- | Truncate rendered HTML to ~N words, closing any unclosed tags.
--- Counts only visible text words, skips inside tags and entities.
-truncateHtml :: Int -> Text -> Text
-truncateHtml maxWords html =
-  let (result, openTags) = go 0 [] (T.unpack html)
-      closingTags = concatMap (\t -> "</" ++ t ++ ">") openTags
-  in T.pack result <> T.pack closingTags
-  where
-    -- Track open tag stack, count words in text nodes
-    go :: Int -> [String] -> String -> (String, [String])
-    go _ tags [] = ([], tags)
-    go wc tags _ | wc >= maxWords = ([], tags)
-    go wc tags ('<':'/':rest) =
-      -- Closing tag: consume until '>', pop from stack
-      let (tagContent, after) = span (/= '>') rest
-          tagName = takeWhile (\c -> c /= ' ' && c /= '>') tagContent
-          closeStr = "</" ++ tagContent ++ ">"
-          tags' = dropFirst tagName tags
-          (remainder, finalTags) = go wc tags' (drop 1 after)
-      in (closeStr ++ remainder, finalTags)
-    go wc tags ('<':rest) =
-      -- Opening tag: consume until '>', push to stack if not void/self-closing
-      let (tagContent, after) = span (/= '>') rest
-          tagName = takeWhile (\c -> c /= ' ' && c /= '>' && c /= '/') tagContent
-          isSelfClosing = not (null tagContent) && last tagContent == '/'
-          isVoid = tagName `elem` voidElements
-          tagStr = "<" ++ tagContent ++ ">"
-      in if tagName == "style"
-         then -- Skip style block content without counting words
-           let (styleBody, afterClose) = skipUntilClose "style" (drop 1 after)
-               (remainder, finalTags) = go wc tags afterClose
-           in (tagStr ++ styleBody ++ remainder, finalTags)
-         else
-           let tags' = if isSelfClosing || isVoid || null tagName
-                       then tags
-                       else tagName : tags
-               (remainder, finalTags) = go wc tags' (drop 1 after)
-           in (tagStr ++ remainder, finalTags)
-    go wc tags ('&':rest) =
-      -- HTML entity: pass through without counting as word
-      let (entity, after) = span (/= ';') rest
-          entityStr = "&" ++ entity ++ ";"
-          (remainder, finalTags) = go wc tags (drop 1 after)
-      in (entityStr ++ remainder, finalTags)
-    go wc tags (c:rest)
-      | c == ' ' || c == '\n' || c == '\t' || c == '\r' =
-          let (remainder, finalTags) = go wc tags rest
-          in (c : remainder, finalTags)
-      | otherwise =
-          -- Start of a word: consume until whitespace or tag
-          let (word, after) = span (\ch -> ch /= ' ' && ch /= '\n' && ch /= '\t' && ch /= '\r' && ch /= '<' && ch /= '&') rest
-              fullWord = c : word
-              wc' = wc + 1
-              (remainder, finalTags) = go wc' tags after
-          in (fullWord ++ remainder, finalTags)
-
-    dropFirst :: String -> [String] -> [String]
-    dropFirst _ [] = []
-    dropFirst x (y:ys)
-      | x == y    = ys
-      | otherwise = y : dropFirst x ys
-
-    voidElements :: [String]
-    voidElements = ["br", "img", "hr", "input", "meta", "link", "area",
-                    "base", "col", "embed", "source", "track", "wbr"]
-
-    -- | Consume everything up to and including a closing tag, returning
-    --   the consumed content (with closing tag) and the remainder.
-    skipUntilClose :: String -> String -> (String, String)
-    skipUntilClose _ [] = ([], [])
-    skipUntilClose name ('<':'/':rest) =
-      let (tagContent, after) = span (/= '>') rest
-          closeName = takeWhile (\c -> c /= ' ' && c /= '>') tagContent
-      in if closeName == name
-         then ("</" ++ tagContent ++ ">", drop 1 after)
-         else let (body, remaining) = skipUntilClose name (drop 1 after)
-              in ("</" ++ tagContent ++ ">" ++ body, remaining)
-    skipUntilClose name (c:rest) =
-      let (body, remaining) = skipUntilClose name rest
-      in (c : body, remaining)
 
 -- =============================================================================
 -- Tag and category maps

--- a/shake/shake.cabal
+++ b/shake/shake.cabal
@@ -9,6 +9,7 @@ build-type:         Simple
 executable shake-blog
   main-is:          Shakefile.hs
   other-modules:
+    ArticleSummary
     AssetHash
     Feed
     Metadata
@@ -45,6 +46,7 @@ test-suite unit
   type:             exitcode-stdio-1.0
   main-is:          Test.hs
   other-modules:
+    ArticleSummary
     AssetHash
     PageChrome
     PenguinTemplates

--- a/shake/test/Test.hs
+++ b/shake/test/Test.hs
@@ -27,6 +27,7 @@ import Text.Blaze.Html5 ((!))
 import qualified Text.Blaze.Html5 as H
 import qualified Text.Blaze.Html5.Attributes as A
 
+import ArticleSummary (truncateHtml)
 import AssetHash (GehashteAssets(..), gehashteAssetNaam, herschrijfAssetVerwijzingen)
 import Data.Char (isHexDigit)
 import qualified Data.ByteString.Char8 as BSC
@@ -193,7 +194,45 @@ main = defaultMain $
         [ taxonomieKrijgtNoindexIndexNiet
         , vierNulVierNoindexEnBuitenSitemap
         ]
+    , testGroup "article summaries stay inert teasers"
+        [ summaryDropsScriptBlocks
+        , summaryDropsStyleBlocks
+        , summaryStillTruncatesAndCloses
+        ]
     ]
+
+-- | Summaries are embedded many-per-page on the index; an inline script that
+-- survives into a summary executes there. Both coin-flip posts mount into the
+-- same #coin-flip-game id, so the level-1 init hijacked the hidden-rewards
+-- summary slot on jappie.me. Scripts must be dropped wholesale.
+summaryDropsScriptBlocks :: TestTree
+summaryDropsScriptBlocks = testCase "script blocks are dropped wholesale" $ do
+  let summary = truncateHtml 50
+        "<p>intro words</p><script src=\"/coin-flip-level2.js\"></script>\
+        \<script>Elm.CoinFlipLevel2.init({ node: document.getElementById('coin-flip-game') });</script>\
+        \<p>closing words</p>"
+  assertBool "keeps the surrounding prose" ("intro words" `T.isInfixOf` summary)
+  assertBool "keeps prose after the scripts" ("closing words" `T.isInfixOf` summary)
+  assertBool "drops the script tags and their content" (not ("script" `T.isInfixOf` summary))
+  assertBool "drops the init call" (not ("CoinFlipLevel2" `T.isInfixOf` summary))
+
+-- | Style blocks used to be copied into the summary verbatim; they belong to
+-- the article page, not to the index.
+summaryDropsStyleBlocks :: TestTree
+summaryDropsStyleBlocks = testCase "style blocks are dropped wholesale" $ do
+  let summary = truncateHtml 50
+        "<p>words</p><style>#coin-flip-game { border: 1px solid red; }</style><p>more</p>"
+  assertBool "keeps the prose" ("words" `T.isInfixOf` summary)
+  assertBool "drops the style tag and its rules" (not ("style" `T.isInfixOf` summary))
+  assertBool "drops the css selector" (not ("coin-flip-game" `T.isInfixOf` summary))
+
+-- | The original truncation contract is unchanged: cut at the word limit and
+-- close whatever tags are still open.
+summaryStillTruncatesAndCloses :: TestTree
+summaryStillTruncatesAndCloses = testCase "truncates at the word limit and closes open tags" $ do
+  let summary = truncateHtml 3 "<p>one two three four five</p>"
+  assertBool "stops after three words" (not ("four" `T.isInfixOf` summary))
+  assertBool "closes the dangling paragraph" ("</p>" `T.isInfixOf` summary)
 
 -- | De 404-pagina draagt noindex (een foutpagina hoort niet in de index) en
 -- ontbreekt in de sitemap. Dit faalt wanneer iemand de pagina per ongeluk


### PR DESCRIPTION
## Bug

On the jappie.me index, the hidden-rewards entry showed the level-1 game. Article summaries carried the posts' inline `<script>` blocks verbatim, so both game inits ran on the index page; both posts mount into the same `#coin-flip-game` id, and the level-1 init (running last in document order) replaced the level-2 game inside the hidden-rewards summary slot. `<style>` blocks were also copied into summaries.

## Fix

`truncateHtml` moves from the Shakefile into a new `ArticleSummary` module (so the unit suite can reach it, restructured to top-level helpers per house style) and now drops `<style>` and `<script>` blocks wholesale from summaries: a summary is a teaser, not a running app. The empty mount div that remains is unstyled and renders as nothing.

## Verification

- New unit tests assert script and style blocks are dropped and the truncate-and-close contract is unchanged; both dropping tests verified to FAIL against the old semantics before the fix.
- `nix-build nix/ci.nix` passes; in the built output `jappieklooster.nl/index.html` contains zero game scripts/styles while `hidden-rewards.html` still mounts its own game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
