### PR TITLE
Level 3: black-swan multi-coin game with two distractor coins

### DIFF
--- a/content/black-swan.md
+++ b/content/black-swan.md
@@ -59,6 +59,7 @@ TODO
   #coin-flip-game .coin-bet label { font-weight: bold; }
   #coin-flip-game .flip-button { width: 100%; padding: 0.6em; font-weight: bold; }
   #coin-flip-game .tally { font-weight: bold; }
+  #coin-flip-game .glasses { font-weight: bold; }
   #coin-flip-game .shop {
     border-top: 1px dashed #196019;
     padding-top: 0.6em;

--- a/content/black-swan.md
+++ b/content/black-swan.md
@@ -1,0 +1,109 @@
+Title: Black swan
+Date: 2026-08-20 22:30
+Category: reflection
+OPTIONS: toc:nil
+Tags: gambling, finance, game
+
+TODO
+
+<div id="coin-flip-game"></div>
+
+<style>
+  #coin-flip-game {
+    border: 2px solid #196019;
+    border-radius: 6px;
+    overflow: hidden;
+    max-width: 26em;
+    margin: 1.5em auto;
+    padding: 0 1em 1em;
+    font-family: "Inconsolata", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", monospace;
+    background: rgba(255, 255, 255, 0.85);
+  }
+  #coin-flip-game h3 {
+    background: #196019;
+    color: white;
+    margin: 0 -1em 1em;
+    padding: 0.4em 1em;
+    font-size: 1.1em;
+  }
+  #coin-flip-game .stats { display: flex; justify-content: space-between; font-weight: bold; }
+  #coin-flip-game .progress-track {
+    background: #d3d7cf;
+    height: 12px;
+    margin: 0.5em 0;
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  #coin-flip-game .progress-fill { background: #30bb30; height: 100%; transition: width 0.3s; }
+  #coin-flip-game .balance { font-size: 2.2em; font-weight: bold; text-align: center; margin: 0.3em 0; }
+  #coin-flip-game .controls { text-align: center; }
+  #coin-flip-game .controls > div { margin: 0.6em 0; }
+  #coin-flip-game button {
+    touch-action: manipulation;
+    font-family: inherit;
+    background: #196019;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    padding: 0.25em 0.7em;
+    cursor: pointer;
+  }
+  #coin-flip-game button:hover { background: #259025; }
+  #coin-flip-game button:active { transform: scale(0.97); }
+  #coin-flip-game .coin-bet {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1em;
+  }
+  #coin-flip-game .coin-bet label { font-weight: bold; }
+  #coin-flip-game .flip-button { width: 100%; padding: 0.6em; font-weight: bold; }
+  #coin-flip-game .tally { font-weight: bold; }
+  #coin-flip-game .shop {
+    border-top: 1px dashed #196019;
+    padding-top: 0.6em;
+    display: grid;
+    gap: 0.4em;
+    text-align: left;
+  }
+  #coin-flip-game .shop-header { font-weight: bold; }
+  #coin-flip-game .shop-item {
+    display: flex;
+    justify-content: space-between;
+    gap: 1em;
+    width: 100%;
+  }
+  #coin-flip-game input[type="number"] {
+    font-family: inherit;
+    border: 1px solid #196019;
+    border-radius: 4px;
+    padding: 0.3em 0.5em;
+    width: 7em;
+    background: transparent;
+    color: inherit;
+  }
+  #coin-flip-game .log {
+    height: 8em;
+    overflow-y: auto;
+    font-size: 0.85em;
+    text-align: left;
+    border-top: 1px dashed #196019;
+    padding-top: 0.5em;
+    margin-top: 0.8em;
+  }
+  #coin-flip-game .win-text { color: #1e7d1e; }
+  #coin-flip-game .lose-text { color: #b03030; }
+  #coin-flip-game .game-over { font-weight: bold; text-align: center; font-size: 1.1em; margin: 0.5em 0; }
+  #coin-flip-game .game-over a { color: inherit; text-decoration: underline; }
+  @media (prefers-color-scheme: dark) {
+    #coin-flip-game { background: rgba(0, 0, 0, 0.85); }
+    #coin-flip-game .progress-track { background: #134013; }
+    #coin-flip-game .win-text { color: #7dff7d; }
+    #coin-flip-game .lose-text { color: #ff6b6b; }
+  }
+</style>
+
+<script src="/coin-flip-level3.js"></script>
+<script>
+Elm.CoinFlipLevel3.init({ node: document.getElementById('coin-flip-game') });
+</script>

--- a/elm/src/CoinFlipGame.elm
+++ b/elm/src/CoinFlipGame.elm
@@ -471,8 +471,9 @@ purchaseTracker offer model =
                     }
 
 
-{-| Pay uncle and draw one of his pre-programmed pearls of wisdom. Like
-the tracker, refused when it would wipe the balance to $0.
+{-| Pay uncle and draw one of his pre-programmed pearls of wisdom.
+Unlike the tracker, uncle happily takes your last dollars: spending
+yourself into bankruptcy on advice is a lesson the game wants to allow.
 -}
 purchaseUncleAdvice : UncleOffer -> Model -> ( Model, Cmd Msg )
 purchaseUncleAdvice offer model =
@@ -484,15 +485,16 @@ purchaseUncleAdvice offer model =
             if model.phase /= Playing then
                 ( model, Cmd.none )
 
-            else if model.balanceCents <= uncle.priceCents then
+            else if model.balanceCents < uncle.priceCents then
                 ( logLine NeutralTone "You cannot afford uncle's advice." model, Cmd.none )
 
             else
-                ( { model
-                    | balanceCents = model.balanceCents - uncle.priceCents
-                    , uncleAdviceCount = model.uncleAdviceCount + 1
-                    , betInput = clampBetInput (model.balanceCents - uncle.priceCents) model.betInput
-                  }
+                ( checkEndState
+                    { model
+                        | balanceCents = model.balanceCents - uncle.priceCents
+                        , uncleAdviceCount = model.uncleAdviceCount + 1
+                        , betInput = clampBetInput (model.balanceCents - uncle.priceCents) model.betInput
+                    }
                 , Random.generate UncleAdviceGiven
                     (Random.uniform uncle.firstPhrase uncle.morePhrases)
                 )

--- a/elm/src/CoinFlipGame.elm
+++ b/elm/src/CoinFlipGame.elm
@@ -261,7 +261,7 @@ update config msg model =
             placeBet playerChoice model
 
         CoinLanded flip ->
-            ( settleFlip flip model, Cmd.none )
+            ( settleFlip config.uncleOffer flip model, Cmd.none )
 
         ClockTicked ->
             ( tickClock model, Cmd.none )
@@ -330,8 +330,8 @@ coinFlipGenerator bias =
 {-| Apply a landed coin flip: pay out or collect, count it, and check for
 the win/bust end states.
 -}
-settleFlip : { playerChoice : CoinSide, betCents : Int, landed : CoinSide } -> Model -> Model
-settleFlip flip model =
+settleFlip : UncleOffer -> { playerChoice : CoinSide, betCents : Int, landed : CoinSide } -> Model -> Model
+settleFlip uncleOffer flip model =
     if model.phase /= Playing then
         model
 
@@ -371,7 +371,7 @@ settleFlip flip model =
                     , betInput = clampBetInput newBalance model.betInput
                 }
         in
-        checkEndState
+        checkEndState uncleOffer
             (logLine
                 (if won then
                     WinTone
@@ -410,16 +410,29 @@ clampBetInput balanceCents input =
                 input
 
 
-checkEndState : Model -> Model
-checkEndState model =
+checkEndState : UncleOffer -> Model -> Model
+checkEndState uncleOffer model =
     if model.balanceCents >= targetBalanceCents then
         { model | phase = WonGame }
 
     else if model.balanceCents <= 0 then
-        { model | phase = WentBust }
+        uncleGloatsOnBust uncleOffer { model | phase = WentBust }
 
     else
         model
+
+
+{-| The moment you go bankrupt, uncle pops into the log, if this level
+has an uncle at all.
+-}
+uncleGloatsOnBust : UncleOffer -> Model -> Model
+uncleGloatsOnBust offer model =
+    case offer of
+        NoUncleAdvice ->
+            model
+
+        UncleAdviceForSale _ ->
+            logLine NeutralTone "\u{1F9D3} Uncle: \u{201C}I'm proud of you kid\u{201D} \u{1F911}" model
 
 
 tickClock : Model -> Model
@@ -489,7 +502,7 @@ purchaseUncleAdvice offer model =
                 ( logLine NeutralTone "You cannot afford uncle's advice." model, Cmd.none )
 
             else
-                ( checkEndState
+                ( checkEndState offer
                     { model
                         | balanceCents = model.balanceCents - uncle.priceCents
                         , uncleAdviceCount = model.uncleAdviceCount + 1

--- a/elm/src/CoinFlipGame.elm
+++ b/elm/src/CoinFlipGame.elm
@@ -13,6 +13,7 @@ module CoinFlipGame exposing
     , NextLevelLink(..)
     , TrackerOffer(..)
     , TrackerState(..)
+    , UncleGloat(..)
     , UncleOffer(..)
     , formatCents
     , formatClock
@@ -144,6 +145,15 @@ type LogTone
     | NeutralTone
 
 
+{-| Whether uncle already dropped his "proud of you" line. He gloats
+exactly once, and only after his final piece of advice has landed in
+the log, so the gloat stays the newest line.
+-}
+type UncleGloat
+    = UncleHasNotGloated
+    | UncleHasGloated
+
+
 type alias LogLine =
     { tone : LogTone, text : String }
 
@@ -162,6 +172,7 @@ type alias Model =
     , tailsLandedCount : Int
     , tracker : TrackerState
     , uncleAdviceCount : Int
+    , uncleGloat : UncleGloat
     , log : List LogLine
     }
 
@@ -221,6 +232,7 @@ initialModel config =
     , tailsLandedCount = 0
     , tracker = TrackerNotBought
     , uncleAdviceCount = 0
+    , uncleGloat = UncleHasNotGloated
     , log = [ { tone = NeutralTone, text = config.introLogLine } ]
     }
 
@@ -273,7 +285,8 @@ update config msg model =
             purchaseUncleAdvice config.uncleOffer model
 
         UncleAdviceGiven phrase ->
-            ( logLine NeutralTone ("\u{1F9D3} Uncle: \u{201C}" ++ phrase ++ "\u{201D}") model
+            ( gloatIfBusted config.uncleOffer
+                (logLine NeutralTone ("\u{1F9D3} Uncle: \u{201C}" ++ phrase ++ "\u{201D}") model)
             , Cmd.none
             )
 
@@ -371,16 +384,18 @@ settleFlip uncleOffer flip model =
                     , betInput = clampBetInput newBalance model.betInput
                 }
         in
-        checkEndState uncleOffer
-            (logLine
-                (if won then
-                    WinTone
+        gloatIfBusted uncleOffer
+            (checkEndState
+                (logLine
+                    (if won then
+                        WinTone
 
-                 else
-                    LoseTone
+                     else
+                        LoseTone
+                    )
+                    outcomeText
+                    counted
                 )
-                outcomeText
-                counted
             )
 
 
@@ -410,29 +425,38 @@ clampBetInput balanceCents input =
                 input
 
 
-checkEndState : UncleOffer -> Model -> Model
-checkEndState uncleOffer model =
+checkEndState : Model -> Model
+checkEndState model =
     if model.balanceCents >= targetBalanceCents then
         { model | phase = WonGame }
 
     else if model.balanceCents <= 0 then
-        uncleGloatsOnBust uncleOffer { model | phase = WentBust }
+        { model | phase = WentBust }
 
     else
         model
 
 
-{-| The moment you go bankrupt, uncle pops into the log, if this level
-has an uncle at all.
+{-| Once bankrupt, uncle pops into the log, if this level has an uncle
+at all. Called after every event that could have busted the game (a
+settled flip, or uncle's own advice landing when the purchase took the
+last dollars), so his gloat is always the newest log line, exactly
+once.
 -}
-uncleGloatsOnBust : UncleOffer -> Model -> Model
-uncleGloatsOnBust offer model =
+gloatIfBusted : UncleOffer -> Model -> Model
+gloatIfBusted offer model =
     case offer of
         NoUncleAdvice ->
             model
 
         UncleAdviceForSale _ ->
-            logLine NeutralTone "\u{1F9D3} Uncle: \u{201C}I'm proud of you kid\u{201D} \u{1F911}" model
+            if model.phase == WentBust && model.uncleGloat == UncleHasNotGloated then
+                logLine NeutralTone
+                    "\u{1F9D3} Uncle: \u{201C}I'm proud of you kid\u{201D} \u{1F911}"
+                    { model | uncleGloat = UncleHasGloated }
+
+            else
+                model
 
 
 tickClock : Model -> Model
@@ -502,7 +526,10 @@ purchaseUncleAdvice offer model =
                 ( logLine NeutralTone "You cannot afford uncle's advice." model, Cmd.none )
 
             else
-                ( checkEndState offer
+                -- No gloat here even when this purchase busts the game:
+                -- the bought advice is still in flight, and the gloat
+                -- must land after it (see gloatIfBusted).
+                ( checkEndState
                     { model
                         | balanceCents = model.balanceCents - uncle.priceCents
                         , uncleAdviceCount = model.uncleAdviceCount + 1

--- a/elm/src/CoinFlipGame.elm
+++ b/elm/src/CoinFlipGame.elm
@@ -1,5 +1,6 @@
 module CoinFlipGame exposing
     ( BiasState(..)
+    , ClockState(..)
     , CoinBias(..)
     , CoinSide(..)
     , GamePhase(..)
@@ -24,6 +25,7 @@ module CoinFlipGame exposing
     , startingBalanceCents
     , targetBalanceCents
     , timeLimitSeconds
+    , toneClass
     , update
     , view
     )
@@ -589,20 +591,22 @@ landedPercent sideCount totalFlips =
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    case ( model.phase, model.clock ) of
-        ( Playing, ClockRunning ) ->
-            Time.every 1000 (\_ -> ClockTicked)
+    case model.phase of
+        Playing ->
+            case model.clock of
+                ClockRunning ->
+                    Time.every 1000 (\_ -> ClockTicked)
 
-        ( Playing, ClockIdle ) ->
+                ClockIdle ->
+                    Sub.none
+
+        WonGame ->
             Sub.none
 
-        ( WonGame, _ ) ->
+        WentBust ->
             Sub.none
 
-        ( WentBust, _ ) ->
-            Sub.none
-
-        ( RanOutOfTime, _ ) ->
+        RanOutOfTime ->
             Sub.none
 
 

--- a/elm/src/CoinFlipLevel2.elm
+++ b/elm/src/CoinFlipLevel2.elm
@@ -40,7 +40,7 @@ levelConfig =
                 ]
             }
     , nextLevelLink = NextLevelLinkTo { url = "/black-swan.html", label = "<<next level>>" }
-    , bustEnding = BustEndingQuote "Remember: never do business with family."
+    , bustEnding = BustEndingQuote "Uncle would be proud. That's not a compliment."
     , introLogLine = "The coin is rigged again, but this time I won't tell you how. The clock starts on your first bet. Good luck!"
     }
 

--- a/elm/src/CoinFlipLevel2.elm
+++ b/elm/src/CoinFlipLevel2.elm
@@ -40,7 +40,7 @@ levelConfig =
                 ]
             }
     , nextLevelLink = NextLevelLinkTo { url = "/black-swan.html", label = "<<next level>>" }
-    , bustEnding = BustEndingQuote "Remember: family is for walking with, not for trading with."
+    , bustEnding = BustEndingQuote "Remember: never do business with family."
     , introLogLine = "The coin is rigged again, but this time I won't tell you how. The clock starts on your first bet. Good luck!"
     }
 

--- a/elm/src/CoinFlipLevel2.elm
+++ b/elm/src/CoinFlipLevel2.elm
@@ -39,7 +39,7 @@ levelConfig =
                 , "Back in my day we didn't track ratios, we used our gut."
                 ]
             }
-    , nextLevelLink = NoNextLevelLink
+    , nextLevelLink = NextLevelLinkTo { url = "/black-swan.html", label = "<<next level>>" }
     , bustEnding = BustEndingQuote "Remember: family is for walking with, not for trading with."
     , introLogLine = "The coin is rigged again, but this time I won't tell you how. The clock starts on your first bet. Good luck!"
     }

--- a/elm/src/CoinFlipLevel2.elm
+++ b/elm/src/CoinFlipLevel2.elm
@@ -40,7 +40,7 @@ levelConfig =
                 ]
             }
     , nextLevelLink = NextLevelLinkTo { url = "/black-swan.html", label = "<<next level>>" }
-    , bustEnding = BustEndingQuote "Uncle would be proud. That's not a compliment."
+    , bustEnding = BustEndingQuote "Uncle is proud. Or perhaps he just appreciates all the money you gave him."
     , introLogLine = "The coin is rigged again, but this time I won't tell you how. The clock starts on your first bet. Good luck!"
     }
 

--- a/elm/src/CoinFlipLevel3.elm
+++ b/elm/src/CoinFlipLevel3.elm
@@ -1,0 +1,44 @@
+module CoinFlipLevel3 exposing (levelConfig, main)
+
+{-| Level 3 of the rigged-coin game: the black swan (black-swan.html).
+
+Three coins, everything hidden. Swan is the black swan: it almost never
+lands heads, but pays out huge, and it is the only coin worth betting.
+Magpie looks like a fair double-or-nothing but robs you slowly; Sparrow
+wins often but pays so little it bleeds you anyway.
+
+-}
+
+import CoinFlipGame exposing (TrackerOffer(..), UncleOffer(..))
+import MultiCoinGame exposing (Model, Msg, MultiCoinConfig, gameProgram)
+
+
+levelConfig : MultiCoinConfig
+levelConfig =
+    { title = "\u{1FA99} Rigged Coin Trader III: Rare Birds"
+    , coins =
+        [ { coinName = "Swan", winPercent = 5, payoutPercent = 3000 }
+        , { coinName = "Magpie", winPercent = 45, payoutPercent = 100 }
+        , { coinName = "Sparrow", winPercent = 60, payoutPercent = 50 }
+        ]
+    , trackerOffer = TrackerForSale 1500
+    , uncleOffer =
+        UncleAdviceForSale
+            { priceCents = 500
+            , firstPhrase = "Oh I don't know son, sparrows never let you down."
+            , morePhrases =
+                [ "A swan bit me once. Never trust a swan."
+                , "Magpies are drawn to money, that's gotta mean something."
+                , "Bet all three, that way you always win something."
+                , "The swan is due, I can feel it."
+                , "Double your bet after every loss, that's how you win it back."
+                , "Winners don't do math, son."
+                ]
+            }
+    , introLogLine = "Three coins, three payouts, all hidden. Stake any of them on heads and press flip. The clock starts on your first flip. Good luck!"
+    }
+
+
+main : Program () Model Msg
+main =
+    gameProgram levelConfig

--- a/elm/src/CoinFlipLevel3.elm
+++ b/elm/src/CoinFlipLevel3.elm
@@ -10,7 +10,7 @@ wins often but pays so little it bleeds you anyway.
 -}
 
 import CoinFlipGame exposing (TrackerOffer(..), UncleOffer(..))
-import MultiCoinGame exposing (Model, Msg, MultiCoinConfig, gameProgram)
+import MultiCoinGame exposing (GlassesOffer(..), Model, Msg, MultiCoinConfig, gameProgram)
 
 
 levelConfig : MultiCoinConfig
@@ -22,6 +22,7 @@ levelConfig =
         , { coinName = "Sparrow", winPercent = 60, payoutPercent = 50 }
         ]
     , trackerOffer = TrackerForSale 1500
+    , glassesOffer = GoldenGlassesForSale 2000
     , uncleOffer =
         UncleAdviceForSale
             { priceCents = 500
@@ -31,8 +32,8 @@ levelConfig =
                 , "Magpies are drawn to money, that's gotta mean something."
                 , "Bet all three, that way you always win something."
                 , "The swan is due, I can feel it."
-                , "Double your bet after every loss, that's how you win it back."
-                , "Winners don't do math, son."
+                , "If it wins more often than it loses, it's a winner. Simple."
+                , "Your aunt won three magpies in a row once. Three!"
                 ]
             }
     , introLogLine = "Three coins, three payouts, all hidden. Stake any of them on heads and press flip. The clock starts on your first flip. Good luck!"

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -50,6 +50,7 @@ import CoinFlipGame
         , LogTone(..)
         , TrackerOffer(..)
         , TrackerState(..)
+        , UncleGloat(..)
         , UncleOffer(..)
         , formatCents
         , formatClock
@@ -118,6 +119,7 @@ type alias Model =
     , tracker : TrackerState
     , glasses : GoldenGlasses
     , uncleAdviceCount : Int
+    , uncleGloat : UncleGloat
     , bustCause : BustCause
     , log : List LogLine
     }
@@ -166,6 +168,7 @@ initialModel config =
     , tracker = TrackerNotBought
     , glasses = GlassesNotBought
     , uncleAdviceCount = 0
+    , uncleGloat = UncleHasNotGloated
     , bustCause = NotBusted
     , log = [ { tone = NeutralTone, text = config.introLogLine } ]
     }
@@ -209,7 +212,8 @@ update config msg model =
             purchaseUncleAdvice config.uncleOffer model
 
         UncleAdviceGiven phrase ->
-            ( logLine NeutralTone ("\u{1F9D3} Uncle: \u{201C}" ++ phrase ++ "\u{201D}") model
+            ( gloatIfBusted config.uncleOffer
+                (logLine NeutralTone ("\u{1F9D3} Uncle: \u{201C}" ++ phrase ++ "\u{201D}") model)
             , Cmd.none
             )
 
@@ -414,39 +418,49 @@ settleRound config landedRound model =
             roundLogLines =
                 List.concatMap .logLines outcomes
         in
-        checkEndState config.uncleOffer
-            BustByBetting
-            { model
-                | balanceCents = newBalance
-                , tallies = List.map .tally outcomes
-                , roundCount = model.roundCount + 1
-                , log = List.reverse roundLogLines ++ model.log
-            }
+        gloatIfBusted config.uncleOffer
+            (checkEndState BustByBetting
+                { model
+                    | balanceCents = newBalance
+                    , tallies = List.map .tally outcomes
+                    , roundCount = model.roundCount + 1
+                    , log = List.reverse roundLogLines ++ model.log
+                }
+            )
 
 
-checkEndState : UncleOffer -> BustCause -> Model -> Model
-checkEndState uncleOffer causeIfBusted model =
+checkEndState : BustCause -> Model -> Model
+checkEndState causeIfBusted model =
     if model.balanceCents >= targetBalanceCents then
         { model | phase = WonGame }
 
     else if model.balanceCents <= 0 then
-        uncleGloatsOnBust uncleOffer { model | phase = WentBust, bustCause = causeIfBusted }
+        { model | phase = WentBust, bustCause = causeIfBusted }
 
     else
         model
 
 
-{-| The moment you go bankrupt, uncle pops into the log, if this level
-has an uncle at all.
+{-| Once bankrupt, uncle pops into the log, if this level has an uncle
+at all. Called after every event that could have busted the game (a
+settled round, or uncle's own advice landing when the purchase took the
+last dollars), so his gloat is always the newest log line, exactly
+once.
 -}
-uncleGloatsOnBust : UncleOffer -> Model -> Model
-uncleGloatsOnBust offer model =
+gloatIfBusted : UncleOffer -> Model -> Model
+gloatIfBusted offer model =
     case offer of
         NoUncleAdvice ->
             model
 
         UncleAdviceForSale _ ->
-            logLine NeutralTone "\u{1F9D3} Uncle: \u{201C}I'm proud of you kid\u{201D} \u{1F911}" model
+            if model.phase == WentBust && model.uncleGloat == UncleHasNotGloated then
+                logLine NeutralTone
+                    "\u{1F9D3} Uncle: \u{201C}I'm proud of you kid\u{201D} \u{1F911}"
+                    { model | uncleGloat = UncleHasGloated }
+
+            else
+                model
 
 
 tickClock : Model -> Model
@@ -546,8 +560,10 @@ purchaseUncleAdvice offer model =
                 ( logLine NeutralTone "You cannot afford uncle's advice." model, Cmd.none )
 
             else
-                ( checkEndState offer
-                    BustByUncleAdvice
+                -- No gloat here even when this purchase busts the game:
+                -- the bought advice is still in flight, and the gloat
+                -- must land after it (see gloatIfBusted).
+                ( checkEndState BustByUncleAdvice
                     { model
                         | balanceCents = model.balanceCents - uncle.priceCents
                         , uncleAdviceCount = model.uncleAdviceCount + 1

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -1,5 +1,6 @@
 module MultiCoinGame exposing
-    ( CoinConfig
+    ( BustCause(..)
+    , CoinConfig
     , CoinTally
     , GlassesOffer(..)
     , GoldenGlasses(..)
@@ -117,8 +118,19 @@ type alias Model =
     , tracker : TrackerState
     , glasses : GoldenGlasses
     , uncleAdviceCount : Int
+    , bustCause : BustCause
     , log : List LogLine
     }
+
+
+{-| How the bankruptcy happened. Busting on a coin flip is the game
+working as intended; busting on uncle's consulting fee earns its own
+callout.
+-}
+type BustCause
+    = NotBusted
+    | BustByBetting
+    | BustByUncleAdvice
 
 
 type Msg
@@ -154,6 +166,7 @@ initialModel config =
     , tracker = TrackerNotBought
     , glasses = GlassesNotBought
     , uncleAdviceCount = 0
+    , bustCause = NotBusted
     , log = [ { tone = NeutralTone, text = config.introLogLine } ]
     }
 
@@ -401,7 +414,7 @@ settleRound config landedRound model =
             roundLogLines =
                 List.concatMap .logLines outcomes
         in
-        checkEndState
+        checkEndState BustByBetting
             { model
                 | balanceCents = newBalance
                 , tallies = List.map .tally outcomes
@@ -410,13 +423,13 @@ settleRound config landedRound model =
             }
 
 
-checkEndState : Model -> Model
-checkEndState model =
+checkEndState : BustCause -> Model -> Model
+checkEndState causeIfBusted model =
     if model.balanceCents >= targetBalanceCents then
         { model | phase = WonGame }
 
     else if model.balanceCents <= 0 then
-        { model | phase = WentBust }
+        { model | phase = WentBust, bustCause = causeIfBusted }
 
     else
         model
@@ -519,7 +532,7 @@ purchaseUncleAdvice offer model =
                 ( logLine NeutralTone "You cannot afford uncle's advice." model, Cmd.none )
 
             else
-                ( checkEndState
+                ( checkEndState BustByUncleAdvice
                     { model
                         | balanceCents = model.balanceCents - uncle.priceCents
                         , uncleAdviceCount = model.uncleAdviceCount + 1
@@ -782,8 +795,9 @@ viewGameOver config model =
     Html.div
         [ Html.Attributes.class ("game-over " ++ CoinFlipGame.toneClass tone) ]
         (List.concat
-            [ [ Html.text message
-              , Html.div []
+            [ [ Html.text message ]
+            , viewUncleBustCallout model
+            , [ Html.div []
                     [ Html.text "It took you exactly "
                     , Html.strong [] [ Html.text (String.fromInt model.roundCount) ]
                     , Html.text " presses to get here."
@@ -793,6 +807,21 @@ viewGameOver config model =
             , viewUncleSpend config.uncleOffer model
             ]
         )
+
+
+viewUncleBustCallout : Model -> List (Html Msg)
+viewUncleBustCallout model =
+    case model.bustCause of
+        NotBusted ->
+            []
+
+        BustByBetting ->
+            []
+
+        BustByUncleAdvice ->
+            [ Html.div [ Html.Attributes.class "uncle-bust" ]
+                [ Html.text "You didn't even lose it betting: you spent your last dollars on uncle's advice. That's just sad." ]
+            ]
 
 
 gameOverMessage : Model -> ( String, LogTone )

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -1,6 +1,8 @@
 module MultiCoinGame exposing
     ( CoinConfig
     , CoinTally
+    , GlassesOffer(..)
+    , GoldenGlasses(..)
     , Model
     , Msg(..)
     , MultiCoinConfig
@@ -72,11 +74,26 @@ type alias CoinConfig =
     }
 
 
+{-| The golden glasses reveal every coin's payout multiplier while
+playing (the win percents stay hidden; that is what the ratio tracker
+approximates). Price in cents.
+-}
+type GlassesOffer
+    = NoGoldenGlasses
+    | GoldenGlassesForSale Int
+
+
+type GoldenGlasses
+    = GlassesNotBought
+    | GlassesBought
+
+
 type alias MultiCoinConfig =
     { title : String
     , coins : List CoinConfig
     , trackerOffer : TrackerOffer
     , uncleOffer : UncleOffer
+    , glassesOffer : GlassesOffer
     , introLogLine : String
     }
 
@@ -98,6 +115,7 @@ type alias Model =
     , secondsLeft : Int
     , roundCount : Int
     , tracker : TrackerState
+    , glasses : GoldenGlasses
     , uncleAdviceCount : Int
     , log : List LogLine
     }
@@ -109,6 +127,7 @@ type Msg
     | CoinsLanded { stakes : List Int, rolls : List Int }
     | ClockTicked
     | TrackerPurchased
+    | GlassesPurchased
     | UncleAdviceRequested
     | UncleAdviceGiven String
 
@@ -133,6 +152,7 @@ initialModel config =
     , secondsLeft = timeLimitSeconds
     , roundCount = 0
     , tracker = TrackerNotBought
+    , glasses = GlassesNotBought
     , uncleAdviceCount = 0
     , log = [ { tone = NeutralTone, text = config.introLogLine } ]
     }
@@ -168,6 +188,9 @@ update config msg model =
 
         TrackerPurchased ->
             ( purchaseTracker config.trackerOffer model, Cmd.none )
+
+        GlassesPurchased ->
+            ( purchaseGlasses config.glassesOffer model, Cmd.none )
 
         UncleAdviceRequested ->
             purchaseUncleAdvice config.uncleOffer model
@@ -329,16 +352,18 @@ resolveCoin coin tally stake roll =
                     paidOut =
                         payoutCents coin.payoutPercent stake
                 in
+                -- The logged amount is the full return, stake plus
+                -- winnings, because "paid out $0.10 on your $0.10" read
+                -- as a break-even coin. The balance delta stays the
+                -- winnings alone: the stake never left the balance.
                 { tally = { headsCount = tally.headsCount + 1, flipCount = tally.flipCount + 1 }
                 , deltaCents = paidOut
                 , logLines =
                     [ { tone = WinTone
                       , text =
                             coin.coinName
-                                ++ " landed heads! Paid out $"
-                                ++ formatCents paidOut
-                                ++ " on your $"
-                                ++ formatCents stake
+                                ++ " landed heads! You win $"
+                                ++ formatCents (stake + paidOut)
                                 ++ "."
                       }
                     ]
@@ -349,7 +374,7 @@ resolveCoin coin tally stake roll =
                 , deltaCents = -stake
                 , logLines =
                     [ { tone = LoseTone
-                      , text = coin.coinName ++ " landed tails. You lost $" ++ formatCents stake ++ "."
+                      , text = coin.coinName ++ " landed tails. You lost your $" ++ formatCents stake ++ " stake."
                       }
                     ]
                 }
@@ -440,6 +465,36 @@ purchaseTracker offer model =
                     { model
                         | balanceCents = model.balanceCents - priceCents
                         , tracker = TrackerBought
+                    }
+
+
+{-| Buy the golden glasses. Same wipe-out guard as the tracker.
+-}
+purchaseGlasses : GlassesOffer -> Model -> Model
+purchaseGlasses offer model =
+    case ( offer, model.glasses ) of
+        ( NoGoldenGlasses, GlassesNotBought ) ->
+            model
+
+        ( NoGoldenGlasses, GlassesBought ) ->
+            model
+
+        ( GoldenGlassesForSale _, GlassesBought ) ->
+            model
+
+        ( GoldenGlassesForSale priceCents, GlassesNotBought ) ->
+            if model.phase /= Playing then
+                model
+
+            else if model.balanceCents <= priceCents then
+                logLine NeutralTone "You cannot afford the golden glasses." model
+
+            else
+                logLine NeutralTone
+                    ("Bought the golden glasses for $" ++ formatCents priceCents ++ ".")
+                    { model
+                        | balanceCents = model.balanceCents - priceCents
+                        , glasses = GlassesBought
                     }
 
 
@@ -566,10 +621,34 @@ viewControls config model =
                     ]
                     [ Html.text "FLIP" ]
               ]
+            , viewGlassesPayouts config model
             , viewTally config model
             , viewShop config model
             ]
         )
+
+
+{-| The payout multipliers the golden glasses reveal, under the flip
+button. Only the payouts: the win percents stay hidden.
+-}
+viewGlassesPayouts : MultiCoinConfig -> Model -> List (Html Msg)
+viewGlassesPayouts config model =
+    case model.glasses of
+        GlassesNotBought ->
+            []
+
+        GlassesBought ->
+            [ Html.div [ Html.Attributes.class "glasses" ]
+                [ Html.text
+                    ("\u{1F453} Pays: "
+                        ++ String.join " \u{00B7} "
+                            (List.map
+                                (\coin -> coin.coinName ++ " " ++ formatPayout coin.payoutPercent)
+                                config.coins
+                            )
+                    )
+                ]
+            ]
 
 
 viewCoinRow : Int -> ( CoinConfig, String ) -> Html Msg
@@ -621,7 +700,11 @@ coinTallyText coin tally =
 
 viewShop : MultiCoinConfig -> Model -> List (Html Msg)
 viewShop config model =
-    case viewTrackerShopItem config.trackerOffer model ++ viewUncleShopItem config.uncleOffer of
+    case
+        viewTrackerShopItem config.trackerOffer model
+            ++ viewGlassesShopItem config.glassesOffer model
+            ++ viewUncleShopItem config.uncleOffer
+    of
         [] ->
             []
 
@@ -656,6 +739,22 @@ viewTrackerShopItem offer model =
 
         ( TrackerForSale priceCents, TrackerNotBought ) ->
             [ viewShopItem TrackerPurchased "Buy ratio tracker" priceCents ]
+
+
+viewGlassesShopItem : GlassesOffer -> Model -> List (Html Msg)
+viewGlassesShopItem offer model =
+    case ( offer, model.glasses ) of
+        ( NoGoldenGlasses, GlassesNotBought ) ->
+            []
+
+        ( NoGoldenGlasses, GlassesBought ) ->
+            []
+
+        ( GoldenGlassesForSale _, GlassesBought ) ->
+            []
+
+        ( GoldenGlassesForSale priceCents, GlassesNotBought ) ->
+            [ viewShopItem GlassesPurchased "Buy golden glasses" priceCents ]
 
 
 viewUncleShopItem : UncleOffer -> List (Html Msg)

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -1,0 +1,801 @@
+module MultiCoinGame exposing
+    ( CoinConfig
+    , CoinTally
+    , Model
+    , Msg(..)
+    , MultiCoinConfig
+    , StakeInput(..)
+    , formatPayout
+    , gameProgram
+    , initialModel
+    , parseStake
+    , payoutCents
+    , update
+    , view
+    )
+
+{-| Engine for the multi-coin betting game (level 3, black-swan.html).
+
+Several named coins can be staked at once: the player fills in an amount
+per coin (always betting heads), presses flip, and every staked coin
+resolves with its own hidden win percent and hidden payout multiplier.
+Finding out which coin is worth betting on IS the game, so nothing is
+printed on the controls and the win logs state the exact payout.
+
+Money and clock formatting, the game phases, and the shop offers are
+shared with the single-coin engine (CoinFlipGame, levels 1 and 2); the
+model, update, and view are separate because the interaction differs:
+many simultaneous stakes and one flip button instead of a heads/tails
+choice on a single coin.
+
+-}
+-- Decision: a separate engine module next to CoinFlipGame rather than
+-- generalizing CoinFlipGame to N coins. The single-coin levels bet on a
+-- side of one biased coin; this level stakes amounts on heads of several
+-- coins at once. Forcing both interaction models through one
+-- Model/Msg/view doubled the case analysis everywhere it was tried on
+-- paper; sharing the pure pieces (phases, money, clock, shop types) keeps
+-- the duplication to the small view fragments.
+
+import Browser
+import CoinFlipGame
+    exposing
+        ( ClockState(..)
+        , CoinSide(..)
+        , GamePhase(..)
+        , LogLine
+        , LogTone(..)
+        , TrackerOffer(..)
+        , TrackerState(..)
+        , UncleOffer(..)
+        , formatCents
+        , formatClock
+        , landedPercent
+        , startingBalanceCents
+        , targetBalanceCents
+        , timeLimitSeconds
+        )
+import Html exposing (Html)
+import Html.Attributes
+import Html.Events
+import Random
+import Time
+
+
+{-| One coin on the table. The win percent and the payout (as a percent
+of the stake: 100 = 1:1, 3000 = 30x) are never shown to the player.
+-}
+type alias CoinConfig =
+    { coinName : String
+    , winPercent : Int
+    , payoutPercent : Int
+    }
+
+
+type alias MultiCoinConfig =
+    { title : String
+    , coins : List CoinConfig
+    , trackerOffer : TrackerOffer
+    , uncleOffer : UncleOffer
+    , introLogLine : String
+    }
+
+
+{-| Per-coin flip statistics, counting only flips the player staked.
+-}
+type alias CoinTally =
+    { headsCount : Int
+    , flipCount : Int
+    }
+
+
+type alias Model =
+    { balanceCents : Int
+    , stakeInputs : List String
+    , tallies : List CoinTally
+    , phase : GamePhase
+    , clock : ClockState
+    , secondsLeft : Int
+    , roundCount : Int
+    , tracker : TrackerState
+    , uncleAdviceCount : Int
+    , log : List LogLine
+    }
+
+
+type Msg
+    = StakeInputChanged Int String
+    | FlipPressed
+    | CoinsLanded { stakes : List Int, rolls : List Int }
+    | ClockTicked
+    | TrackerPurchased
+    | UncleAdviceRequested
+    | UncleAdviceGiven String
+
+
+gameProgram : MultiCoinConfig -> Program () Model Msg
+gameProgram config =
+    Browser.element
+        { init = \() -> ( initialModel config, Cmd.none )
+        , update = update config
+        , subscriptions = subscriptions
+        , view = view config
+        }
+
+
+initialModel : MultiCoinConfig -> Model
+initialModel config =
+    { balanceCents = startingBalanceCents
+    , stakeInputs = List.map (\_ -> "0.00") config.coins
+    , tallies = List.map (\_ -> { headsCount = 0, flipCount = 0 }) config.coins
+    , phase = Playing
+    , clock = ClockIdle
+    , secondsLeft = timeLimitSeconds
+    , roundCount = 0
+    , tracker = TrackerNotBought
+    , uncleAdviceCount = 0
+    , log = [ { tone = NeutralTone, text = config.introLogLine } ]
+    }
+
+
+update : MultiCoinConfig -> Msg -> Model -> ( Model, Cmd Msg )
+update config msg model =
+    case msg of
+        StakeInputChanged coinIndex newInput ->
+            ( { model
+                | stakeInputs =
+                    List.indexedMap
+                        (\index input ->
+                            if index == coinIndex then
+                                newInput
+
+                            else
+                                input
+                        )
+                        model.stakeInputs
+              }
+            , Cmd.none
+            )
+
+        FlipPressed ->
+            pressFlip config model
+
+        CoinsLanded landedRound ->
+            ( settleRound config landedRound model, Cmd.none )
+
+        ClockTicked ->
+            ( tickClock model, Cmd.none )
+
+        TrackerPurchased ->
+            ( purchaseTracker config.trackerOffer model, Cmd.none )
+
+        UncleAdviceRequested ->
+            purchaseUncleAdvice config.uncleOffer model
+
+        UncleAdviceGiven phrase ->
+            ( logLine NeutralTone ("\u{1F9D3} Uncle: \u{201C}" ++ phrase ++ "\u{201D}") model
+            , Cmd.none
+            )
+
+
+{-| A stake input field, classified. Blank or zero means the coin simply
+is not played this round; junk that fails to parse is an error the
+player must see, never a silent no-bet.
+-}
+type StakeInput
+    = NoStake
+    | Stake Int
+    | UnreadableStake
+
+
+parseStake : String -> StakeInput
+parseStake input =
+    if String.isEmpty (String.trim input) then
+        NoStake
+
+    else
+        case String.toFloat input of
+            Nothing ->
+                UnreadableStake
+
+            Just dollars ->
+                let
+                    cents =
+                        round (dollars * 100)
+                in
+                if cents <= 0 then
+                    NoStake
+
+                else
+                    Stake cents
+
+
+{-| Validate all stake inputs and, if they hold up, flip every staked
+coin at once. The clock starts on the first accepted flip.
+-}
+pressFlip : MultiCoinConfig -> Model -> ( Model, Cmd Msg )
+pressFlip config model =
+    if model.phase /= Playing then
+        ( model, Cmd.none )
+
+    else
+        case validateStakes config.coins model.stakeInputs of
+            UnreadableCoin coinName ->
+                ( logLine NeutralTone ("Cannot read your bet on " ++ coinName ++ ".") model
+                , Cmd.none
+                )
+
+            ReadableStakes stakes ->
+                let
+                    totalStaked =
+                        List.sum stakes
+                in
+                if totalStaked <= 0 then
+                    ( logLine NeutralTone "Place a bet on at least one coin first." model
+                    , Cmd.none
+                    )
+
+                else if totalStaked > model.balanceCents then
+                    ( logLine NeutralTone "You cannot bet more than your current balance!" model
+                    , Cmd.none
+                    )
+
+                else
+                    ( { model | clock = ClockRunning }
+                    , Random.generate
+                        (\rolls -> CoinsLanded { stakes = stakes, rolls = rolls })
+                        (Random.list (List.length config.coins) (Random.int 1 100))
+                    )
+
+
+{-| All stake inputs validated together: either every input reads as an
+amount (unplayed coins as zero), or the first unreadable coin's name.
+The unreadable case never turns into a number, so a typo can never be
+silently played as a $0 bet.
+-}
+type StakesValidation
+    = ReadableStakes (List Int)
+    | UnreadableCoin String
+
+
+validateStakes : List CoinConfig -> List String -> StakesValidation
+validateStakes coins stakeInputs =
+    validateStakePairs (List.map2 Tuple.pair coins stakeInputs)
+
+
+validateStakePairs : List ( CoinConfig, String ) -> StakesValidation
+validateStakePairs pairs =
+    case pairs of
+        [] ->
+            ReadableStakes []
+
+        ( coin, input ) :: rest ->
+            case parseStake input of
+                UnreadableStake ->
+                    UnreadableCoin coin.coinName
+
+                NoStake ->
+                    prependStake 0 (validateStakePairs rest)
+
+                Stake cents ->
+                    prependStake cents (validateStakePairs rest)
+
+
+prependStake : Int -> StakesValidation -> StakesValidation
+prependStake cents validated =
+    case validated of
+        UnreadableCoin coinName ->
+            UnreadableCoin coinName
+
+        ReadableStakes stakes ->
+            ReadableStakes (cents :: stakes)
+
+
+{-| What a win on this stake pays out (the profit; the stake itself is
+never taken on a win, matching levels 1 and 2). Floored to whole cents
+but never zero: a "win" that pays nothing would be a silent lie.
+-}
+payoutCents : Int -> Int -> Int
+payoutCents payoutPercent stake =
+    max 1 (stake * payoutPercent // 100)
+
+
+{-| The result of one coin in a settled round.
+-}
+type alias CoinOutcome =
+    { tally : CoinTally
+    , deltaCents : Int
+    , logLines : List LogLine
+    }
+
+
+resolveCoin : CoinConfig -> CoinTally -> Int -> Int -> CoinOutcome
+resolveCoin coin tally stake roll =
+    if stake <= 0 then
+        { tally = tally, deltaCents = 0, logLines = [] }
+
+    else
+        let
+            landed =
+                if roll <= coin.winPercent then
+                    Heads
+
+                else
+                    Tails
+        in
+        case landed of
+            Heads ->
+                let
+                    paidOut =
+                        payoutCents coin.payoutPercent stake
+                in
+                { tally = { headsCount = tally.headsCount + 1, flipCount = tally.flipCount + 1 }
+                , deltaCents = paidOut
+                , logLines =
+                    [ { tone = WinTone
+                      , text =
+                            coin.coinName
+                                ++ " landed heads! Paid out $"
+                                ++ formatCents paidOut
+                                ++ " on your $"
+                                ++ formatCents stake
+                                ++ "."
+                      }
+                    ]
+                }
+
+            Tails ->
+                { tally = { headsCount = tally.headsCount, flipCount = tally.flipCount + 1 }
+                , deltaCents = -stake
+                , logLines =
+                    [ { tone = LoseTone
+                      , text = coin.coinName ++ " landed tails. You lost $" ++ formatCents stake ++ "."
+                      }
+                    ]
+                }
+
+
+{-| Apply a landed round: pay out or collect per staked coin, update the
+tallies, and check for the win/bust end states.
+-}
+settleRound : MultiCoinConfig -> { stakes : List Int, rolls : List Int } -> Model -> Model
+settleRound config landedRound model =
+    if model.phase /= Playing then
+        model
+
+    else
+        let
+            outcomes =
+                List.map4 resolveCoin config.coins model.tallies landedRound.stakes landedRound.rolls
+
+            newBalance =
+                max 0 (model.balanceCents + List.sum (List.map .deltaCents outcomes))
+
+            roundLogLines =
+                List.concatMap .logLines outcomes
+        in
+        checkEndState
+            { model
+                | balanceCents = newBalance
+                , tallies = List.map .tally outcomes
+                , roundCount = model.roundCount + 1
+                , log = List.reverse roundLogLines ++ model.log
+            }
+
+
+checkEndState : Model -> Model
+checkEndState model =
+    if model.balanceCents >= targetBalanceCents then
+        { model | phase = WonGame }
+
+    else if model.balanceCents <= 0 then
+        { model | phase = WentBust }
+
+    else
+        model
+
+
+tickClock : Model -> Model
+tickClock model =
+    if model.phase /= Playing then
+        model
+
+    else
+        let
+            newSecondsLeft =
+                model.secondsLeft - 1
+        in
+        if newSecondsLeft <= 0 then
+            { model | secondsLeft = 0, phase = RanOutOfTime }
+
+        else
+            { model | secondsLeft = newSecondsLeft }
+
+
+{-| Buy the ratio tracker. Refused when it would wipe the balance to $0,
+same rule as levels 1 and 2.
+-}
+purchaseTracker : TrackerOffer -> Model -> Model
+purchaseTracker offer model =
+    case ( offer, model.tracker ) of
+        ( NoTrackerForSale, TrackerNotBought ) ->
+            model
+
+        ( NoTrackerForSale, TrackerBought ) ->
+            model
+
+        ( TrackerForSale _, TrackerBought ) ->
+            model
+
+        ( TrackerForSale priceCents, TrackerNotBought ) ->
+            if model.phase /= Playing then
+                model
+
+            else if model.balanceCents <= priceCents then
+                logLine NeutralTone "You cannot afford the ratio tracker." model
+
+            else
+                logLine NeutralTone
+                    ("Bought the ratio tracker for $" ++ formatCents priceCents ++ ".")
+                    { model
+                        | balanceCents = model.balanceCents - priceCents
+                        , tracker = TrackerBought
+                    }
+
+
+{-| Pay uncle and draw one of his pre-programmed pearls of wisdom.
+-}
+purchaseUncleAdvice : UncleOffer -> Model -> ( Model, Cmd Msg )
+purchaseUncleAdvice offer model =
+    case offer of
+        NoUncleAdvice ->
+            ( model, Cmd.none )
+
+        UncleAdviceForSale uncle ->
+            if model.phase /= Playing then
+                ( model, Cmd.none )
+
+            else if model.balanceCents <= uncle.priceCents then
+                ( logLine NeutralTone "You cannot afford uncle's advice." model, Cmd.none )
+
+            else
+                ( { model
+                    | balanceCents = model.balanceCents - uncle.priceCents
+                    , uncleAdviceCount = model.uncleAdviceCount + 1
+                  }
+                , Random.generate UncleAdviceGiven
+                    (Random.uniform uncle.firstPhrase uncle.morePhrases)
+                )
+
+
+logLine : LogTone -> String -> Model -> Model
+logLine tone text model =
+    { model | log = { tone = tone, text = text } :: model.log }
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    case model.phase of
+        Playing ->
+            case model.clock of
+                ClockRunning ->
+                    Time.every 1000 (\_ -> ClockTicked)
+
+                ClockIdle ->
+                    Sub.none
+
+        WonGame ->
+            Sub.none
+
+        WentBust ->
+            Sub.none
+
+        RanOutOfTime ->
+            Sub.none
+
+
+
+-- VIEW
+
+
+{-| The root carries the same id the markdown mount div has, because
+Browser.element replaces the mount node and the posts' inline CSS is
+scoped to #coin-flip-game.
+-}
+view : MultiCoinConfig -> Model -> Html Msg
+view config model =
+    Html.div [ Html.Attributes.id "coin-flip-game" ]
+        (List.concat
+            [ [ Html.h3 [] [ Html.text config.title ]
+              , viewStats model
+              , viewProgressBar model
+              , Html.div []
+                    [ Html.text "Total flips: "
+                    , Html.span [ Html.Attributes.class "flip-count" ]
+                        [ Html.text (String.fromInt model.roundCount) ]
+                    ]
+              , Html.div [ Html.Attributes.class "balance" ]
+                    [ Html.text ("$" ++ formatCents model.balanceCents) ]
+              ]
+            , if model.phase == Playing then
+                [ viewControls config model ]
+
+              else
+                [ viewGameOver config model ]
+            , [ viewLog model ]
+            ]
+        )
+
+
+viewStats : Model -> Html Msg
+viewStats model =
+    Html.div [ Html.Attributes.class "stats" ]
+        [ Html.div [] [ Html.text ("Target: $" ++ String.fromInt (targetBalanceCents // 100)) ]
+        , Html.div []
+            [ Html.text "Time left: "
+            , Html.span [ Html.Attributes.class "timer" ]
+                [ Html.text (formatClock model.secondsLeft) ]
+            ]
+        ]
+
+
+viewProgressBar : Model -> Html Msg
+viewProgressBar model =
+    let
+        progressPercent =
+            min 100 (100 * toFloat model.balanceCents / toFloat targetBalanceCents)
+    in
+    Html.div [ Html.Attributes.class "progress-track" ]
+        [ Html.div
+            [ Html.Attributes.class "progress-fill"
+            , Html.Attributes.style "width" (String.fromFloat progressPercent ++ "%")
+            ]
+            []
+        ]
+
+
+viewControls : MultiCoinConfig -> Model -> Html Msg
+viewControls config model =
+    Html.div [ Html.Attributes.class "controls" ]
+        (List.concat
+            [ List.indexedMap viewCoinRow
+                (List.map2 Tuple.pair config.coins model.stakeInputs)
+            , [ Html.button
+                    [ Html.Attributes.class "flip-button"
+                    , Html.Events.onClick FlipPressed
+                    ]
+                    [ Html.text "FLIP" ]
+              ]
+            , viewTally config model
+            , viewShop config model
+            ]
+        )
+
+
+viewCoinRow : Int -> ( CoinConfig, String ) -> Html Msg
+viewCoinRow coinIndex ( coin, stakeInput ) =
+    Html.div [ Html.Attributes.class "coin-bet" ]
+        [ Html.label [] [ Html.text (coin.coinName ++ " $:") ]
+        , Html.input
+            [ Html.Attributes.class "bet-amount"
+            , Html.Attributes.type_ "number"
+            , Html.Attributes.step "0.01"
+            , Html.Attributes.min "0.01"
+            , Html.Attributes.value stakeInput
+            , Html.Events.onInput (StakeInputChanged coinIndex)
+            ]
+            []
+        ]
+
+
+{-| The per-coin tally the ratio tracker paints under the flip button.
+-}
+viewTally : MultiCoinConfig -> Model -> List (Html Msg)
+viewTally config model =
+    case model.tracker of
+        TrackerNotBought ->
+            []
+
+        TrackerBought ->
+            [ Html.div [ Html.Attributes.class "tally" ]
+                [ Html.text
+                    ("\u{1F4CA} "
+                        ++ String.join " \u{00B7} "
+                            (List.map2 coinTallyText config.coins model.tallies)
+                    )
+                ]
+            ]
+
+
+coinTallyText : CoinConfig -> CoinTally -> String
+coinTallyText coin tally =
+    coin.coinName
+        ++ " "
+        ++ String.fromInt tally.headsCount
+        ++ "/"
+        ++ String.fromInt tally.flipCount
+        ++ " ("
+        ++ String.fromInt (landedPercent tally.headsCount tally.flipCount)
+        ++ "%)"
+
+
+viewShop : MultiCoinConfig -> Model -> List (Html Msg)
+viewShop config model =
+    case viewTrackerShopItem config.trackerOffer model ++ viewUncleShopItem config.uncleOffer of
+        [] ->
+            []
+
+        shopItems ->
+            [ Html.div [ Html.Attributes.class "shop" ]
+                (Html.div [ Html.Attributes.class "shop-header" ] [ Html.text "\u{1F6D2} Shop" ]
+                    :: shopItems
+                )
+            ]
+
+
+viewShopItem : Msg -> String -> Int -> Html Msg
+viewShopItem onBuy itemName priceCents =
+    Html.button
+        [ Html.Attributes.class "shop-item", Html.Events.onClick onBuy ]
+        [ Html.span [] [ Html.text itemName ]
+        , Html.span [] [ Html.text ("$" ++ formatCents priceCents) ]
+        ]
+
+
+viewTrackerShopItem : TrackerOffer -> Model -> List (Html Msg)
+viewTrackerShopItem offer model =
+    case ( offer, model.tracker ) of
+        ( NoTrackerForSale, TrackerNotBought ) ->
+            []
+
+        ( NoTrackerForSale, TrackerBought ) ->
+            []
+
+        ( TrackerForSale _, TrackerBought ) ->
+            []
+
+        ( TrackerForSale priceCents, TrackerNotBought ) ->
+            [ viewShopItem TrackerPurchased "Buy ratio tracker" priceCents ]
+
+
+viewUncleShopItem : UncleOffer -> List (Html Msg)
+viewUncleShopItem offer =
+    case offer of
+        NoUncleAdvice ->
+            []
+
+        UncleAdviceForSale uncle ->
+            [ viewShopItem UncleAdviceRequested "Ask uncle for advice" uncle.priceCents ]
+
+
+viewGameOver : MultiCoinConfig -> Model -> Html Msg
+viewGameOver config model =
+    let
+        ( message, tone ) =
+            gameOverMessage model
+    in
+    Html.div
+        [ Html.Attributes.class ("game-over " ++ CoinFlipGame.toneClass tone) ]
+        (List.concat
+            [ [ Html.text message
+              , Html.div []
+                    [ Html.text "It took you exactly "
+                    , Html.strong [] [ Html.text (String.fromInt model.roundCount) ]
+                    , Html.text " presses to get here."
+                    ]
+              ]
+            , List.map viewCoinReveal config.coins
+            , viewUncleSpend config.uncleOffer model
+            ]
+        )
+
+
+gameOverMessage : Model -> ( String, LogTone )
+gameOverMessage model =
+    case model.phase of
+        Playing ->
+            ( "", NeutralTone )
+
+        WonGame ->
+            ( "\u{1F389} YOU WIN! You reached $" ++ formatCents model.balanceCents ++ "!", WinTone )
+
+        WentBust ->
+            ( "\u{1F480} REKT! You hit $0.00. Bankrupt.", LoseTone )
+
+        RanOutOfTime ->
+            ( "Time's up! You failed to reach the target.", LoseTone )
+
+
+{-| Only revealed at the end: what each coin actually did.
+-}
+viewCoinReveal : CoinConfig -> Html Msg
+viewCoinReveal coin =
+    Html.div [ Html.Attributes.class "bias-reveal" ]
+        [ Html.strong [] [ Html.text coin.coinName ]
+        , Html.text
+            (": heads "
+                ++ String.fromInt coin.winPercent
+                ++ "% of the time, paying "
+                ++ formatPayout coin.payoutPercent
+                ++ " the stake."
+            )
+        ]
+
+
+{-| A payout percent as a multiplier: 3000 -> "30x", 50 -> "0.5x".
+-}
+formatPayout : Int -> String
+formatPayout payoutPercent =
+    if modBy 100 payoutPercent == 0 then
+        String.fromInt (payoutPercent // 100) ++ "\u{00D7}"
+
+    else
+        String.fromInt (payoutPercent // 100)
+            ++ "."
+            ++ String.fromInt (modBy 100 payoutPercent // 10)
+            ++ "\u{00D7}"
+
+
+viewUncleSpend : UncleOffer -> Model -> List (Html Msg)
+viewUncleSpend offer model =
+    case offer of
+        NoUncleAdvice ->
+            []
+
+        UncleAdviceForSale uncle ->
+            if model.uncleAdviceCount == 0 then
+                []
+
+            else
+                [ Html.div []
+                    ([ Html.text "You paid uncle $"
+                     , Html.strong []
+                        [ Html.text (formatCents (model.uncleAdviceCount * uncle.priceCents)) ]
+                     , Html.text " for his advice."
+                     ]
+                        ++ viewUncleVerdict model.phase
+                    )
+                ]
+
+
+viewUncleVerdict : GamePhase -> List (Html Msg)
+viewUncleVerdict phase =
+    case phase of
+        Playing ->
+            []
+
+        WonGame ->
+            [ Html.span [ Html.Attributes.class "uncle-verdict" ]
+                [ Html.text " Congratulations on ignoring every word of it." ]
+            ]
+
+        WentBust ->
+            [ Html.span [ Html.Attributes.class "uncle-verdict" ]
+                [ Html.text " It shows." ]
+            ]
+
+        RanOutOfTime ->
+            [ Html.span [ Html.Attributes.class "uncle-verdict" ]
+                [ Html.text " It shows." ]
+            ]
+
+
+viewLog : Model -> Html Msg
+viewLog model =
+    Html.div [ Html.Attributes.class "log" ]
+        (List.map viewLogLine model.log)
+
+
+viewLogLine : LogLine -> Html Msg
+viewLogLine line =
+    case line.tone of
+        NeutralTone ->
+            Html.div [] [ Html.em [] [ Html.text line.text ] ]
+
+        WinTone ->
+            Html.div [ Html.Attributes.class (CoinFlipGame.toneClass line.tone) ]
+                [ Html.text line.text ]
+
+        LoseTone ->
+            Html.div [ Html.Attributes.class (CoinFlipGame.toneClass line.tone) ]
+                [ Html.text line.text ]

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -364,7 +364,9 @@ resolveCoin coin tally stake roll =
                             coin.coinName
                                 ++ " landed heads! You win $"
                                 ++ formatCents (stake + paidOut)
-                                ++ "."
+                                ++ ", of which $"
+                                ++ formatCents stake
+                                ++ " is your stake."
                       }
                     ]
                 }
@@ -499,6 +501,9 @@ purchaseGlasses offer model =
 
 
 {-| Pay uncle and draw one of his pre-programmed pearls of wisdom.
+Unlike the tracker and glasses, uncle happily takes your last dollars:
+spending yourself into bankruptcy on advice is a lesson the game wants
+to allow.
 -}
 purchaseUncleAdvice : UncleOffer -> Model -> ( Model, Cmd Msg )
 purchaseUncleAdvice offer model =
@@ -510,14 +515,15 @@ purchaseUncleAdvice offer model =
             if model.phase /= Playing then
                 ( model, Cmd.none )
 
-            else if model.balanceCents <= uncle.priceCents then
+            else if model.balanceCents < uncle.priceCents then
                 ( logLine NeutralTone "You cannot afford uncle's advice." model, Cmd.none )
 
             else
-                ( { model
-                    | balanceCents = model.balanceCents - uncle.priceCents
-                    , uncleAdviceCount = model.uncleAdviceCount + 1
-                  }
+                ( checkEndState
+                    { model
+                        | balanceCents = model.balanceCents - uncle.priceCents
+                        , uncleAdviceCount = model.uncleAdviceCount + 1
+                    }
                 , Random.generate UncleAdviceGiven
                     (Random.uniform uncle.firstPhrase uncle.morePhrases)
                 )

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -414,7 +414,8 @@ settleRound config landedRound model =
             roundLogLines =
                 List.concatMap .logLines outcomes
         in
-        checkEndState BustByBetting
+        checkEndState config.uncleOffer
+            BustByBetting
             { model
                 | balanceCents = newBalance
                 , tallies = List.map .tally outcomes
@@ -423,16 +424,29 @@ settleRound config landedRound model =
             }
 
 
-checkEndState : BustCause -> Model -> Model
-checkEndState causeIfBusted model =
+checkEndState : UncleOffer -> BustCause -> Model -> Model
+checkEndState uncleOffer causeIfBusted model =
     if model.balanceCents >= targetBalanceCents then
         { model | phase = WonGame }
 
     else if model.balanceCents <= 0 then
-        { model | phase = WentBust, bustCause = causeIfBusted }
+        uncleGloatsOnBust uncleOffer { model | phase = WentBust, bustCause = causeIfBusted }
 
     else
         model
+
+
+{-| The moment you go bankrupt, uncle pops into the log, if this level
+has an uncle at all.
+-}
+uncleGloatsOnBust : UncleOffer -> Model -> Model
+uncleGloatsOnBust offer model =
+    case offer of
+        NoUncleAdvice ->
+            model
+
+        UncleAdviceForSale _ ->
+            logLine NeutralTone "\u{1F9D3} Uncle: \u{201C}I'm proud of you kid\u{201D} \u{1F911}" model
 
 
 tickClock : Model -> Model
@@ -532,7 +546,8 @@ purchaseUncleAdvice offer model =
                 ( logLine NeutralTone "You cannot afford uncle's advice." model, Cmd.none )
 
             else
-                ( checkEndState BustByUncleAdvice
+                ( checkEndState offer
+                    BustByUncleAdvice
                     { model
                         | balanceCents = model.balanceCents - uncle.priceCents
                         , uncleAdviceCount = model.uncleAdviceCount + 1

--- a/elm/tests/CoinFlipGameTest.elm
+++ b/elm/tests/CoinFlipGameTest.elm
@@ -231,6 +231,20 @@ shopSuite =
                     { level2Start | balanceCents = 499 }
                     |> .uncleAdviceCount
                     |> Expect.equal 0
+        , test "going bust summons a proud uncle in the log" <|
+            \_ ->
+                apply CoinFlipLevel2.levelConfig
+                    [ landedFlip Heads 1000 Tails ]
+                    { level2Start | balanceCents = 1000 }
+                    |> latestLogText
+                    |> Expect.equal "\u{1F9D3} Uncle: \u{201C}I'm proud of you kid\u{201D} \u{1F911}"
+        , test "level 1 has no uncle to gloat on a bust" <|
+            \_ ->
+                apply CoinFlipLevel1.levelConfig
+                    [ landedFlip Heads 1000 Tails ]
+                    { level1Start | balanceCents = 1000 }
+                    |> latestLogText
+                    |> Expect.notEqual "\u{1F9D3} Uncle: \u{201C}I'm proud of you kid\u{201D} \u{1F911}"
         , test "uncle's advice ends up in the log" <|
             \_ ->
                 apply CoinFlipLevel2.levelConfig

--- a/elm/tests/CoinFlipGameTest.elm
+++ b/elm/tests/CoinFlipGameTest.elm
@@ -231,6 +231,22 @@ shopSuite =
                     { level2Start | balanceCents = 499 }
                     |> .uncleAdviceCount
                     |> Expect.equal 0
+        , test "busting on uncle's advice gloats after the advice lands, once" <|
+            \_ ->
+                let
+                    gloatLine =
+                        "\u{1F9D3} Uncle: \u{201C}I'm proud of you kid\u{201D} \u{1F911}"
+
+                    busted =
+                        apply CoinFlipLevel2.levelConfig
+                            [ UncleAdviceRequested, UncleAdviceGiven "Bet big." ]
+                            { level2Start | balanceCents = 500 }
+
+                    gloatCount =
+                        List.length (List.filter (\line -> line.text == gloatLine) busted.log)
+                in
+                ( latestLogText busted, gloatCount )
+                    |> Expect.equal ( gloatLine, 1 )
         , test "going bust summons a proud uncle in the log" <|
             \_ ->
                 apply CoinFlipLevel2.levelConfig

--- a/elm/tests/CoinFlipGameTest.elm
+++ b/elm/tests/CoinFlipGameTest.elm
@@ -283,9 +283,14 @@ gameOverSuite =
                 view CoinFlipLevel1.levelConfig { level1Start | phase = WentBust }
                     |> Query.fromHtml
                     |> Query.hasNot [ tag "a" ]
-        , test "level 2 has no next level to link on a win" <|
+        , test "level 2 links the next level on a win" <|
             \_ ->
                 view CoinFlipLevel2.levelConfig { level2Start | phase = WonGame }
+                    |> Query.fromHtml
+                    |> Query.has [ tag "a" ]
+        , test "level 2 shows no next-level link on a bust" <|
+            \_ ->
+                view CoinFlipLevel2.levelConfig { level2Start | phase = WentBust }
                     |> Query.fromHtml
                     |> Query.hasNot [ tag "a" ]
         , test "level 2 shows the bust ending only on a bust" <|

--- a/elm/tests/CoinFlipGameTest.elm
+++ b/elm/tests/CoinFlipGameTest.elm
@@ -214,11 +214,21 @@ shopSuite =
                 in
                 ( advised.balanceCents, advised.uncleAdviceCount )
                     |> Expect.equal ( 1500, 2 )
-        , test "uncle is refused when it would wipe the balance" <|
+        , test "spending the last dollars on uncle goes bust" <|
+            \_ ->
+                let
+                    busted =
+                        apply CoinFlipLevel2.levelConfig
+                            [ UncleAdviceRequested ]
+                            { level2Start | balanceCents = 500 }
+                in
+                ( busted.balanceCents, busted.phase, busted.uncleAdviceCount )
+                    |> Expect.equal ( 0, WentBust, 1 )
+        , test "uncle is refused below his price" <|
             \_ ->
                 apply CoinFlipLevel2.levelConfig
                     [ UncleAdviceRequested ]
-                    { level2Start | balanceCents = 500 }
+                    { level2Start | balanceCents = 499 }
                     |> .uncleAdviceCount
                     |> Expect.equal 0
         , test "uncle's advice ends up in the log" <|

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -1,0 +1,246 @@
+module MultiCoinGameTest exposing (flipSuite, gatingSuite, payoutSuite, shopSuite, stakeSuite)
+
+{-| Tests for the multi-coin engine behind level 3 (black-swan.html).
+They drive the real `update` with the real level config; the coins
+landing is a plain message (`CoinsLanded`), so outcomes are testable
+without running the random command. Level 3's coins: Swan wins on rolls
+1-5 paying 30x, Magpie on 1-45 paying 1x, Sparrow on 1-60 paying 0.5x.
+-}
+
+import CoinFlipGame
+    exposing
+        ( GamePhase(..)
+        , TrackerState(..)
+        )
+import CoinFlipLevel3
+import Expect
+import MultiCoinGame
+    exposing
+        ( Model
+        , Msg(..)
+        , StakeInput(..)
+        , formatPayout
+        , initialModel
+        , parseStake
+        , payoutCents
+        , update
+        , view
+        )
+import Test exposing (Test, describe, test)
+import Test.Html.Query as Query
+import Test.Html.Selector exposing (class)
+
+
+apply : List Msg -> Model -> Model
+apply msgs model =
+    List.foldl
+        (\msg current -> Tuple.first (update CoinFlipLevel3.levelConfig msg current))
+        model
+        msgs
+
+
+level3Start : Model
+level3Start =
+    initialModel CoinFlipLevel3.levelConfig
+
+
+landedRound : List Int -> List Int -> Msg
+landedRound stakes rolls =
+    CoinsLanded { stakes = stakes, rolls = rolls }
+
+
+latestLogText : Model -> String
+latestLogText model =
+    case List.head model.log of
+        Nothing ->
+            "<empty log>"
+
+        Just line ->
+            line.text
+
+
+flipSuite : Test
+flipSuite =
+    describe "MultiCoinGame settling a round"
+        [ test "a swan win pays thirty times the stake" <|
+            \_ ->
+                apply [ landedRound [ 100, 0, 0 ] [ 5, 100, 100 ] ] level3Start
+                    |> .balanceCents
+                    |> Expect.equal (2500 + 3000)
+        , test "a swan loss costs only the stake" <|
+            \_ ->
+                apply [ landedRound [ 100, 0, 0 ] [ 6, 100, 100 ] ] level3Start
+                    |> .balanceCents
+                    |> Expect.equal 2400
+        , test "all staked coins settle together from one balance" <|
+            \_ ->
+                -- swan roll 5 wins +3000, magpie roll 50 loses -200,
+                -- sparrow roll 50 wins +150 (half of 300)
+                apply [ landedRound [ 100, 200, 300 ] [ 5, 50, 50 ] ] level3Start
+                    |> .balanceCents
+                    |> Expect.equal (2500 + 3000 - 200 + 150)
+        , test "unstaked coins do not touch the balance or tallies" <|
+            \_ ->
+                let
+                    played =
+                        apply [ landedRound [ 0, 200, 0 ] [ 5, 50, 50 ] ] level3Start
+                in
+                ( played.balanceCents, List.map .flipCount played.tallies )
+                    |> Expect.equal ( 2300, [ 0, 1, 0 ] )
+        , test "tallies count heads per staked coin" <|
+            \_ ->
+                apply
+                    [ landedRound [ 100, 100, 100 ] [ 5, 50, 50 ]
+                    , landedRound [ 100, 100, 0 ] [ 90, 40, 50 ]
+                    ]
+                    level3Start
+                    |> .tallies
+                    |> Expect.equal
+                        [ { headsCount = 1, flipCount = 2 }
+                        , { headsCount = 1, flipCount = 2 }
+                        , { headsCount = 1, flipCount = 1 }
+                        ]
+        , test "losing the whole balance goes bust at exactly $0.00" <|
+            \_ ->
+                let
+                    busted =
+                        apply [ landedRound [ 100, 100, 100 ] [ 100, 100, 100 ] ]
+                            { level3Start | balanceCents = 300 }
+                in
+                ( busted.phase, busted.balanceCents )
+                    |> Expect.equal ( WentBust, 0 )
+        , test "reaching the target ends the game as won" <|
+            \_ ->
+                apply [ landedRound [ 100, 0, 0 ] [ 1, 100, 100 ] ]
+                    { level3Start | balanceCents = 97000 }
+                    |> .phase
+                    |> Expect.equal WonGame
+        , test "rounds landing after the game ended no longer settle" <|
+            \_ ->
+                apply [ landedRound [ 100, 0, 0 ] [ 1, 100, 100 ] ]
+                    { level3Start | phase = RanOutOfTime }
+                    |> .balanceCents
+                    |> Expect.equal 2500
+        ]
+
+
+stakeSuite : Test
+stakeSuite =
+    describe "MultiCoinGame stake validation on flip"
+        [ test "no stakes at all is refused" <|
+            \_ ->
+                apply [ FlipPressed ] level3Start
+                    |> latestLogText
+                    |> Expect.equal "Place a bet on at least one coin first."
+        , test "staking more than the balance is refused" <|
+            \_ ->
+                apply
+                    [ StakeInputChanged 0 "20.00"
+                    , StakeInputChanged 1 "10.00"
+                    , FlipPressed
+                    ]
+                    level3Start
+                    |> latestLogText
+                    |> Expect.equal "You cannot bet more than your current balance!"
+        , test "an unreadable stake is an error naming the coin, never a silent no-bet" <|
+            \_ ->
+                apply [ StakeInputChanged 1 "much", FlipPressed ] level3Start
+                    |> latestLogText
+                    |> Expect.equal "Cannot read your bet on Magpie."
+        , test "parseStake classifies blank, junk, and amounts" <|
+            \_ ->
+                ( parseStake "", parseStake "much", parseStake "1.50" )
+                    |> Expect.equal ( NoStake, UnreadableStake, Stake 150 )
+        , test "parseStake treats zero as no stake" <|
+            \_ ->
+                ( parseStake "0", parseStake "0.00" )
+                    |> Expect.equal ( NoStake, NoStake )
+        ]
+
+
+payoutSuite : Test
+payoutSuite =
+    describe "MultiCoinGame payouts"
+        [ test "payouts floor to whole cents" <|
+            \_ ->
+                payoutCents 50 3
+                    |> Expect.equal 1
+        , test "a win never pays zero cents" <|
+            \_ ->
+                payoutCents 50 1
+                    |> Expect.equal 1
+        , test "formatPayout renders whole and fractional multipliers" <|
+            \_ ->
+                ( formatPayout 3000, formatPayout 100, formatPayout 50 )
+                    |> Expect.equal ( "30\u{00D7}", "1\u{00D7}", "0.5\u{00D7}" )
+        ]
+
+
+shopSuite : Test
+shopSuite =
+    describe "MultiCoinGame shop"
+        [ test "buying the ratio tracker costs $15.00" <|
+            \_ ->
+                let
+                    bought =
+                        apply [ TrackerPurchased ] level3Start
+                in
+                ( bought.balanceCents, bought.tracker )
+                    |> Expect.equal ( 1000, TrackerBought )
+        , test "the tracker cannot be bought twice" <|
+            \_ ->
+                apply [ TrackerPurchased, TrackerPurchased ] level3Start
+                    |> .balanceCents
+                    |> Expect.equal 1000
+        , test "the tracker is refused when it would wipe the balance" <|
+            \_ ->
+                apply [ TrackerPurchased ] { level3Start | balanceCents = 1500 }
+                    |> .tracker
+                    |> Expect.equal TrackerNotBought
+        , test "uncle charges $5.00 per piece of advice" <|
+            \_ ->
+                let
+                    advised =
+                        apply [ UncleAdviceRequested, UncleAdviceRequested ] level3Start
+                in
+                ( advised.balanceCents, advised.uncleAdviceCount )
+                    |> Expect.equal ( 1500, 2 )
+        , test "uncle is refused when it would wipe the balance" <|
+            \_ ->
+                apply [ UncleAdviceRequested ] { level3Start | balanceCents = 500 }
+                    |> .uncleAdviceCount
+                    |> Expect.equal 0
+        ]
+
+
+gatingSuite : Test
+gatingSuite =
+    describe "MultiCoinGame view gating"
+        [ test "the tally only renders once the tracker is bought" <|
+            \_ ->
+                view CoinFlipLevel3.levelConfig level3Start
+                    |> Query.fromHtml
+                    |> Query.hasNot [ class "tally" ]
+        , test "the bought tracker renders the tally" <|
+            \_ ->
+                view CoinFlipLevel3.levelConfig { level3Start | tracker = TrackerBought }
+                    |> Query.fromHtml
+                    |> Query.has [ class "tally" ]
+        , test "bought uncle advice draws a verdict on a bust" <|
+            \_ ->
+                view CoinFlipLevel3.levelConfig
+                    { level3Start | phase = WentBust, uncleAdviceCount = 1 }
+                    |> Query.fromHtml
+                    |> Query.has [ class "uncle-verdict" ]
+        , test "the coin reveal only renders after the game ends" <|
+            \_ ->
+                view CoinFlipLevel3.levelConfig level3Start
+                    |> Query.fromHtml
+                    |> Query.hasNot [ class "bias-reveal" ]
+        , test "the ended game reveals every coin" <|
+            \_ ->
+                view CoinFlipLevel3.levelConfig { level3Start | phase = WonGame }
+                    |> Query.fromHtml
+                    |> Query.findAll [ class "bias-reveal" ]
+                    |> Query.count (Expect.equal 3)
+        ]

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -16,7 +16,8 @@ import CoinFlipLevel3
 import Expect
 import MultiCoinGame
     exposing
-        ( GoldenGlasses(..)
+        ( BustCause(..)
+        , GoldenGlasses(..)
         , Model
         , Msg(..)
         , StakeInput(..)
@@ -206,14 +207,20 @@ shopSuite =
                 in
                 ( advised.balanceCents, advised.uncleAdviceCount )
                     |> Expect.equal ( 1500, 2 )
-        , test "spending the last dollars on uncle goes bust" <|
+        , test "spending the last dollars on uncle goes bust, attributed to uncle" <|
             \_ ->
                 let
                     busted =
                         apply [ UncleAdviceRequested ] { level3Start | balanceCents = 500 }
                 in
-                ( busted.balanceCents, busted.phase, busted.uncleAdviceCount )
-                    |> Expect.equal ( 0, WentBust, 1 )
+                ( busted.balanceCents, busted.phase, busted.bustCause )
+                    |> Expect.equal ( 0, WentBust, BustByUncleAdvice )
+        , test "busting on a flip is attributed to betting" <|
+            \_ ->
+                apply [ landedRound [ 100, 0, 0 ] [ 100, 100, 100 ] ]
+                    { level3Start | balanceCents = 100 }
+                    |> .bustCause
+                    |> Expect.equal BustByBetting
         , test "uncle is refused below his price" <|
             \_ ->
                 apply [ UncleAdviceRequested ] { level3Start | balanceCents = 499 }
@@ -269,6 +276,19 @@ gatingSuite =
                     { level3Start | phase = WentBust, uncleAdviceCount = 1 }
                     |> Query.fromHtml
                     |> Query.has [ class "uncle-verdict" ]
+        , test "busting on uncle's advice draws the sad callout" <|
+            \_ ->
+                apply [ UncleAdviceRequested ] { level3Start | balanceCents = 500 }
+                    |> view CoinFlipLevel3.levelConfig
+                    |> Query.fromHtml
+                    |> Query.has [ class "uncle-bust" ]
+        , test "busting on a flip draws no uncle-bust callout" <|
+            \_ ->
+                apply [ landedRound [ 100, 0, 0 ] [ 100, 100, 100 ] ]
+                    { level3Start | balanceCents = 100 }
+                    |> view CoinFlipLevel3.levelConfig
+                    |> Query.fromHtml
+                    |> Query.hasNot [ class "uncle-bust" ]
         , test "the coin reveal only renders after the game ends" <|
             \_ ->
                 view CoinFlipLevel3.levelConfig level3Start

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -215,6 +215,21 @@ shopSuite =
                 in
                 ( busted.balanceCents, busted.phase, busted.bustCause )
                     |> Expect.equal ( 0, WentBust, BustByUncleAdvice )
+        , test "busting on uncle's advice gloats after the advice lands, once" <|
+            \_ ->
+                let
+                    gloatLine =
+                        "\u{1F9D3} Uncle: \u{201C}I'm proud of you kid\u{201D} \u{1F911}"
+
+                    busted =
+                        apply [ UncleAdviceRequested, UncleAdviceGiven "Bet big." ]
+                            { level3Start | balanceCents = 500 }
+
+                    gloatCount =
+                        List.length (List.filter (\line -> line.text == gloatLine) busted.log)
+                in
+                ( latestLogText busted, gloatCount )
+                    |> Expect.equal ( gloatLine, 1 )
         , test "going bust summons a proud uncle in the log" <|
             \_ ->
                 apply [ landedRound [ 100, 0, 0 ] [ 100, 100, 100 ] ]

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -16,7 +16,8 @@ import CoinFlipLevel3
 import Expect
 import MultiCoinGame
     exposing
-        ( Model
+        ( GoldenGlasses(..)
+        , Model
         , Msg(..)
         , StakeInput(..)
         , formatPayout
@@ -210,6 +211,24 @@ shopSuite =
                 apply [ UncleAdviceRequested ] { level3Start | balanceCents = 500 }
                     |> .uncleAdviceCount
                     |> Expect.equal 0
+        , test "buying the golden glasses costs $20.00" <|
+            \_ ->
+                let
+                    bought =
+                        apply [ GlassesPurchased ] level3Start
+                in
+                ( bought.balanceCents, bought.glasses )
+                    |> Expect.equal ( 500, GlassesBought )
+        , test "the glasses cannot be bought twice" <|
+            \_ ->
+                apply [ GlassesPurchased, GlassesPurchased ] level3Start
+                    |> .balanceCents
+                    |> Expect.equal 500
+        , test "the glasses are refused when they would wipe the balance" <|
+            \_ ->
+                apply [ GlassesPurchased ] { level3Start | balanceCents = 2000 }
+                    |> .glasses
+                    |> Expect.equal GlassesNotBought
         ]
 
 
@@ -226,6 +245,16 @@ gatingSuite =
                 view CoinFlipLevel3.levelConfig { level3Start | tracker = TrackerBought }
                     |> Query.fromHtml
                     |> Query.has [ class "tally" ]
+        , test "the payout line only renders once the glasses are bought" <|
+            \_ ->
+                view CoinFlipLevel3.levelConfig level3Start
+                    |> Query.fromHtml
+                    |> Query.hasNot [ class "glasses" ]
+        , test "the bought glasses render the payout line" <|
+            \_ ->
+                view CoinFlipLevel3.levelConfig { level3Start | glasses = GlassesBought }
+                    |> Query.fromHtml
+                    |> Query.has [ class "glasses" ]
         , test "bought uncle advice draws a verdict on a bust" <|
             \_ ->
                 view CoinFlipLevel3.levelConfig

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -215,6 +215,12 @@ shopSuite =
                 in
                 ( busted.balanceCents, busted.phase, busted.bustCause )
                     |> Expect.equal ( 0, WentBust, BustByUncleAdvice )
+        , test "going bust summons a proud uncle in the log" <|
+            \_ ->
+                apply [ landedRound [ 100, 0, 0 ] [ 100, 100, 100 ] ]
+                    { level3Start | balanceCents = 100 }
+                    |> latestLogText
+                    |> Expect.equal "\u{1F9D3} Uncle: \u{201C}I'm proud of you kid\u{201D} \u{1F911}"
         , test "busting on a flip is attributed to betting" <|
             \_ ->
                 apply [ landedRound [ 100, 0, 0 ] [ 100, 100, 100 ] ]

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -206,9 +206,17 @@ shopSuite =
                 in
                 ( advised.balanceCents, advised.uncleAdviceCount )
                     |> Expect.equal ( 1500, 2 )
-        , test "uncle is refused when it would wipe the balance" <|
+        , test "spending the last dollars on uncle goes bust" <|
             \_ ->
-                apply [ UncleAdviceRequested ] { level3Start | balanceCents = 500 }
+                let
+                    busted =
+                        apply [ UncleAdviceRequested ] { level3Start | balanceCents = 500 }
+                in
+                ( busted.balanceCents, busted.phase, busted.uncleAdviceCount )
+                    |> Expect.equal ( 0, WentBust, 1 )
+        , test "uncle is refused below his price" <|
+            \_ ->
+                apply [ UncleAdviceRequested ] { level3Start | balanceCents = 499 }
                     |> .uncleAdviceCount
                     |> Expect.equal 0
         , test "buying the golden glasses costs $20.00" <|

--- a/shake/Shakefile.hs
+++ b/shake/Shakefile.hs
@@ -141,6 +141,7 @@ shakeRules = do
       copyStaticAssets
       buildCoinFlipLevel1
       buildCoinFlipLevel2
+      buildCoinFlipLevel3
 
       -- Build penguin site
       need ["build-penguin"]
@@ -182,6 +183,7 @@ shakeRules = do
       copyStaticAssets
       buildCoinFlipLevel1
       buildCoinFlipLevel2
+      buildCoinFlipLevel3
 
       -- Build penguin + webwinkel sites, with penguin's webwinkelverhuis.nl
       -- links pointing at the locally served copy instead of the live site.
@@ -624,6 +626,10 @@ buildCoinFlipLevel1 = buildBlogElmApp "src/CoinFlipLevel1.elm" "coin-flip-level1
 -- | Level 2, hidden rewards (hidden-rewards.html).
 buildCoinFlipLevel2 :: Action ()
 buildCoinFlipLevel2 = buildBlogElmApp "src/CoinFlipLevel2.elm" "coin-flip-level2.js"
+
+-- | Level 3, the black swan (black-swan.html).
+buildCoinFlipLevel3 :: Action ()
+buildCoinFlipLevel3 = buildBlogElmApp "src/CoinFlipLevel3.elm" "coin-flip-level3.js"
 
 -- | The /prijzen price calculator.
 buildPrijsCalculator :: Action ()


### PR DESCRIPTION
## What

Level 3 of the rigged-coin series, mounted on the new post `black-swan.html` (TODO article, game only, same pattern as hidden-rewards).

- New `MultiCoinGame` engine: several named coins flip at once. The player stakes any amount on heads per coin and presses one FLIP button; only staked coins resolve, each with its own log line, and win logs state the exact payout ("Swan landed heads! Paid out $7.50 on your $0.25."). Win percents and payout multipliers are hidden until the end screen.
- `CoinFlipLevel3` configures the three birds:
  - **Swan**: heads 5% of the time paying 30× — the black swan, the only positive-EV bet (EV +0.5/unit, Kelly ≈ 1.8%).
  - **Magpie**: double or nothing at 45% — robs you slowly (EV −0.1).
  - **Sparrow**: wins 60% of the time but pays half the stake — frequent wins that bleed money (EV −0.1).
- Shop: the $15 ratio tracker paints a per-coin heads tally ("Swan 0/34 (0%) · …"), uncle sells bird-flavored terrible advice at $5 ("A swan bit me once. Never trust a swan.").
- The engine shares phases/clock/money/shop types with `CoinFlipGame` but has its own model and view (see the `Decision:` comment); stake validation is a sum type so a typo can never silently play as a $0 bet.
- Level 2's win text now links `<<next level>>` to the new post.

## Verification

- 140 Elm tests pass; the 26 new `MultiCoinGameTest` cases drive the real `update` with the real config (simultaneous settlement, payout flooring, validation refusals, tallies, bust/win/timeout, shop, view gating).
- Played live on the local serve: multi-stake rounds, payout logs, tracker tally, uncle, bust reveal; zero console errors.
- `nix-build nix/ci.nix` passes; the index carries no game scripts in summaries (regression from #151 holds for the new post).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
