### PR TITLE
Level 2 gets the shop upgrades; shared ShopDialog module

### DIFF
--- a/content/hidden-rewards.md
+++ b/content/hidden-rewards.md
@@ -62,7 +62,18 @@ I won't tell which. Good luck!
     gap: 0.4em;
     text-align: left;
   }
-  #coin-flip-game .shop-header { font-weight: bold; }
+  #coin-flip-game .shop-toggle { width: 100%; text-align: left; font-weight: bold; }
+  #coin-flip-game .purchase-dialog {
+    position: fixed;
+    z-index: 10;
+    width: 20em;
+    border: 1px solid #196019;
+    border-radius: 4px;
+    padding: 0.6em;
+    text-align: left;
+    background: #eafbea;
+  }
+  #coin-flip-game .dialog-actions { display: flex; gap: 0.6em; margin-bottom: 0.5em; }
   #coin-flip-game .shop-item {
     display: flex;
     justify-content: space-between;
@@ -96,6 +107,7 @@ I won't tell which. Good luck!
     #coin-flip-game .progress-track { background: #134013; }
     #coin-flip-game .win-text { color: #7dff7d; }
     #coin-flip-game .lose-text { color: #ff6b6b; }
+    #coin-flip-game .purchase-dialog { background: #062606; }
   }
 </style>
 

--- a/elm/src/CoinFlipGame.elm
+++ b/elm/src/CoinFlipGame.elm
@@ -11,6 +11,8 @@ module CoinFlipGame exposing
     , Msg(..)
     , BustEnding(..)
     , NextLevelLink(..)
+    , PendingPurchase(..)
+    , ShopItemKind(..)
     , TrackerOffer(..)
     , TrackerState(..)
     , UncleGloat(..)
@@ -51,10 +53,13 @@ rounded floats after every flip to paper over drift.
 -- and the test suite can drive it deterministically.
 
 import Browser
+import Browser.Events
 import Html exposing (Html)
 import Html.Attributes
 import Html.Events
+import Json.Decode as Decode
 import Random
+import ShopDialog exposing (ClickPoint, ShopFold(..))
 import Time
 
 
@@ -87,6 +92,23 @@ The phrase list is split head/tail so an empty list cannot be configured.
 type UncleOffer
     = NoUncleAdvice
     | UncleAdviceForSale { priceCents : Int, firstPhrase : String, morePhrases : List String }
+
+
+{-| The shop items the purchase dialog explains before any money moves.
+-}
+type ShopItemKind
+    = TrackerItem
+    | UncleAdviceItem
+
+
+{-| A purchase mid-consideration: clicking a shop item opens a dialog
+explaining it, and only confirming actually buys. Uncle's advice keeps
+the dialog open after confirming (repeat customers welcome); the
+tracker closes it.
+-}
+type PendingPurchase
+    = NoPendingPurchase
+    | Considering ShopItemKind ClickPoint
 
 
 {-| Shown in the win text when this level has a sequel to link to.
@@ -172,6 +194,8 @@ type alias Model =
     , headsLandedCount : Int
     , tailsLandedCount : Int
     , tracker : TrackerState
+    , shopFold : ShopFold
+    , pendingPurchase : PendingPurchase
     , uncleAdviceCount : Int
     , uncleGloat : UncleGloat
     , log : List LogLine
@@ -186,6 +210,11 @@ type Msg
     | CoinLanded { playerChoice : CoinSide, betCents : Int, landed : CoinSide }
     | ClockTicked
     | TrackerPurchased
+    | ShopToggled
+    | PurchaseConsidered ShopItemKind ClickPoint
+    | PurchaseConfirmed
+    | PurchaseCancelled
+    | DialogClicked
     | UncleAdviceRequested
     | UncleAdviceGiven String
 
@@ -232,6 +261,8 @@ initialModel config =
     , headsLandedCount = 0
     , tailsLandedCount = 0
     , tracker = TrackerNotBought
+    , shopFold = ShopCollapsed
+    , pendingPurchase = NoPendingPurchase
     , uncleAdviceCount = 0
     , uncleGloat = UncleHasNotGloated
     , log = [ { tone = NeutralTone, text = config.introLogLine } ]
@@ -284,6 +315,45 @@ update config msg model =
 
         TrackerPurchased ->
             ( purchaseTracker config.trackerOffer model, Cmd.none )
+
+        ShopToggled ->
+            ( { model
+                | shopFold =
+                    case model.shopFold of
+                        ShopCollapsed ->
+                            ShopExpanded
+
+                        ShopExpanded ->
+                            ShopCollapsed
+              }
+            , Cmd.none
+            )
+
+        PurchaseConsidered itemKind clickPoint ->
+            ( { model | pendingPurchase = Considering itemKind clickPoint }, Cmd.none )
+
+        PurchaseConfirmed ->
+            case model.pendingPurchase of
+                NoPendingPurchase ->
+                    ( model, Cmd.none )
+
+                Considering TrackerItem _ ->
+                    ( purchaseTracker config.trackerOffer
+                        { model | pendingPurchase = NoPendingPurchase }
+                    , Cmd.none
+                    )
+
+                Considering UncleAdviceItem _ ->
+                    -- Stays open: uncle appreciates repeat customers.
+                    purchaseUncleAdvice config.uncleOffer model
+
+        PurchaseCancelled ->
+            ( { model | pendingPurchase = NoPendingPurchase }, Cmd.none )
+
+        DialogClicked ->
+            -- A click inside the dialog, swallowed (stopPropagation) so
+            -- the document-level dismiss listener never sees it.
+            ( model, Cmd.none )
 
         UncleAdviceRequested ->
             purchaseUncleAdvice config.uncleOffer model
@@ -637,6 +707,25 @@ landedPercent sideCount totalFlips =
 
 subscriptions : Model -> Sub Msg
 subscriptions model =
+    Sub.batch [ clockSubscription model, dialogDismissSubscription model ]
+
+
+{-| While a purchase dialog is open, any document-level click closes it.
+Clicks inside the dialog and on the shop items stop propagation, so
+they never reach this listener: only genuinely-outside clicks dismiss.
+-}
+dialogDismissSubscription : Model -> Sub Msg
+dialogDismissSubscription model =
+    case model.pendingPurchase of
+        NoPendingPurchase ->
+            Sub.none
+
+        Considering _ _ ->
+            Browser.Events.onClick (Decode.succeed PurchaseCancelled)
+
+
+clockSubscription : Model -> Sub Msg
+clockSubscription model =
     case model.phase of
         Playing ->
             case model.clock of
@@ -814,22 +903,21 @@ viewShop config model =
 
         shopItems ->
             [ Html.div [ Html.Attributes.class "shop" ]
-                (Html.div [ Html.Attributes.class "shop-header" ] [ Html.text "\u{1F6D2} Shop" ]
-                    :: shopItems
+                (ShopDialog.viewShopToggle ShopToggled model.shopFold
+                    :: (case model.shopFold of
+                            ShopCollapsed ->
+                                []
+
+                            ShopExpanded ->
+                                shopItems ++ viewPurchaseDialog config model
+                       )
                 )
             ]
 
 
-{-| One row in the shop: item name left, price right, so the prices line
-up across items (the .shop-item CSS spreads the two spans apart).
--}
-viewShopItem : Msg -> String -> Int -> Html Msg
-viewShopItem onBuy itemName priceCents =
-    Html.button
-        [ Html.Attributes.class "shop-item", Html.Events.onClick onBuy ]
-        [ Html.span [] [ Html.text itemName ]
-        , Html.span [] [ Html.text ("$" ++ formatCents priceCents) ]
-        ]
+viewShopItem : (ClickPoint -> Msg) -> String -> Int -> Html Msg
+viewShopItem onBuyAt itemName priceCents =
+    ShopDialog.viewShopItem onBuyAt itemName ("$" ++ formatCents priceCents)
 
 
 viewTrackerShopItem : TrackerOffer -> Model -> List (Html Msg)
@@ -845,7 +933,7 @@ viewTrackerShopItem offer model =
             []
 
         ( TrackerForSale priceCents, TrackerNotBought ) ->
-            [ viewShopItem TrackerPurchased "Buy ratio tracker" priceCents ]
+            [ viewShopItem (PurchaseConsidered TrackerItem) "Buy ratio tracker" priceCents ]
 
 
 viewUncleShopItem : UncleOffer -> List (Html Msg)
@@ -855,7 +943,76 @@ viewUncleShopItem offer =
             []
 
         UncleAdviceForSale uncle ->
-            [ viewShopItem UncleAdviceRequested "Ask uncle for advice" uncle.priceCents ]
+            [ viewShopItem (PurchaseConsidered UncleAdviceItem) "Ask uncle for advice" uncle.priceCents ]
+
+
+viewPurchaseDialog : LevelConfig -> Model -> List (Html Msg)
+viewPurchaseDialog config model =
+    case model.pendingPurchase of
+        NoPendingPurchase ->
+            []
+
+        Considering itemKind clickPoint ->
+            [ ShopDialog.viewPurchaseDialog
+                { clickPoint = clickPoint
+                , question =
+                    "Buy "
+                        ++ itemDisplayName itemKind
+                        ++ " for $"
+                        ++ formatCents (itemPriceCents config itemKind)
+                        ++ "?"
+                , explanation = itemExplanation itemKind
+                , onConfirm = PurchaseConfirmed
+                , onCancel = PurchaseCancelled
+                , onInsideClick = DialogClicked
+                }
+            ]
+
+
+{-| The item's name with its article, ready for "Buy ... for $x?".
+-}
+itemDisplayName : ShopItemKind -> String
+itemDisplayName itemKind =
+    case itemKind of
+        TrackerItem ->
+            "the ratio tracker"
+
+        UncleAdviceItem ->
+            "uncle's advice"
+
+
+itemExplanation : ShopItemKind -> String
+itemExplanation itemKind =
+    case itemKind of
+        TrackerItem ->
+            "Counts how often heads and tails won across your flips, so you don't have to tally the log by hand."
+
+        UncleAdviceItem ->
+            "Uncle's advice speaks for itself. He's your uncle, surely he knows best."
+
+
+{-| The price the dialog quotes. Zero for an absent offer, which is
+never read: the dialog only opens from a shop button that an absent
+offer never renders.
+-}
+itemPriceCents : LevelConfig -> ShopItemKind -> Int
+itemPriceCents config itemKind =
+    case itemKind of
+        TrackerItem ->
+            case config.trackerOffer of
+                NoTrackerForSale ->
+                    0
+
+                TrackerForSale priceCents ->
+                    priceCents
+
+        UncleAdviceItem ->
+            case config.uncleOffer of
+                NoUncleAdvice ->
+                    0
+
+                UncleAdviceForSale uncle ->
+                    uncle.priceCents
 
 
 viewGameOver : LevelConfig -> Model -> Html Msg

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -2,7 +2,6 @@ module MultiCoinGame exposing
     ( Autoclicker(..)
     , AutoclickerOffer(..)
     , BustCause(..)
-    , ClickPoint
     , CoinConfig
     , CoinTally
     , FlipHelperOffer(..)
@@ -14,7 +13,6 @@ module MultiCoinGame exposing
     , MultiCoinConfig
     , PendingPurchase(..)
     , ProfileAssignment(..)
-    , ShopFold(..)
     , ShopItemKind(..)
     , StakeInput(..)
     , formatPayout
@@ -76,6 +74,7 @@ import Html.Events
 import Html.Keyed
 import Json.Decode as Decode
 import Random
+import ShopDialog exposing (ClickPoint, ShopFold(..))
 import Time
 
 
@@ -135,14 +134,6 @@ type FlipHelperOffer
     | FlipHelpersForSale { basePriceCents : Int, priceIncreasePercent : Int }
 
 
-{-| The shop folds away behind its header and starts collapsed, so the
-game opens on the bets, not the catalogue.
--}
-type ShopFold
-    = ShopCollapsed
-    | ShopExpanded
-
-
 {-| The shop items a purchase dialog explains before any money moves.
 -}
 type ShopItemKind
@@ -151,17 +142,6 @@ type ShopItemKind
     | AutoclickerItem
     | FlipHelperItem
     | UncleAdviceItem
-
-
-{-| Where in the viewport the shop item was clicked. The dialog is
-positioned so its confirm button renders right under this point: the
-pointer cannot be moved by a web page, but the button can be brought to
-the pointer.
--}
-type alias ClickPoint =
-    { x : Float
-    , y : Float
-    }
 
 
 {-| A purchase mid-consideration: clicking a shop item opens a dialog
@@ -1242,40 +1222,20 @@ viewPurchaseDialog config model =
             []
 
         Considering itemKind clickPoint ->
-            [ Html.div
-                [ Html.Attributes.class "purchase-dialog"
-                , Html.Attributes.style "left" (pixels (max 8 (clickPoint.x - 71)))
-                , Html.Attributes.style "top" (pixels (max 8 (clickPoint.y - 32)))
-                , Html.Events.stopPropagationOn "click" (Decode.succeed ( DialogClicked, True ))
-                ]
-                [ Html.div [ Html.Attributes.class "dialog-actions" ]
-                    [ Html.button
-                        [ Html.Events.onClick PurchaseConfirmed
-                        , Html.Attributes.style "width" "120px"
-                        , Html.Attributes.style "height" "42px"
-                        ]
-                        [ Html.text "Confirm" ]
-                    , Html.button [ Html.Events.onClick PurchaseCancelled ] [ Html.text "Cancel" ]
-                    ]
-                , Html.div []
-                    [ Html.strong []
-                        [ Html.text
-                            ("Buy "
-                                ++ itemDisplayName itemKind
-                                ++ " for $"
-                                ++ formatCents (itemPriceCents config model itemKind)
-                                ++ "?"
-                            )
-                        ]
-                    ]
-                , Html.div [] [ Html.text (itemExplanation itemKind) ]
-                ]
+            [ ShopDialog.viewPurchaseDialog
+                { clickPoint = clickPoint
+                , question =
+                    "Buy "
+                        ++ itemDisplayName itemKind
+                        ++ " for $"
+                        ++ formatCents (itemPriceCents config model itemKind)
+                        ++ "?"
+                , explanation = itemExplanation itemKind
+                , onConfirm = PurchaseConfirmed
+                , onCancel = PurchaseCancelled
+                , onInsideClick = DialogClicked
+                }
             ]
-
-
-pixels : Float -> String
-pixels amount =
-    String.fromFloat amount ++ "px"
 
 
 {-| The item's name with its article, ready for "Buy ... for $x?".
@@ -1363,39 +1323,12 @@ itemPriceCents config model itemKind =
 
 viewShopToggle : ShopFold -> Html Msg
 viewShopToggle fold =
-    Html.button
-        [ Html.Attributes.class "shop-toggle", Html.Events.onClick ShopToggled ]
-        [ Html.text
-            (case fold of
-                ShopCollapsed ->
-                    "\u{1F6D2} Shop \u{25B8}"
-
-                ShopExpanded ->
-                    "\u{1F6D2} Shop \u{25BE}"
-            )
-        ]
+    ShopDialog.viewShopToggle ShopToggled fold
 
 
 viewShopItem : (ClickPoint -> Msg) -> String -> Int -> Html Msg
 viewShopItem onBuyAt itemName priceCents =
-    Html.button
-        [ Html.Attributes.class "shop-item"
-
-        -- stopPropagation: the click that opens (or switches) the
-        -- dialog must never reach the document-level dismiss listener.
-        , Html.Events.stopPropagationOn "click"
-            (Decode.map (\clickPoint -> ( onBuyAt clickPoint, True )) clickPointDecoder)
-        ]
-        [ Html.span [] [ Html.text itemName ]
-        , Html.span [] [ Html.text ("$" ++ formatCents priceCents) ]
-        ]
-
-
-clickPointDecoder : Decode.Decoder ClickPoint
-clickPointDecoder =
-    Decode.map2 ClickPoint
-        (Decode.field "clientX" Decode.float)
-        (Decode.field "clientY" Decode.float)
+    ShopDialog.viewShopItem onBuyAt itemName ("$" ++ formatCents priceCents)
 
 
 viewTrackerShopItem : TrackerOffer -> Model -> List (Html Msg)

--- a/elm/src/ShopDialog.elm
+++ b/elm/src/ShopDialog.elm
@@ -1,0 +1,128 @@
+module ShopDialog exposing
+    ( ClickPoint
+    , ShopFold(..)
+    , clickPointDecoder
+    , viewPurchaseDialog
+    , viewShopItem
+    , viewShopToggle
+    )
+
+{-| The shared in-game shop chrome: the fold-away toggle, the item rows,
+and the confirm/cancel purchase dialog that renders its confirm button
+under the click that opened it. Message-generic so both game engines
+(CoinFlipGame and MultiCoinGame) use one implementation.
+-}
+-- Decision: one message-generic module (Html msg, callers pass their
+-- own Msg constructors) instead of the alternatives tried first:
+-- duplicating the shop chrome per engine (how it started; the two
+-- copies immediately drifted when level 3 gained dialogs level 2
+-- lacked) or letting one engine render the other's Html Msg (needs
+-- Html.map noise and still couples the Msg types). Prices arrive as
+-- pre-formatted strings rather than cents so this module does not
+-- import CoinFlipGame's formatCents, which would create an import
+-- cycle: CoinFlipGame imports ShopDialog for the views.
+
+import Html exposing (Html)
+import Html.Attributes
+import Html.Events
+import Json.Decode as Decode
+
+
+{-| The shop folds away behind its header and starts collapsed, so the
+game opens on the bets, not the catalogue.
+-}
+type ShopFold
+    = ShopCollapsed
+    | ShopExpanded
+
+
+{-| Where in the viewport a shop item was clicked. The dialog is
+positioned so its confirm button renders right under this point: the
+pointer cannot be moved by a web page, but the button can be brought to
+the pointer.
+-}
+type alias ClickPoint =
+    { x : Float
+    , y : Float
+    }
+
+
+clickPointDecoder : Decode.Decoder ClickPoint
+clickPointDecoder =
+    Decode.map2 ClickPoint
+        (Decode.field "clientX" Decode.float)
+        (Decode.field "clientY" Decode.float)
+
+
+viewShopToggle : msg -> ShopFold -> Html msg
+viewShopToggle onToggle fold =
+    Html.button
+        [ Html.Attributes.class "shop-toggle", Html.Events.onClick onToggle ]
+        [ Html.text
+            (case fold of
+                ShopCollapsed ->
+                    "\u{1F6D2} Shop \u{25B8}"
+
+                ShopExpanded ->
+                    "\u{1F6D2} Shop \u{25BE}"
+            )
+        ]
+
+
+{-| One row in the shop: item name left, price right. The click carries
+its viewport coordinates so the dialog can open under the pointer, and
+stops propagating so it never reaches a document-level dismiss listener.
+-}
+viewShopItem : (ClickPoint -> msg) -> String -> String -> Html msg
+viewShopItem onBuyAt itemName priceText =
+    Html.button
+        [ Html.Attributes.class "shop-item"
+        , Html.Events.stopPropagationOn "click"
+            (Decode.map (\clickPoint -> ( onBuyAt clickPoint, True )) clickPointDecoder)
+        ]
+        [ Html.span [] [ Html.text itemName ]
+        , Html.span [] [ Html.text priceText ]
+        ]
+
+
+{-| The confirm/cancel dialog a considered purchase opens, explaining
+what the item does before any money moves. Fixed-positioned so the
+confirm button (a known 120x42 box, first in the dialog, inside the
+0.6em padding and 1px border) renders centered under the click that
+opened it: buying again is a click without moving the mouse. Clicks
+inside stop propagating (as `onInsideClick`) so only genuinely-outside
+clicks reach the caller's document-level dismiss listener.
+-}
+viewPurchaseDialog :
+    { clickPoint : ClickPoint
+    , question : String
+    , explanation : String
+    , onConfirm : msg
+    , onCancel : msg
+    , onInsideClick : msg
+    }
+    -> Html msg
+viewPurchaseDialog dialog =
+    Html.div
+        [ Html.Attributes.class "purchase-dialog"
+        , Html.Attributes.style "left" (pixels (max 8 (dialog.clickPoint.x - 71)))
+        , Html.Attributes.style "top" (pixels (max 8 (dialog.clickPoint.y - 32)))
+        , Html.Events.stopPropagationOn "click" (Decode.succeed ( dialog.onInsideClick, True ))
+        ]
+        [ Html.div [ Html.Attributes.class "dialog-actions" ]
+            [ Html.button
+                [ Html.Events.onClick dialog.onConfirm
+                , Html.Attributes.style "width" "120px"
+                , Html.Attributes.style "height" "42px"
+                ]
+                [ Html.text "Confirm" ]
+            , Html.button [ Html.Events.onClick dialog.onCancel ] [ Html.text "Cancel" ]
+            ]
+        , Html.div [] [ Html.strong [] [ Html.text dialog.question ] ]
+        , Html.div [] [ Html.text dialog.explanation ]
+        ]
+
+
+pixels : Float -> String
+pixels amount =
+    String.fromFloat amount ++ "px"

--- a/elm/tests/CoinFlipGameTest.elm
+++ b/elm/tests/CoinFlipGameTest.elm
@@ -20,6 +20,8 @@ import CoinFlipGame
         , formatClock
         , initialModel
         , landedPercent
+        , PendingPurchase(..)
+        , ShopItemKind(..)
         , parseBetCents
         , quickBetCents
         , update
@@ -29,6 +31,7 @@ import CoinFlipLevel1
 import CoinFlipLevel2
 import Expect
 import Test exposing (Test, describe, test)
+import ShopDialog
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (class, tag)
 
@@ -176,10 +179,66 @@ hiddenBiasSuite =
         ]
 
 
+clickAtOrigin : ShopDialog.ClickPoint
+clickAtOrigin =
+    { x = 0, y = 0 }
+
+
 shopSuite : Test
 shopSuite =
     describe "CoinFlipGame shop (level 2)"
-        [ test "buying the ratio tracker costs $15.00" <|
+        [ test "the shop starts collapsed with no items visible" <|
+            \_ ->
+                view CoinFlipLevel2.levelConfig level2Start
+                    |> Query.fromHtml
+                    |> Query.hasNot [ class "shop-item" ]
+        , test "toggling the shop reveals the items" <|
+            \_ ->
+                apply CoinFlipLevel2.levelConfig [ ShopToggled ] level2Start
+                    |> view CoinFlipLevel2.levelConfig
+                    |> Query.fromHtml
+                    |> Query.has [ class "shop-item" ]
+        , test "considering the tracker charges nothing" <|
+            \_ ->
+                let
+                    considering =
+                        apply CoinFlipLevel2.levelConfig
+                            [ PurchaseConsidered TrackerItem clickAtOrigin ]
+                            level2Start
+                in
+                ( considering.balanceCents, considering.tracker )
+                    |> Expect.equal ( 2500, TrackerNotBought )
+        , test "confirming the tracker buys it and closes the dialog" <|
+            \_ ->
+                let
+                    bought =
+                        apply CoinFlipLevel2.levelConfig
+                            [ PurchaseConsidered TrackerItem clickAtOrigin, PurchaseConfirmed ]
+                            level2Start
+                in
+                ( bought.balanceCents, bought.tracker, bought.pendingPurchase )
+                    |> Expect.equal ( 1000, TrackerBought, NoPendingPurchase )
+        , test "confirming uncle keeps the dialog open for repeat customers" <|
+            \_ ->
+                let
+                    advised =
+                        apply CoinFlipLevel2.levelConfig
+                            [ PurchaseConsidered UncleAdviceItem clickAtOrigin
+                            , PurchaseConfirmed
+                            , PurchaseConfirmed
+                            ]
+                            level2Start
+                in
+                ( advised.balanceCents, advised.uncleAdviceCount, advised.pendingPurchase )
+                    |> Expect.equal ( 1500, 2, Considering UncleAdviceItem clickAtOrigin )
+        , test "cancelling a considered purchase keeps the money" <|
+            \_ ->
+                apply CoinFlipLevel2.levelConfig
+                    [ PurchaseConsidered UncleAdviceItem clickAtOrigin, PurchaseCancelled ]
+                    level2Start
+                    |> .uncleAdviceCount
+                    |> Expect.equal 0
+        , test "buying the ratio tracker costs $15.00" <|
             \_ ->
                 let
                     bought =

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -34,6 +34,7 @@ import MultiCoinGame
         , view
         )
 import Random
+import ShopDialog
 import Test exposing (Test, describe, test)
 import Test.Html.Query as Query
 import Test.Html.Selector exposing (class, text)
@@ -57,7 +58,7 @@ landedRound stakes rolls =
     CoinsLanded { stakes = stakes, rolls = rolls }
 
 
-clickAtOrigin : MultiCoinGame.ClickPoint
+clickAtOrigin : ShopDialog.ClickPoint
 clickAtOrigin =
     { x = 0, y = 0 }
 


### PR DESCRIPTION
The hidden-rewards shop was still the old buy-on-click, always-open version. It now has everything black-swan's shop got:

- Folds behind "🛒 Shop ▸" and starts collapsed.
- Tracker and uncle open the confirm/cancel dialog with plain-language explanations (uncle's being "Uncle's advice speaks for itself. He's your uncle, surely he knows best.").
- The confirm button renders under the click that opened the dialog, uncle's dialog stays open for confirm-mashing, and clicking outside dismisses.

The shop chrome (toggle, item rows, positioned dialog) is extracted into a message-generic `ShopDialog` module used by both engines, replacing MultiCoinGame's own copies (see the `Decision:` comment; prices cross the boundary pre-formatted to avoid an import cycle).

Verified live on hidden-rewards.html across all flows; 186 Elm tests pass; `nix-build nix/ci.nix` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
