### PR TITLE
Hide all end-screen odds; random winning side; shuffled bird profiles

### DIFF
--- a/elm/src/CoinFlipGame.elm
+++ b/elm/src/CoinFlipGame.elm
@@ -66,13 +66,14 @@ type CoinSide
 {-| How the coin is rigged for a level.
 
   - `KnownHeadsPercent`: the bias is fixed and printed on the bet buttons.
-  - `HiddenFavoredPercentRange`: the favored side's win percent is drawn
-    uniformly from the inclusive range at game start, and never shown.
+  - `HiddenRandomBias`: the favored side is drawn fifty-fifty and its win
+    percent uniformly from the inclusive range, both at game start, and
+    neither is ever shown, not even on the end screen.
 
 -}
 type CoinBias
     = KnownHeadsPercent Int
-    | HiddenFavoredPercentRange { favored : CoinSide, minPercent : Int, maxPercent : Int }
+    | HiddenRandomBias { minPercent : Int, maxPercent : Int }
 
 
 type TrackerOffer
@@ -220,7 +221,7 @@ initialModel config =
             KnownHeadsPercent percent ->
                 BiasReady { favored = Heads, favoredPercent = percent }
 
-            HiddenFavoredPercentRange _ ->
+            HiddenRandomBias _ ->
                 BiasUndrawn
     , phase = Playing
     , clock = ClockIdle
@@ -244,10 +245,13 @@ init config () =
         KnownHeadsPercent _ ->
             Cmd.none
 
-        HiddenFavoredPercentRange range ->
-            Random.generate
-                (\percent -> BiasDrawn { favored = range.favored, favoredPercent = percent })
-                (Random.int range.minPercent range.maxPercent)
+        HiddenRandomBias range ->
+            Random.generate BiasDrawn
+                (Random.map2
+                    (\favored percent -> { favored = favored, favoredPercent = percent })
+                    (Random.uniform Heads [ Tails ])
+                    (Random.int range.minPercent range.maxPercent)
+                )
     )
 
 
@@ -767,7 +771,7 @@ betButtonLabel bias side =
                 Tails ->
                     "Bet TAILS (" ++ String.fromInt (100 - headsPercent) ++ "%)"
 
-        HiddenFavoredPercentRange _ ->
+        HiddenRandomBias _ ->
             case side of
                 Heads ->
                     "Bet HEADS"
@@ -975,7 +979,9 @@ gameOverMessage model =
 
 
 {-| Only revealed at the end, so the reader can incriminate themselves
-first. Level 1 calls out tails bets; level 2 also reveals the drawn bias.
+first. Level 1 calls out tails bets against its printed bias; a hidden
+bias is never revealed, not even here: the reader has to earn that
+knowledge through the shop and their own tallying.
 -}
 viewBiasReveal : CoinBias -> Model -> List (Html Msg)
 viewBiasReveal bias model =
@@ -1000,54 +1006,8 @@ viewBiasReveal bias model =
                     ]
                 ]
 
-        HiddenFavoredPercentRange range ->
-            case model.biasState of
-                BiasUndrawn ->
-                    []
-
-                BiasReady actualBias ->
-                    List.concat
-                        [ [ Html.div []
-                                [ Html.text "The coin was rigged for "
-                                , Html.strong [] [ Html.text (String.toLower (sideName actualBias.favored)) ]
-                                , Html.text
-                                    (" this time: it wins "
-                                        ++ String.fromInt actualBias.favoredPercent
-                                        ++ "% of the flips."
-                                    )
-                                ]
-                          ]
-                        , viewLosingSideBets (oppositeSide range.favored) model
-                        ]
-
-
-viewLosingSideBets : CoinSide -> Model -> List (Html Msg)
-viewLosingSideBets losingSide model =
-    let
-        losingBetCount =
-            case losingSide of
-                Heads ->
-                    model.headsBetCount
-
-                Tails ->
-                    model.tailsBetCount
-    in
-    if losingBetCount == 0 then
-        []
-
-    else
-        [ Html.div []
-            [ Html.text ("You bet on " ++ String.toLower (sideName losingSide) ++ " ")
-            , Html.strong [] [ Html.text (String.fromInt losingBetCount) ]
-            , Html.text
-                (if losingBetCount == 1 then
-                    " time."
-
-                 else
-                    " times."
-                )
-            ]
-        ]
+        HiddenRandomBias _ ->
+            []
 
 
 viewLog : Model -> Html Msg

--- a/elm/src/CoinFlipLevel2.elm
+++ b/elm/src/CoinFlipLevel2.elm
@@ -1,16 +1,15 @@
 module CoinFlipLevel2 exposing (levelConfig, main)
 
-{-| Level 2 of the rigged-coin game: hidden rewards. The coin favors tails
-this time, with a win percent drawn between 55 and 65 at game start and
-never shown. The shop sells a ratio tracker (steep) and uncle's terrible
-advice (cheap, worth less).
+{-| Level 2 of the rigged-coin game: hidden rewards. Which side wins is
+drawn fifty-fifty at game start, its win percent between 55 and 65, and
+neither is ever shown, not even on the end screen. The shop sells a
+ratio tracker (steep) and uncle's terrible advice (cheap, worth less).
 -}
 
 import CoinFlipGame
     exposing
         ( BustEnding(..)
         , CoinBias(..)
-        , CoinSide(..)
         , LevelConfig
         , Model
         , Msg
@@ -24,7 +23,7 @@ import CoinFlipGame
 levelConfig : LevelConfig
 levelConfig =
     { title = "\u{1FA99} Rigged Coin Trader II: Hidden Rewards"
-    , bias = HiddenFavoredPercentRange { favored = Tails, minPercent = 55, maxPercent = 65 }
+    , bias = HiddenRandomBias { minPercent = 55, maxPercent = 65 }
     , trackerOffer = TrackerForSale 1500
     , uncleOffer =
         UncleAdviceForSale

--- a/elm/src/CoinFlipLevel3.elm
+++ b/elm/src/CoinFlipLevel3.elm
@@ -2,15 +2,16 @@ module CoinFlipLevel3 exposing (levelConfig, main)
 
 {-| Level 3 of the rigged-coin game: the black swan (black-swan.html).
 
-Three coins, everything hidden. Swan is the black swan: it almost never
-lands heads, but pays out huge, and it is the only coin worth betting.
-Magpie looks like a fair double-or-nothing but robs you slowly; Sparrow
-wins often but pays so little it bleeds you anyway.
+Three birds share three hidden profiles, dealt across the names at
+random on every game start: a black swan (rarely lands heads but pays
+out huge, the only bet worth taking), a double-or-nothing that robs you
+slowly, and a frequent winner that pays so little it bleeds you anyway.
+Which bird got which profile has to be rediscovered every replay.
 
 -}
 
 import CoinFlipGame exposing (TrackerOffer(..), UncleOffer(..))
-import MultiCoinGame exposing (GlassesOffer(..), Model, Msg, MultiCoinConfig, gameProgram)
+import MultiCoinGame exposing (GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), gameProgram)
 
 
 levelConfig : MultiCoinConfig
@@ -21,6 +22,7 @@ levelConfig =
         , { coinName = "Magpie", winPercent = 45, payoutPercent = 100 }
         , { coinName = "Sparrow", winPercent = 60, payoutPercent = 50 }
         ]
+    , profileAssignment = ProfilesShuffledAcrossCoins
     , trackerOffer = TrackerForSale 1500
     , glassesOffer = GoldenGlassesForSale 2000
     , uncleOffer =

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -7,12 +7,14 @@ module MultiCoinGame exposing
     , Model
     , Msg(..)
     , MultiCoinConfig
+    , ProfileAssignment(..)
     , StakeInput(..)
     , formatPayout
     , gameProgram
     , initialModel
     , parseStake
     , payoutCents
+    , shuffledCoinsGenerator
     , update
     , view
     )
@@ -90,9 +92,19 @@ type GoldenGlasses
     | GlassesBought
 
 
+{-| Whether the (win percent, payout) profiles play on the coins as
+written in the config, or get dealt across the coin names at random on
+every game start, so a replay means rediscovering which coin is which.
+-}
+type ProfileAssignment
+    = ProfilesAsWritten
+    | ProfilesShuffledAcrossCoins
+
+
 type alias MultiCoinConfig =
     { title : String
     , coins : List CoinConfig
+    , profileAssignment : ProfileAssignment
     , trackerOffer : TrackerOffer
     , uncleOffer : UncleOffer
     , glassesOffer : GlassesOffer
@@ -110,6 +122,7 @@ type alias CoinTally =
 
 type alias Model =
     { balanceCents : Int
+    , coins : List CoinConfig
     , stakeInputs : List String
     , tallies : List CoinTally
     , phase : GamePhase
@@ -136,7 +149,8 @@ type BustCause
 
 
 type Msg
-    = StakeInputChanged Int String
+    = ProfilesShuffled (List CoinConfig)
+    | StakeInputChanged Int String
     | FlipPressed
     | CoinsLanded { stakes : List Int, rolls : List Int }
     | ClockTicked
@@ -149,16 +163,55 @@ type Msg
 gameProgram : MultiCoinConfig -> Program () Model Msg
 gameProgram config =
     Browser.element
-        { init = \() -> ( initialModel config, Cmd.none )
+        { init = init config
         , update = update config
         , subscriptions = subscriptions
         , view = view config
         }
 
 
+-- Decision: with shuffled profiles the model briefly holds the coins as
+-- written until the ProfilesShuffled draw lands, one runtime tick after
+-- init. No pending state guards this window (unlike level 2's
+-- BiasUndrawn): the as-written assignment is itself a valid hidden
+-- assignment, no human can act within the tick, and gating every coin
+-- access on an assignment state doubled the case analysis for nothing.
+init : MultiCoinConfig -> () -> ( Model, Cmd Msg )
+init config () =
+    ( initialModel config
+    , case config.profileAssignment of
+        ProfilesAsWritten ->
+            Cmd.none
+
+        ProfilesShuffledAcrossCoins ->
+            Random.generate ProfilesShuffled (shuffledCoinsGenerator config.coins)
+    )
+
+
+{-| Deal the (win percent, payout) profiles across the coin names at
+random: the names keep their display order, the profiles land on a
+random coin each.
+-}
+shuffledCoinsGenerator : List CoinConfig -> Random.Generator (List CoinConfig)
+shuffledCoinsGenerator coins =
+    Random.map
+        (\sortKeys ->
+            List.map2
+                (\coin profile ->
+                    { coin | winPercent = profile.winPercent, payoutPercent = profile.payoutPercent }
+                )
+                coins
+                (List.map Tuple.second
+                    (List.sortBy Tuple.first (List.map2 Tuple.pair sortKeys coins))
+                )
+        )
+        (Random.list (List.length coins) (Random.float 0 1))
+
+
 initialModel : MultiCoinConfig -> Model
 initialModel config =
     { balanceCents = startingBalanceCents
+    , coins = config.coins
     , stakeInputs = List.map (\_ -> "0.00") config.coins
     , tallies = List.map (\_ -> { headsCount = 0, flipCount = 0 }) config.coins
     , phase = Playing
@@ -177,6 +230,9 @@ initialModel config =
 update : MultiCoinConfig -> Msg -> Model -> ( Model, Cmd Msg )
 update config msg model =
     case msg of
+        ProfilesShuffled shuffledCoins ->
+            ( { model | coins = shuffledCoins }, Cmd.none )
+
         StakeInputChanged coinIndex newInput ->
             ( { model
                 | stakeInputs =
@@ -259,7 +315,7 @@ pressFlip config model =
         ( model, Cmd.none )
 
     else
-        case validateStakes config.coins model.stakeInputs of
+        case validateStakes model.coins model.stakeInputs of
             UnreadableCoin coinName ->
                 ( logLine NeutralTone ("Cannot read your bet on " ++ coinName ++ ".") model
                 , Cmd.none
@@ -284,7 +340,7 @@ pressFlip config model =
                     ( { model | clock = ClockRunning }
                     , Random.generate
                         (\rolls -> CoinsLanded { stakes = stakes, rolls = rolls })
-                        (Random.list (List.length config.coins) (Random.int 1 100))
+                        (Random.list (List.length model.coins) (Random.int 1 100))
                     )
 
 
@@ -410,7 +466,7 @@ settleRound config landedRound model =
     else
         let
             outcomes =
-                List.map4 resolveCoin config.coins model.tallies landedRound.stakes landedRound.rolls
+                List.map4 resolveCoin model.coins model.tallies landedRound.stakes landedRound.rolls
 
             newBalance =
                 max 0 (model.balanceCents + List.sum (List.map .deltaCents outcomes))
@@ -664,14 +720,14 @@ viewControls config model =
     Html.div [ Html.Attributes.class "controls" ]
         (List.concat
             [ List.indexedMap viewCoinRow
-                (List.map2 Tuple.pair config.coins model.stakeInputs)
+                (List.map2 Tuple.pair model.coins model.stakeInputs)
             , [ Html.button
                     [ Html.Attributes.class "flip-button"
                     , Html.Events.onClick FlipPressed
                     ]
                     [ Html.text "FLIP" ]
               ]
-            , viewGlassesPayouts config model
+            , viewGlassesPayouts model
             , viewTally config model
             , viewShop config model
             ]
@@ -679,10 +735,12 @@ viewControls config model =
 
 
 {-| The payout multipliers the golden glasses reveal, under the flip
-button. Only the payouts: the win percents stay hidden.
+button. Only the payouts: the win percents stay hidden. Read from the
+model's coins, not the config: with shuffled profiles the glasses must
+report the deal actually in play.
 -}
-viewGlassesPayouts : MultiCoinConfig -> Model -> List (Html Msg)
-viewGlassesPayouts config model =
+viewGlassesPayouts : Model -> List (Html Msg)
+viewGlassesPayouts model =
     case model.glasses of
         GlassesNotBought ->
             []
@@ -694,7 +752,7 @@ viewGlassesPayouts config model =
                         ++ String.join " \u{00B7} "
                             (List.map
                                 (\coin -> coin.coinName ++ " " ++ formatPayout coin.payoutPercent)
-                                config.coins
+                                model.coins
                             )
                     )
                 ]
@@ -730,7 +788,7 @@ viewTally config model =
                 [ Html.text
                     ("\u{1F4CA} "
                         ++ String.join " \u{00B7} "
-                            (List.map2 coinTallyText config.coins model.tallies)
+                            (List.map2 coinTallyText model.coins model.tallies)
                     )
                 ]
             ]
@@ -834,7 +892,6 @@ viewGameOver config model =
                     , Html.text " presses to get here."
                     ]
               ]
-            , List.map viewCoinReveal config.coins
             , viewUncleSpend config.uncleOffer model
             ]
         )
@@ -869,22 +926,6 @@ gameOverMessage model =
 
         RanOutOfTime ->
             ( "Time's up! You failed to reach the target.", LoseTone )
-
-
-{-| Only revealed at the end: what each coin actually did.
--}
-viewCoinReveal : CoinConfig -> Html Msg
-viewCoinReveal coin =
-    Html.div [ Html.Attributes.class "bias-reveal" ]
-        [ Html.strong [] [ Html.text coin.coinName ]
-        , Html.text
-            (": heads "
-                ++ String.fromInt coin.winPercent
-                ++ "% of the time, paying "
-                ++ formatPayout coin.payoutPercent
-                ++ " the stake."
-            )
-        ]
 
 
 {-| A payout percent as a multiplier: 3000 -> "30x", 50 -> "0.5x".

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -1,4 +1,4 @@
-module MultiCoinGameTest exposing (flipSuite, gatingSuite, payoutSuite, shopSuite, stakeSuite)
+module MultiCoinGameTest exposing (flipSuite, gatingSuite, payoutSuite, shopSuite, shuffleSuite, stakeSuite)
 
 {-| Tests for the multi-coin engine behind level 3 (black-swan.html).
 They drive the real `update` with the real level config; the coins
@@ -25,12 +25,14 @@ import MultiCoinGame
         , initialModel
         , parseStake
         , payoutCents
+        , shuffledCoinsGenerator
         , update
         , view
         )
+import Random
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
-import Test.Html.Selector exposing (class)
+import Test.Html.Selector exposing (class, text)
 
 
 apply : List Msg -> Model -> Model
@@ -310,15 +312,80 @@ gatingSuite =
                     |> view CoinFlipLevel3.levelConfig
                     |> Query.fromHtml
                     |> Query.hasNot [ class "uncle-bust" ]
-        , test "the coin reveal only renders after the game ends" <|
-            \_ ->
-                view CoinFlipLevel3.levelConfig level3Start
-                    |> Query.fromHtml
-                    |> Query.hasNot [ class "bias-reveal" ]
-        , test "the ended game reveals every coin" <|
+        , test "the ended game keeps every coin's odds and payout hidden" <|
             \_ ->
                 view CoinFlipLevel3.levelConfig { level3Start | phase = WonGame }
                     |> Query.fromHtml
-                    |> Query.findAll [ class "bias-reveal" ]
-                    |> Query.count (Expect.equal 3)
+                    |> Query.hasNot [ class "bias-reveal" ]
         ]
+
+
+shuffleSuite : Test
+shuffleSuite =
+    describe "MultiCoinGame profile shuffling"
+        [ test "the shuffled draw replaces the active coins" <|
+            \_ ->
+                let
+                    reassigned =
+                        [ { coinName = "Swan", winPercent = 60, payoutPercent = 50 }
+                        , { coinName = "Magpie", winPercent = 5, payoutPercent = 3000 }
+                        , { coinName = "Sparrow", winPercent = 45, payoutPercent = 100 }
+                        ]
+                in
+                apply [ ProfilesShuffled reassigned ] level3Start
+                    |> .coins
+                    |> Expect.equal reassigned
+        , test "settling uses the shuffled profiles, not the written ones" <|
+            \_ ->
+                -- After the reassignment above, Magpie carries the 30x
+                -- swan profile: a winning roll of 5 on Magpie pays 30x.
+                apply
+                    [ ProfilesShuffled
+                        [ { coinName = "Swan", winPercent = 60, payoutPercent = 50 }
+                        , { coinName = "Magpie", winPercent = 5, payoutPercent = 3000 }
+                        , { coinName = "Sparrow", winPercent = 45, payoutPercent = 100 }
+                        ]
+                    , landedRound [ 0, 100, 0 ] [ 50, 5, 50 ]
+                    ]
+                    level3Start
+                    |> .balanceCents
+                    |> Expect.equal (2500 + 3000)
+        , test "the glasses report the shuffled deal, not the written one" <|
+            \_ ->
+                apply
+                    [ ProfilesShuffled
+                        [ { coinName = "Swan", winPercent = 60, payoutPercent = 50 }
+                        , { coinName = "Magpie", winPercent = 5, payoutPercent = 3000 }
+                        , { coinName = "Sparrow", winPercent = 45, payoutPercent = 100 }
+                        ]
+                    ]
+                    { level3Start | glasses = GlassesBought }
+                    |> view CoinFlipLevel3.levelConfig
+                    |> Query.fromHtml
+                    |> Query.find [ class "glasses" ]
+                    |> Query.has [ text "Magpie 30\u{00D7}" ]
+        , test "shuffling keeps the names in place and deals every profile once" <|
+            \_ ->
+                let
+                    shuffled =
+                        Tuple.first
+                            (Random.step
+                                (shuffledCoinsGenerator CoinFlipLevel3.levelConfig.coins)
+                                (Random.initialSeed 42)
+                            )
+                in
+                ( List.map .coinName shuffled, sortedProfiles shuffled )
+                    |> Expect.equal
+                        ( [ "Swan", "Magpie", "Sparrow" ]
+                        , sortedProfiles CoinFlipLevel3.levelConfig.coins
+                        )
+        ]
+
+
+{-| The (win percent, payout) profiles of a coin list, order-insensitive,
+for comparing a shuffle against the original deal.
+-}
+sortedProfiles : List MultiCoinGame.CoinConfig -> List { winPercent : Int, payoutPercent : Int }
+sortedProfiles coins =
+    List.sortBy .winPercent
+        (List.map (\coin -> { winPercent = coin.winPercent, payoutPercent = coin.payoutPercent }) coins)


### PR DESCRIPTION
Follow-up to #152 (merged while this round was in flight); this PR carries the one commit that came after the merge.

- End screens on levels 2 and 3 no longer reveal any odds, sides, or payouts: that knowledge has to be earned via the shop and the player's own tallying. Level 1's known-bias tails callout stays.
- Level 2 now draws heads or tails as the winner fifty-fifty at game start (`HiddenRandomBias`), on top of the 55–65% percent draw, and its end screen no longer tells which side was rigged.
- Level 3 deals its three (odds, payout) profiles across Swan/Magpie/Sparrow at random every game start (`ProfilesShuffledAcrossCoins`), so a replay means rediscovering which bird is the black swan. A live browser check caught the golden glasses still reporting the as-written deal; they now read the model's active coins, regression-tested.
- Level 2's win screen keeps linking `<<next level>>` to black-swan.html.

158 Elm tests pass; verified live that fresh loads deal different profiles and both end screens stay silent. `nix-build nix/ci.nix` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
