### PR TITLE
Autoclicker in the level-3 shop: hold the flip button to auto-flip

### DIFF
--- a/content/black-swan.md
+++ b/content/black-swan.md
@@ -15,7 +15,7 @@ of a gambler may succeed.
     border: 2px solid #196019;
     border-radius: 6px;
     overflow: hidden;
-    max-width: 26em;
+    max-width: 34em;
     margin: 1.5em auto;
     padding: 0 1em 1em;
     font-family: "Inconsolata", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", monospace;
@@ -69,7 +69,8 @@ of a gambler may succeed.
     gap: 0.4em;
     text-align: left;
   }
-  #coin-flip-game .shop-header { font-weight: bold; }
+  #coin-flip-game .shop-toggle { width: 100%; text-align: left; font-weight: bold; }
+  #coin-flip-game .helpers { font-weight: bold; }
   #coin-flip-game .shop-item {
     display: flex;
     justify-content: space-between;

--- a/elm/src/CoinFlipLevel3.elm
+++ b/elm/src/CoinFlipLevel3.elm
@@ -11,7 +11,7 @@ Which bird got which profile has to be rediscovered every replay.
 -}
 
 import CoinFlipGame exposing (TrackerOffer(..), UncleOffer(..))
-import MultiCoinGame exposing (AutoclickerOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), gameProgram)
+import MultiCoinGame exposing (AutoclickerOffer(..), FlipHelperOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), gameProgram)
 
 
 levelConfig : MultiCoinConfig
@@ -26,6 +26,7 @@ levelConfig =
     , trackerOffer = TrackerForSale 1500
     , glassesOffer = GoldenGlassesForSale 2000
     , autoclickerOffer = AutoclickerForSale 1000
+    , flipHelperOffer = FlipHelpersForSale { basePriceCents = 100, priceIncreasePercent = 10 }
     , uncleOffer =
         UncleAdviceForSale
             { priceCents = 500

--- a/elm/src/CoinFlipLevel3.elm
+++ b/elm/src/CoinFlipLevel3.elm
@@ -11,7 +11,7 @@ Which bird got which profile has to be rediscovered every replay.
 -}
 
 import CoinFlipGame exposing (TrackerOffer(..), UncleOffer(..))
-import MultiCoinGame exposing (GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), gameProgram)
+import MultiCoinGame exposing (AutoclickerOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), gameProgram)
 
 
 levelConfig : MultiCoinConfig
@@ -25,6 +25,7 @@ levelConfig =
     , profileAssignment = ProfilesShuffledAcrossCoins
     , trackerOffer = TrackerForSale 1500
     , glassesOffer = GoldenGlassesForSale 2000
+    , autoclickerOffer = AutoclickerForSale 1000
     , uncleOffer =
         UncleAdviceForSale
             { priceCents = 500

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -4,6 +4,7 @@ module MultiCoinGame exposing
     , BustCause(..)
     , CoinConfig
     , CoinTally
+    , FlipHelperOffer(..)
     , FlipHold(..)
     , GlassesOffer(..)
     , GoldenGlasses(..)
@@ -11,6 +12,7 @@ module MultiCoinGame exposing
     , Msg(..)
     , MultiCoinConfig
     , ProfileAssignment(..)
+    , ShopFold(..)
     , StakeInput(..)
     , formatPayout
     , gameProgram
@@ -118,6 +120,24 @@ type FlipHold
     | FlipHeld
 
 
+{-| Flip helpers flip for the player: each one presses flip once per
+five seconds, staggered, so owning N means a flip every 5000/N ms. The
+price starts at the base and rises by the given percent on every hire,
+compounding: automation gets progressively more expensive.
+-}
+type FlipHelperOffer
+    = NoFlipHelpers
+    | FlipHelpersForSale { basePriceCents : Int, priceIncreasePercent : Int }
+
+
+{-| The shop folds away behind its header and starts collapsed, so the
+game opens on the bets, not the catalogue.
+-}
+type ShopFold
+    = ShopCollapsed
+    | ShopExpanded
+
+
 {-| Whether the (win percent, payout) profiles play on the coins as
 written in the config, or get dealt across the coin names at random on
 every game start, so a replay means rediscovering which coin is which.
@@ -135,6 +155,7 @@ type alias MultiCoinConfig =
     , uncleOffer : UncleOffer
     , glassesOffer : GlassesOffer
     , autoclickerOffer : AutoclickerOffer
+    , flipHelperOffer : FlipHelperOffer
     , introLogLine : String
     }
 
@@ -160,6 +181,9 @@ type alias Model =
     , glasses : GoldenGlasses
     , autoclicker : Autoclicker
     , flipHold : FlipHold
+    , flipHelperCount : Int
+    , nextHelperPriceCents : Int
+    , shopFold : ShopFold
     , uncleAdviceCount : Int
     , uncleGloat : UncleGloat
     , bustCause : BustCause
@@ -184,6 +208,9 @@ type Msg
     | FlipHoldStarted
     | FlipHoldEnded
     | AutoclickerTicked
+    | FlipHelperHired
+    | FlipHelpersTicked
+    | ShopToggled
     | CoinsLanded { stakes : List Int, rolls : List Int }
     | ClockTicked
     | TrackerPurchased
@@ -255,6 +282,9 @@ initialModel config =
     , glasses = GlassesNotBought
     , autoclicker = ClickerNotBought
     , flipHold = FlipReleased
+    , flipHelperCount = 0
+    , nextHelperPriceCents = initialHelperPriceCents config.flipHelperOffer
+    , shopFold = ShopCollapsed
     , uncleAdviceCount = 0
     , uncleGloat = UncleHasNotGloated
     , bustCause = NotBusted
@@ -295,6 +325,25 @@ update config msg model =
 
         AutoclickerTicked ->
             pressFlip config model
+
+        FlipHelperHired ->
+            ( hireFlipHelper config.flipHelperOffer model, Cmd.none )
+
+        FlipHelpersTicked ->
+            pressFlip config model
+
+        ShopToggled ->
+            ( { model
+                | shopFold =
+                    case model.shopFold of
+                        ShopCollapsed ->
+                            ShopExpanded
+
+                        ShopExpanded ->
+                            ShopCollapsed
+              }
+            , Cmd.none
+            )
 
         CoinsLanded landedRound ->
             ( settleRound config landedRound model, Cmd.none )
@@ -644,6 +693,59 @@ purchaseGlasses offer model =
                     }
 
 
+{-| What the very first flip helper costs. Zero without an offer, which
+is never read: hiring is impossible when no helpers are for sale, the
+purchase path matches on the offer before touching the price.
+-}
+initialHelperPriceCents : FlipHelperOffer -> Int
+initialHelperPriceCents offer =
+    case offer of
+        NoFlipHelpers ->
+            0
+
+        FlipHelpersForSale sale ->
+            sale.basePriceCents
+
+
+{-| Hire one more flip helper at the current price, then raise the
+price for the next one. Same wipe-out guard as the other equipment.
+-}
+hireFlipHelper : FlipHelperOffer -> Model -> Model
+hireFlipHelper offer model =
+    case offer of
+        NoFlipHelpers ->
+            model
+
+        FlipHelpersForSale sale ->
+            if model.phase /= Playing then
+                model
+
+            else if model.balanceCents <= model.nextHelperPriceCents then
+                logLine NeutralTone "You cannot afford another flip helper." model
+
+            else
+                logLine NeutralTone
+                    ("Hired flip helper number "
+                        ++ String.fromInt (model.flipHelperCount + 1)
+                        ++ " for $"
+                        ++ formatCents model.nextHelperPriceCents
+                        ++ ". Each helper flips once per five seconds."
+                    )
+                    { model
+                        | balanceCents = model.balanceCents - model.nextHelperPriceCents
+                        , flipHelperCount = model.flipHelperCount + 1
+                        , nextHelperPriceCents =
+                            raisePriceByPercent sale.priceIncreasePercent model.nextHelperPriceCents
+                    }
+
+
+{-| A price raised by the given percent, rounded to whole cents.
+-}
+raisePriceByPercent : Int -> Int -> Int
+raisePriceByPercent increasePercent priceCents =
+    (priceCents * (100 + increasePercent) + 50) // 100
+
+
 {-| Buy the autoclicker. Same wipe-out guard as the tracker.
 -}
 purchaseAutoclicker : AutoclickerOffer -> Model -> Model
@@ -716,7 +818,35 @@ logLine tone text model =
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
-    Sub.batch [ clockSubscription model, autoclickerSubscription model ]
+    Sub.batch
+        [ clockSubscription model
+        , autoclickerSubscription model
+        , flipHelperSubscription model
+        ]
+
+
+{-| Each hired helper flips once per five seconds, staggered: N helpers
+share one timer at 5000/N ms, which is N evenly spread flips per five
+seconds.
+-}
+flipHelperSubscription : Model -> Sub Msg
+flipHelperSubscription model =
+    case model.phase of
+        Playing ->
+            if model.flipHelperCount > 0 then
+                Time.every (5000 / toFloat model.flipHelperCount) (\_ -> FlipHelpersTicked)
+
+            else
+                Sub.none
+
+        WonGame ->
+            Sub.none
+
+        WentBust ->
+            Sub.none
+
+        RanOutOfTime ->
+            Sub.none
 
 
 clockSubscription : Model -> Sub Msg
@@ -845,9 +975,24 @@ viewControls config model =
               ]
             , viewGlassesPayouts model
             , viewTally config model
+            , viewFlipHelpers model
             , viewShop config model
             ]
         )
+
+
+{-| How many helpers are flipping for the player, shown once any are
+hired.
+-}
+viewFlipHelpers : Model -> List (Html Msg)
+viewFlipHelpers model =
+    if model.flipHelperCount == 0 then
+        []
+
+    else
+        [ Html.div [ Html.Attributes.class "helpers" ]
+            [ Html.text ("\u{1F424} Flip helpers: " ++ String.fromInt model.flipHelperCount) ]
+        ]
 
 
 {-| The payout multipliers the golden glasses reveal, under the flip
@@ -949,6 +1094,7 @@ viewShop config model =
         viewTrackerShopItem config.trackerOffer model
             ++ viewGlassesShopItem config.glassesOffer model
             ++ viewAutoclickerShopItem config.autoclickerOffer model
+            ++ viewFlipHelperShopItem config.flipHelperOffer model
             ++ viewUncleShopItem config.uncleOffer
     of
         [] ->
@@ -956,10 +1102,31 @@ viewShop config model =
 
         shopItems ->
             [ Html.div [ Html.Attributes.class "shop" ]
-                (Html.div [ Html.Attributes.class "shop-header" ] [ Html.text "\u{1F6D2} Shop" ]
-                    :: shopItems
+                (viewShopToggle model.shopFold
+                    :: (case model.shopFold of
+                            ShopCollapsed ->
+                                []
+
+                            ShopExpanded ->
+                                shopItems
+                       )
                 )
             ]
+
+
+viewShopToggle : ShopFold -> Html Msg
+viewShopToggle fold =
+    Html.button
+        [ Html.Attributes.class "shop-toggle", Html.Events.onClick ShopToggled ]
+        [ Html.text
+            (case fold of
+                ShopCollapsed ->
+                    "\u{1F6D2} Shop \u{25B8}"
+
+                ShopExpanded ->
+                    "\u{1F6D2} Shop \u{25BE}"
+            )
+        ]
 
 
 viewShopItem : Msg -> String -> Int -> Html Msg
@@ -1017,6 +1184,19 @@ viewAutoclickerShopItem offer model =
 
         ( AutoclickerForSale priceCents, ClickerNotBought ) ->
             [ viewShopItem AutoclickerPurchased "Buy autoclicker" priceCents ]
+
+
+{-| Unlike the one-shot equipment, helpers stay for sale forever: the
+price just keeps climbing.
+-}
+viewFlipHelperShopItem : FlipHelperOffer -> Model -> List (Html Msg)
+viewFlipHelperShopItem offer model =
+    case offer of
+        NoFlipHelpers ->
+            []
+
+        FlipHelpersForSale _ ->
+            [ viewShopItem FlipHelperHired "Hire flip helper" model.nextHelperPriceCents ]
 
 
 viewUncleShopItem : UncleOffer -> List (Html Msg)

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -1,7 +1,10 @@
 module MultiCoinGame exposing
-    ( BustCause(..)
+    ( Autoclicker(..)
+    , AutoclickerOffer(..)
+    , BustCause(..)
     , CoinConfig
     , CoinTally
+    , FlipHold(..)
     , GlassesOffer(..)
     , GoldenGlasses(..)
     , Model
@@ -64,6 +67,7 @@ import CoinFlipGame
 import Html exposing (Html)
 import Html.Attributes
 import Html.Events
+import Json.Decode as Decode
 import Random
 import Time
 
@@ -92,6 +96,28 @@ type GoldenGlasses
     | GlassesBought
 
 
+{-| The autoclicker spares the player's mouse finger: once bought,
+holding the flip button down fires a flip every 100ms. Price in cents.
+-}
+type AutoclickerOffer
+    = NoAutoclicker
+    | AutoclickerForSale Int
+
+
+type Autoclicker
+    = ClickerNotBought
+    | ClickerBought
+
+
+{-| Whether the flip button is currently held down (mouse or touch).
+Only meaningful with a bought autoclicker: the auto-flip subscription
+runs while held.
+-}
+type FlipHold
+    = FlipReleased
+    | FlipHeld
+
+
 {-| Whether the (win percent, payout) profiles play on the coins as
 written in the config, or get dealt across the coin names at random on
 every game start, so a replay means rediscovering which coin is which.
@@ -108,6 +134,7 @@ type alias MultiCoinConfig =
     , trackerOffer : TrackerOffer
     , uncleOffer : UncleOffer
     , glassesOffer : GlassesOffer
+    , autoclickerOffer : AutoclickerOffer
     , introLogLine : String
     }
 
@@ -131,6 +158,8 @@ type alias Model =
     , roundCount : Int
     , tracker : TrackerState
     , glasses : GoldenGlasses
+    , autoclicker : Autoclicker
+    , flipHold : FlipHold
     , uncleAdviceCount : Int
     , uncleGloat : UncleGloat
     , bustCause : BustCause
@@ -152,10 +181,14 @@ type Msg
     = ProfilesShuffled (List CoinConfig)
     | StakeInputChanged Int String
     | FlipPressed
+    | FlipHoldStarted
+    | FlipHoldEnded
+    | AutoclickerTicked
     | CoinsLanded { stakes : List Int, rolls : List Int }
     | ClockTicked
     | TrackerPurchased
     | GlassesPurchased
+    | AutoclickerPurchased
     | UncleAdviceRequested
     | UncleAdviceGiven String
 
@@ -220,6 +253,8 @@ initialModel config =
     , roundCount = 0
     , tracker = TrackerNotBought
     , glasses = GlassesNotBought
+    , autoclicker = ClickerNotBought
+    , flipHold = FlipReleased
     , uncleAdviceCount = 0
     , uncleGloat = UncleHasNotGloated
     , bustCause = NotBusted
@@ -252,6 +287,15 @@ update config msg model =
         FlipPressed ->
             pressFlip config model
 
+        FlipHoldStarted ->
+            ( { model | flipHold = FlipHeld }, Cmd.none )
+
+        FlipHoldEnded ->
+            ( { model | flipHold = FlipReleased }, Cmd.none )
+
+        AutoclickerTicked ->
+            pressFlip config model
+
         CoinsLanded landedRound ->
             ( settleRound config landedRound model, Cmd.none )
 
@@ -263,6 +307,9 @@ update config msg model =
 
         GlassesPurchased ->
             ( purchaseGlasses config.glassesOffer model, Cmd.none )
+
+        AutoclickerPurchased ->
+            ( purchaseAutoclicker config.autoclickerOffer model, Cmd.none )
 
         UncleAdviceRequested ->
             purchaseUncleAdvice config.uncleOffer model
@@ -597,6 +644,39 @@ purchaseGlasses offer model =
                     }
 
 
+{-| Buy the autoclicker. Same wipe-out guard as the tracker.
+-}
+purchaseAutoclicker : AutoclickerOffer -> Model -> Model
+purchaseAutoclicker offer model =
+    case ( offer, model.autoclicker ) of
+        ( NoAutoclicker, ClickerNotBought ) ->
+            model
+
+        ( NoAutoclicker, ClickerBought ) ->
+            model
+
+        ( AutoclickerForSale _, ClickerBought ) ->
+            model
+
+        ( AutoclickerForSale priceCents, ClickerNotBought ) ->
+            if model.phase /= Playing then
+                model
+
+            else if model.balanceCents <= priceCents then
+                logLine NeutralTone "You cannot afford the autoclicker." model
+
+            else
+                logLine NeutralTone
+                    ("Bought the autoclicker for $"
+                        ++ formatCents priceCents
+                        ++ ". Hold the flip button down to use it."
+                    )
+                    { model
+                        | balanceCents = model.balanceCents - priceCents
+                        , autoclicker = ClickerBought
+                    }
+
+
 {-| Pay uncle and draw one of his pre-programmed pearls of wisdom.
 Unlike the tracker and glasses, uncle happily takes your last dollars:
 spending yourself into bankruptcy on advice is a lesson the game wants
@@ -636,6 +716,11 @@ logLine tone text model =
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
+    Sub.batch [ clockSubscription model, autoclickerSubscription model ]
+
+
+clockSubscription : Model -> Sub Msg
+clockSubscription model =
     case model.phase of
         Playing ->
             case model.clock of
@@ -643,6 +728,36 @@ subscriptions model =
                     Time.every 1000 (\_ -> ClockTicked)
 
                 ClockIdle ->
+                    Sub.none
+
+        WonGame ->
+            Sub.none
+
+        WentBust ->
+            Sub.none
+
+        RanOutOfTime ->
+            Sub.none
+
+
+{-| While a bought autoclicker's flip button is held down, a flip fires
+every 100ms.
+-}
+autoclickerSubscription : Model -> Sub Msg
+autoclickerSubscription model =
+    case model.phase of
+        Playing ->
+            case ( model.autoclicker, model.flipHold ) of
+                ( ClickerBought, FlipHeld ) ->
+                    Time.every 100 (\_ -> AutoclickerTicked)
+
+                ( ClickerBought, FlipReleased ) ->
+                    Sub.none
+
+                ( ClickerNotBought, FlipHeld ) ->
+                    Sub.none
+
+                ( ClickerNotBought, FlipReleased ) ->
                     Sub.none
 
         WonGame ->
@@ -722,9 +837,10 @@ viewControls config model =
             [ List.indexedMap viewCoinRow
                 (List.map2 Tuple.pair model.coins model.stakeInputs)
             , [ Html.button
-                    [ Html.Attributes.class "flip-button"
-                    , Html.Events.onClick FlipPressed
-                    ]
+                    (Html.Attributes.class "flip-button"
+                        :: Html.Events.onClick FlipPressed
+                        :: flipHoldEvents model.autoclicker
+                    )
                     [ Html.text "FLIP" ]
               ]
             , viewGlassesPayouts model
@@ -756,6 +872,27 @@ viewGlassesPayouts model =
                             )
                     )
                 ]
+            ]
+
+
+{-| Hold events for the flip button, mouse and touch. Only attached once
+the autoclicker is bought, so an unbought game never tracks hold state.
+Mouse-leave and touch-cancel count as releasing: dragging off the button
+must not leave the clicker running.
+-}
+flipHoldEvents : Autoclicker -> List (Html.Attribute Msg)
+flipHoldEvents clicker =
+    case clicker of
+        ClickerNotBought ->
+            []
+
+        ClickerBought ->
+            [ Html.Events.onMouseDown FlipHoldStarted
+            , Html.Events.onMouseUp FlipHoldEnded
+            , Html.Events.onMouseLeave FlipHoldEnded
+            , Html.Events.on "touchstart" (Decode.succeed FlipHoldStarted)
+            , Html.Events.on "touchend" (Decode.succeed FlipHoldEnded)
+            , Html.Events.on "touchcancel" (Decode.succeed FlipHoldEnded)
             ]
 
 
@@ -811,6 +948,7 @@ viewShop config model =
     case
         viewTrackerShopItem config.trackerOffer model
             ++ viewGlassesShopItem config.glassesOffer model
+            ++ viewAutoclickerShopItem config.autoclickerOffer model
             ++ viewUncleShopItem config.uncleOffer
     of
         [] ->
@@ -863,6 +1001,22 @@ viewGlassesShopItem offer model =
 
         ( GoldenGlassesForSale priceCents, GlassesNotBought ) ->
             [ viewShopItem GlassesPurchased "Buy golden glasses" priceCents ]
+
+
+viewAutoclickerShopItem : AutoclickerOffer -> Model -> List (Html Msg)
+viewAutoclickerShopItem offer model =
+    case ( offer, model.autoclicker ) of
+        ( NoAutoclicker, ClickerNotBought ) ->
+            []
+
+        ( NoAutoclicker, ClickerBought ) ->
+            []
+
+        ( AutoclickerForSale _, ClickerBought ) ->
+            []
+
+        ( AutoclickerForSale priceCents, ClickerNotBought ) ->
+            [ viewShopItem AutoclickerPurchased "Buy autoclicker" priceCents ]
 
 
 viewUncleShopItem : UncleOffer -> List (Html Msg)

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -280,6 +280,32 @@ shopSuite =
                 apply [ AutoclickerTicked ] level3Start
                     |> latestLogText
                     |> Expect.equal "Place a bet on at least one coin first."
+        , test "hiring a flip helper costs the base price and raises the next one by 10%" <|
+            \_ ->
+                let
+                    hired =
+                        apply [ FlipHelperHired ] level3Start
+                in
+                ( hired.balanceCents, hired.flipHelperCount, hired.nextHelperPriceCents )
+                    |> Expect.equal ( 2400, 1, 110 )
+        , test "helper prices compound per hire" <|
+            \_ ->
+                let
+                    hired =
+                        apply [ FlipHelperHired, FlipHelperHired, FlipHelperHired ] level3Start
+                in
+                ( hired.balanceCents, hired.flipHelperCount, hired.nextHelperPriceCents )
+                    |> Expect.equal ( 2500 - 100 - 110 - 121, 3, 133 )
+        , test "a helper hire is refused when it would wipe the balance" <|
+            \_ ->
+                apply [ FlipHelperHired ] { level3Start | balanceCents = 100 }
+                    |> .flipHelperCount
+                    |> Expect.equal 0
+        , test "a helper tick validates stakes exactly like a manual flip" <|
+            \_ ->
+                apply [ FlipHelpersTicked ] level3Start
+                    |> latestLogText
+                    |> Expect.equal "Place a bet on at least one coin first."
         , test "buying the golden glasses costs $20.00" <|
             \_ ->
                 let
@@ -314,6 +340,34 @@ gatingSuite =
                 view CoinFlipLevel3.levelConfig { level3Start | tracker = TrackerBought }
                     |> Query.fromHtml
                     |> Query.has [ class "tally" ]
+        , test "the shop starts collapsed with no items visible" <|
+            \_ ->
+                view CoinFlipLevel3.levelConfig level3Start
+                    |> Query.fromHtml
+                    |> Query.hasNot [ class "shop-item" ]
+        , test "toggling the shop reveals the items" <|
+            \_ ->
+                apply [ ShopToggled ] level3Start
+                    |> view CoinFlipLevel3.levelConfig
+                    |> Query.fromHtml
+                    |> Query.has [ class "shop-item" ]
+        , test "toggling twice collapses the shop again" <|
+            \_ ->
+                apply [ ShopToggled, ShopToggled ] level3Start
+                    |> view CoinFlipLevel3.levelConfig
+                    |> Query.fromHtml
+                    |> Query.hasNot [ class "shop-item" ]
+        , test "the helper count only renders once helpers are hired" <|
+            \_ ->
+                ( view CoinFlipLevel3.levelConfig level3Start
+                    |> Query.fromHtml
+                    |> Query.hasNot [ class "helpers" ]
+                , apply [ FlipHelperHired ] level3Start
+                    |> view CoinFlipLevel3.levelConfig
+                    |> Query.fromHtml
+                    |> Query.has [ class "helpers" ]
+                )
+                    |> (\( noHelpers, oneHelper ) -> Expect.all [ \_ -> noHelpers, \_ -> oneHelper ] ())
         , test "the payout line only renders once the glasses are bought" <|
             \_ ->
                 view CoinFlipLevel3.levelConfig level3Start

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -16,7 +16,9 @@ import CoinFlipLevel3
 import Expect
 import MultiCoinGame
     exposing
-        ( BustCause(..)
+        ( Autoclicker(..)
+        , BustCause(..)
+        , FlipHold(..)
         , GoldenGlasses(..)
         , Model
         , Msg(..)
@@ -249,6 +251,35 @@ shopSuite =
                 apply [ UncleAdviceRequested ] { level3Start | balanceCents = 499 }
                     |> .uncleAdviceCount
                     |> Expect.equal 0
+        , test "buying the autoclicker costs $10.00" <|
+            \_ ->
+                let
+                    bought =
+                        apply [ AutoclickerPurchased ] level3Start
+                in
+                ( bought.balanceCents, bought.autoclicker )
+                    |> Expect.equal ( 1500, ClickerBought )
+        , test "the autoclicker cannot be bought twice" <|
+            \_ ->
+                apply [ AutoclickerPurchased, AutoclickerPurchased ] level3Start
+                    |> .balanceCents
+                    |> Expect.equal 1500
+        , test "the autoclicker is refused when it would wipe the balance" <|
+            \_ ->
+                apply [ AutoclickerPurchased ] { level3Start | balanceCents = 1000 }
+                    |> .autoclicker
+                    |> Expect.equal ClickerNotBought
+        , test "holding and releasing the flip button tracks the hold state" <|
+            \_ ->
+                ( apply [ FlipHoldStarted ] level3Start |> .flipHold
+                , apply [ FlipHoldStarted, FlipHoldEnded ] level3Start |> .flipHold
+                )
+                    |> Expect.equal ( FlipHeld, FlipReleased )
+        , test "an autoclicker tick validates stakes exactly like a manual flip" <|
+            \_ ->
+                apply [ AutoclickerTicked ] level3Start
+                    |> latestLogText
+                    |> Expect.equal "Place a bet on at least one coin first."
         , test "buying the golden glasses costs $20.00" <|
             \_ ->
                 let


### PR DESCRIPTION
Shop automation for tired mouse fingers on black-swan.html, plus two UI fixes.

## Autoclicker ($10, one-shot)

Once bought, holding the FLIP button down fires a flip every 100ms (mouse and touch; dragging off or touch-cancel releases). The subscription is gated on playing-phase, purchase, and hold state, so it stops on game end and release. Verified live: hold ~1.1s → 12 flips, release → count frozen.

## Flip helpers ($1 base, +10% compounding per hire, repeatable)

Each hired helper flips once per five seconds, staggered: N helpers share one timer at 5000/N ms. Prices climb $1.00 → $1.10 → $1.21 → $1.33 (rounded to whole cents), the hired count shows under the flip button ("🐤 Flip helpers: N"), and they stay for sale forever. Verified live: two helpers produced exactly 2 hands-free flips in 5.5s.

## UI

- The shop folds behind its header button and starts collapsed (verified 0 items → 5 open → 0 re-collapsed).
- The game container widens 26em → 34em so win log lines ("Sparrow landed heads! You win $155.00, of which $5.00 is your stake.") fit on a single line (verified single-line height).

All automated flips (autoclicker ticks and helper ticks) run through the exact same stake validation as manual presses. 171 Elm tests pass (purchase guards, price compounding, hold-state tracking, tick/manual validation parity, shop fold and helper-count gating). `nix-build nix/ci.nix` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
