### PR TITLE
Level 4: birds of a feather, the correlation level

### DIFF
--- a/content/birds-of-a-feather.md
+++ b/content/birds-of-a-feather.md
@@ -70,6 +70,7 @@ TODO
     text-align: left;
   }
   #coin-flip-game .shop-toggle { width: 100%; text-align: left; font-weight: bold; }
+  #coin-flip-game .shop-subtoggle { width: 100%; text-align: left; padding-left: 1.5em; }
   #coin-flip-game .shop-item {
     display: flex;
     justify-content: space-between;

--- a/content/birds-of-a-feather.md
+++ b/content/birds-of-a-feather.md
@@ -61,6 +61,7 @@ TODO
   #coin-flip-game .flip-button { width: 100%; padding: 0.6em; font-weight: bold; }
   #coin-flip-game .tally { font-weight: bold; }
   #coin-flip-game .glasses { font-weight: bold; }
+  #coin-flip-game .correlations { font-weight: bold; }
   #coin-flip-game .shop {
     border-top: 1px dashed #196019;
     padding-top: 0.6em;
@@ -124,10 +125,16 @@ Elm.CoinFlipLevel4.init({ node: document.getElementById('coin-flip-game') });
 
 <!-- TODO: the actual article still has to be written. The game above is
      level 4 of the rigged-coin series: correlation. One hidden weather
-     roll per round (sun 60%, rain 40%); Sunbird wins when sunny paying
-     0.8x, Rainbird when rainy paying 1.8x, perfectly anti-correlated.
-     Their payouts form a Dutch book: staking ~61/39 across both nets a
-     guaranteed ~9.6% per flip ($999 in 41 presses), while either bird
-     alone grows ~0.4% per flip at best, hopeless inside the 200-flip
-     budget. Cuckoo is the red herring: 40x payout at 2%, an 18%
-     negative expected return. -->
+     roll per round (sun 60%, rain 40%); one profile wins when sunny
+     paying 0.8x, another when rainy paying 1.8x, perfectly
+     anti-correlated, and the profiles are dealt across Starling,
+     Swallow, and Cuckoo at random every game. The weather payouts form
+     a Dutch book: staking ~61/39 across the pair nets a guaranteed
+     ~9.6% per flip ($999 in 41 presses), while either alone grows
+     ~0.4% per flip at best, hopeless inside the 200-flip budget. The
+     third profile is the red herring: 40x payout at 2%, an 18%
+     negative expected return. Weather log lines spell the correlation
+     out ("Therefore Swallow loses."); the shop sells the tracker,
+     glasses, a $10 percentage allocator (stakes become percentages of
+     the live balance), and The Elegant Universe at $20, which tracks
+     how often each pair lands the same way. -->

--- a/content/birds-of-a-feather.md
+++ b/content/birds-of-a-feather.md
@@ -70,12 +70,12 @@ TODO
     text-align: left;
   }
   #coin-flip-game .shop-toggle { width: 100%; text-align: left; font-weight: bold; }
-  #coin-flip-game .shop-subtoggle { width: 100%; text-align: left; padding-left: 1.5em; }
+  #coin-flip-game .shop-group-heading { font-weight: bold; }
   #coin-flip-game .shop-item {
     display: flex;
     justify-content: space-between;
     gap: 1em;
-    width: 100%;
+    margin-left: 1.2em;
   }
   #coin-flip-game .purchase-dialog {
     position: fixed;

--- a/content/birds-of-a-feather.md
+++ b/content/birds-of-a-feather.md
@@ -134,8 +134,9 @@ Elm.CoinFlipLevel4.init({ node: document.getElementById('coin-flip-game') });
      ~9.6% per flip ($999 in 41 presses), while either alone grows
      ~0.4% per flip at best, hopeless inside the 200-flip budget. The
      third profile is the red herring: 40x payout at 2%, an 18%
-     negative expected return. Weather log lines spell the correlation
-     out ("Therefore Swallow loses."); the shop sells the tracker,
-     glasses, a $10 percentage allocator (stakes become percentages of
-     the live balance), and The Elegant Universe at $20, which tracks
-     how often each pair lands the same way. -->
+     negative expected return. The logs reveal nothing about the
+     correlation; discovering it takes patience or The Elegant Universe
+     at $20, which tracks how often each pair lands the same way. The
+     shop also sells the tracker, glasses, a $10 percentage allocator
+     (stakes become percentages of the live balance), automation, and
+     uncle. -->

--- a/content/birds-of-a-feather.md
+++ b/content/birds-of-a-feather.md
@@ -1,0 +1,133 @@
+Title: Birds of a feather
+Date: 2026-08-21 22:30
+Category: reflection
+OPTIONS: toc:nil
+Tags: gambling, finance, game
+Summary: Three birds, one sky, two hundred flips. Good luck!
+
+TODO
+
+<div id="coin-flip-game"></div>
+
+<style>
+  #coin-flip-game {
+    border: 2px solid #196019;
+    border-radius: 6px;
+    overflow: hidden;
+    max-width: 34em;
+    margin: 1.5em auto;
+    padding: 0 1em 1em;
+    font-family: "Inconsolata", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", monospace;
+    background: rgba(255, 255, 255, 0.85);
+  }
+  #coin-flip-game h3 {
+    background: #196019;
+    color: white;
+    margin: 0 -1em 1em;
+    padding: 0.4em 1em;
+    font-size: 1.1em;
+  }
+  #coin-flip-game .stats { display: flex; justify-content: space-between; font-weight: bold; }
+  #coin-flip-game .progress-track {
+    background: #d3d7cf;
+    height: 12px;
+    margin: 0.5em 0;
+    border-radius: 6px;
+    overflow: hidden;
+  }
+  #coin-flip-game .progress-fill { background: #30bb30; height: 100%; transition: width 0.3s; }
+  #coin-flip-game .balance { font-size: 2.2em; font-weight: bold; text-align: center; margin: 0.3em 0; }
+  #coin-flip-game .controls { text-align: center; }
+  #coin-flip-game .controls > div { margin: 0.6em 0; }
+  #coin-flip-game button {
+    touch-action: manipulation;
+    font-family: inherit;
+    background: #196019;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    padding: 0.25em 0.7em;
+    cursor: pointer;
+  }
+  #coin-flip-game button:hover { background: #259025; }
+  #coin-flip-game button:active { transform: scale(0.97); }
+  #coin-flip-game .coin-bet {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1em;
+  }
+  #coin-flip-game .coin-bet label { font-weight: bold; }
+  #coin-flip-game .flip-button { width: 100%; padding: 0.6em; font-weight: bold; }
+  #coin-flip-game .tally { font-weight: bold; }
+  #coin-flip-game .glasses { font-weight: bold; }
+  #coin-flip-game .shop {
+    border-top: 1px dashed #196019;
+    padding-top: 0.6em;
+    display: grid;
+    gap: 0.4em;
+    text-align: left;
+  }
+  #coin-flip-game .shop-toggle { width: 100%; text-align: left; font-weight: bold; }
+  #coin-flip-game .shop-item {
+    display: flex;
+    justify-content: space-between;
+    gap: 1em;
+    width: 100%;
+  }
+  #coin-flip-game .purchase-dialog {
+    position: fixed;
+    z-index: 10;
+    width: 20em;
+    border: 1px solid #196019;
+    border-radius: 4px;
+    padding: 0.6em;
+    text-align: left;
+    background: #eafbea;
+  }
+  #coin-flip-game .dialog-actions { display: flex; gap: 0.6em; margin-bottom: 0.5em; }
+  #coin-flip-game input[type="number"] {
+    font-family: inherit;
+    border: 1px solid #196019;
+    border-radius: 4px;
+    padding: 0.3em 0.5em;
+    width: 7em;
+    background: transparent;
+    color: inherit;
+  }
+  #coin-flip-game .log {
+    height: 8em;
+    overflow-y: auto;
+    font-size: 0.85em;
+    text-align: left;
+    border-top: 1px dashed #196019;
+    padding-top: 0.5em;
+    margin-top: 0.8em;
+  }
+  #coin-flip-game .win-text { color: #1e7d1e; }
+  #coin-flip-game .lose-text { color: #b03030; }
+  #coin-flip-game .game-over { font-weight: bold; text-align: center; font-size: 1.1em; margin: 0.5em 0; }
+  #coin-flip-game .game-over a { color: inherit; text-decoration: underline; }
+  @media (prefers-color-scheme: dark) {
+    #coin-flip-game { background: rgba(0, 0, 0, 0.85); }
+    #coin-flip-game .progress-track { background: #134013; }
+    #coin-flip-game .win-text { color: #7dff7d; }
+    #coin-flip-game .lose-text { color: #ff6b6b; }
+    #coin-flip-game .purchase-dialog { background: #062606; }
+  }
+</style>
+
+<script src="/coin-flip-level4.js"></script>
+<script>
+Elm.CoinFlipLevel4.init({ node: document.getElementById('coin-flip-game') });
+</script>
+
+<!-- TODO: the actual article still has to be written. The game above is
+     level 4 of the rigged-coin series: correlation. One hidden weather
+     roll per round (sun 60%, rain 40%); Sunbird wins when sunny paying
+     0.8x, Rainbird when rainy paying 1.8x, perfectly anti-correlated.
+     Their payouts form a Dutch book: staking ~61/39 across both nets a
+     guaranteed ~9.6% per flip ($999 in 41 presses), while either bird
+     alone grows ~0.4% per flip at best, hopeless inside the 200-flip
+     budget. Cuckoo is the red herring: 40x payout at 2%, an 18%
+     negative expected return. -->

--- a/content/black-swan.md
+++ b/content/black-swan.md
@@ -71,6 +71,7 @@ of a gambler may succeed.
     text-align: left;
   }
   #coin-flip-game .shop-toggle { width: 100%; text-align: left; font-weight: bold; }
+  #coin-flip-game .shop-subtoggle { width: 100%; text-align: left; padding-left: 1.5em; }
   #coin-flip-game .helpers { font-weight: bold; }
   #coin-flip-game .helper-bird {
     display: inline-block;

--- a/content/black-swan.md
+++ b/content/black-swan.md
@@ -71,7 +71,7 @@ of a gambler may succeed.
     text-align: left;
   }
   #coin-flip-game .shop-toggle { width: 100%; text-align: left; font-weight: bold; }
-  #coin-flip-game .shop-subtoggle { width: 100%; text-align: left; padding-left: 1.5em; }
+  #coin-flip-game .shop-group-heading { font-weight: bold; }
   #coin-flip-game .helpers { font-weight: bold; }
   #coin-flip-game .helper-bird {
     display: inline-block;
@@ -85,7 +85,7 @@ of a gambler may succeed.
     display: flex;
     justify-content: space-between;
     gap: 1em;
-    width: 100%;
+    margin-left: 1.2em;
   }
   #coin-flip-game .purchase-dialog {
     position: fixed;

--- a/elm/src/CoinFlipGame.elm
+++ b/elm/src/CoinFlipGame.elm
@@ -434,8 +434,11 @@ settleFlip uncleOffer flip model =
                 else
                     max 0 (model.balanceCents - flip.betCents)
 
+            -- Flip lines carry their number, matching the multi-coin
+            -- games' logs.
             outcomeText =
-                "Landed "
+                String.fromInt (model.flipCount + 1)
+                    ++ ": Landed "
                     ++ sideName flip.landed
                     ++ "! You "
                     ++ (if won then

--- a/elm/src/CoinFlipLevel3.elm
+++ b/elm/src/CoinFlipLevel3.elm
@@ -10,18 +10,21 @@ Which bird got which profile has to be rediscovered every replay.
 
 -}
 
-import CoinFlipGame exposing (TrackerOffer(..), UncleOffer(..))
-import MultiCoinGame exposing (AutoclickerOffer(..), FlipHelperOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), gameProgram)
+import CoinFlipGame exposing (NextLevelLink(..), TrackerOffer(..), UncleOffer(..))
+import MultiCoinGame exposing (AutoclickerOffer(..), CoinOdds(..), FlipHelperOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), TurnBudget(..), gameProgram)
 
 
 levelConfig : MultiCoinConfig
 levelConfig =
     { title = "\u{1FA99} Rigged Coin Trader III: Rare Birds"
     , coins =
-        [ { coinName = "Swan", winPercent = 5, payoutPercent = 3000 }
-        , { coinName = "Magpie", winPercent = 45, payoutPercent = 100 }
-        , { coinName = "Sparrow", winPercent = 60, payoutPercent = 50 }
+        [ { coinName = "Swan", odds = IndependentPercent 5, payoutPercent = 3000 }
+        , { coinName = "Magpie", odds = IndependentPercent 45, payoutPercent = 100 }
+        , { coinName = "Sparrow", odds = IndependentPercent 60, payoutPercent = 50 }
         ]
+    , weatherSunPercent = 50
+    , turnBudget = TimeLimit (30 * 60)
+    , nextLevelLink = NextLevelLinkTo { url = "/birds-of-a-feather.html", label = "<<next level>>" }
     , profileAssignment = ProfilesShuffledAcrossCoins
     , trackerOffer = TrackerForSale 1500
     , glassesOffer = GoldenGlassesForSale 2000

--- a/elm/src/CoinFlipLevel3.elm
+++ b/elm/src/CoinFlipLevel3.elm
@@ -11,7 +11,7 @@ Which bird got which profile has to be rediscovered every replay.
 -}
 
 import CoinFlipGame exposing (NextLevelLink(..), TrackerOffer(..), UncleOffer(..))
-import MultiCoinGame exposing (AllocatorOffer(..), AutoclickerOffer(..), CoinOdds(..), CorrelationBookOffer(..), FlipHelperOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), TurnBudget(..), gameProgram)
+import MultiCoinGame exposing (AllocatorOffer(..), AutoclickerOffer(..), CoinOdds(..), CorrelationBookOffer(..), FlipHelperOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), RefundOffer(..), TurnBudget(..), gameProgram)
 
 
 levelConfig : MultiCoinConfig
@@ -32,6 +32,7 @@ levelConfig =
     , flipHelperOffer = FlipHelpersForSale { basePriceCents = 100, priceIncreasePercent = 10 }
     , allocatorOffer = NoAllocator
     , bookOffer = NoCorrelationBook
+    , refundOffer = NoRefund
     , uncleOffer =
         UncleAdviceForSale
             { priceCents = 500

--- a/elm/src/CoinFlipLevel3.elm
+++ b/elm/src/CoinFlipLevel3.elm
@@ -11,7 +11,7 @@ Which bird got which profile has to be rediscovered every replay.
 -}
 
 import CoinFlipGame exposing (NextLevelLink(..), TrackerOffer(..), UncleOffer(..))
-import MultiCoinGame exposing (AllocatorOffer(..), AutoclickerOffer(..), CoinOdds(..), CorrelationBookOffer(..), FlipHelperOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), RefundOffer(..), TurnBudget(..), gameProgram)
+import MultiCoinGame exposing (AllocatorOffer(..), AutoclickerOffer(..), CoinOdds(..), CorrelationBookOffer(..), ExtraTurnsOffer(..), FlipHelperOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), RefundOffer(..), TurnBudget(..), gameProgram)
 
 
 levelConfig : MultiCoinConfig
@@ -33,6 +33,7 @@ levelConfig =
     , allocatorOffer = NoAllocator
     , bookOffer = NoCorrelationBook
     , refundOffer = NoRefund
+    , extraTurnsOffer = NoExtraTurns
     , uncleOffer =
         UncleAdviceForSale
             { priceCents = 500

--- a/elm/src/CoinFlipLevel3.elm
+++ b/elm/src/CoinFlipLevel3.elm
@@ -11,7 +11,7 @@ Which bird got which profile has to be rediscovered every replay.
 -}
 
 import CoinFlipGame exposing (NextLevelLink(..), TrackerOffer(..), UncleOffer(..))
-import MultiCoinGame exposing (AutoclickerOffer(..), CoinOdds(..), FlipHelperOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), TurnBudget(..), gameProgram)
+import MultiCoinGame exposing (AllocatorOffer(..), AutoclickerOffer(..), CoinOdds(..), CorrelationBookOffer(..), FlipHelperOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), TurnBudget(..), gameProgram)
 
 
 levelConfig : MultiCoinConfig
@@ -30,6 +30,8 @@ levelConfig =
     , glassesOffer = GoldenGlassesForSale 2000
     , autoclickerOffer = AutoclickerForSale 1000
     , flipHelperOffer = FlipHelpersForSale { basePriceCents = 100, priceIncreasePercent = 10 }
+    , allocatorOffer = NoAllocator
+    , bookOffer = NoCorrelationBook
     , uncleOffer =
         UncleAdviceForSale
             { priceCents = 500

--- a/elm/src/CoinFlipLevel4.elm
+++ b/elm/src/CoinFlipLevel4.elm
@@ -1,0 +1,62 @@
+module CoinFlipLevel4 exposing (levelConfig, main)
+
+{-| Level 4 of the rigged-coin game: birds of a feather
+(birds-of-a-feather.html), the correlation level.
+
+One hidden weather roll per round (sun 60%, rain 40%). Sunbird wins
+exactly when it is sunny paying 0.8x, Rainbird exactly when it rains
+paying 1.8x: perfectly anti-correlated, exactly one wins every round.
+Their payouts form a Dutch book (0.8 * 1.8 > 1), so the right stake
+split (about 61/39) nets a guaranteed ~9.6% per flip, reaching $999 in
+41 presses. Either bird alone is positive EV but grows ~0.4% per flip
+at best, hopeless inside the 200-flip budget. Cuckoo is the red
+herring: a fat 40x payout at 2%, which is a -18% expected return.
+
+No automation in this shop: with 200 flips the game is about sizing,
+not pressing.
+
+-}
+
+import CoinFlipGame exposing (NextLevelLink(..), TrackerOffer(..), UncleOffer(..))
+import MultiCoinGame exposing (AutoclickerOffer(..), CoinOdds(..), FlipHelperOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), TurnBudget(..), gameProgram)
+
+
+levelConfig : MultiCoinConfig
+levelConfig =
+    { title = "\u{1FA99} Rigged Coin Trader IV: Birds of a Feather"
+    , coins =
+        [ { coinName = "Sunbird", odds = WinsWhenSunny, payoutPercent = 80 }
+        , { coinName = "Rainbird", odds = WinsWhenRainy, payoutPercent = 180 }
+        , { coinName = "Cuckoo", odds = IndependentPercent 2, payoutPercent = 4000 }
+        ]
+    , weatherSunPercent = 60
+    , turnBudget = FlipLimit 200
+    , nextLevelLink = NoNextLevelLink
+
+    -- As written: the bird names are the weather hint, shuffling would
+    -- detach them from their roles.
+    , profileAssignment = ProfilesAsWritten
+    , trackerOffer = TrackerForSale 1500
+    , glassesOffer = GoldenGlassesForSale 2000
+    , autoclickerOffer = NoAutoclicker
+    , flipHelperOffer = NoFlipHelpers
+    , uncleOffer =
+        UncleAdviceForSale
+            { priceCents = 500
+            , firstPhrase = "Don't split your money son, pick a winner and commit."
+            , morePhrases =
+                [ "Oh I don't know son, I'd put it all on the cuckoo."
+                , "The cuckoo is due, I can feel it."
+                , "A real gambler doesn't hedge."
+                , "Diversification is for people who don't know what they're doing."
+                , "Just bet whichever bird won last time, they get on streaks."
+                , "Sunbird AND Rainbird? One of them always loses, that's throwing money away."
+                ]
+            }
+    , introLogLine = "Three birds, one sky, two hundred flips. Stake any of them on heads and press flip. Good luck!"
+    }
+
+
+main : Program () Model Msg
+main =
+    gameProgram levelConfig

--- a/elm/src/CoinFlipLevel4.elm
+++ b/elm/src/CoinFlipLevel4.elm
@@ -22,7 +22,7 @@ costs money and yields only his fondest farewell.
 -}
 
 import CoinFlipGame exposing (NextLevelLink(..), TrackerOffer(..), UncleOffer(..))
-import MultiCoinGame exposing (AllocatorOffer(..), AutoclickerOffer(..), CoinOdds(..), CorrelationBookOffer(..), FlipHelperOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), RefundOffer(..), TurnBudget(..), gameProgram)
+import MultiCoinGame exposing (AllocatorOffer(..), AutoclickerOffer(..), CoinOdds(..), CorrelationBookOffer(..), ExtraTurnsOffer(..), FlipHelperOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), RefundOffer(..), TurnBudget(..), gameProgram)
 
 
 levelConfig : MultiCoinConfig
@@ -46,6 +46,7 @@ levelConfig =
     , flipHelperOffer = FlipHelpersForSale { basePriceCents = 100, priceIncreasePercent = 10 }
     , allocatorOffer = AllocatorForSale 1000
     , bookOffer = CorrelationBookForSale 2000
+    , extraTurnsOffer = ExtraTurnsForSale { priceCents = 50000, extraFlips = 50 }
     , refundOffer =
         RefundForSale
             { priceCents = 1000

--- a/elm/src/CoinFlipLevel4.elm
+++ b/elm/src/CoinFlipLevel4.elm
@@ -14,13 +14,15 @@ split (about 61/39) nets a guaranteed ~9.6% per flip, reaching $999 in
 at best, hopeless inside the 200-flip budget. Cuckoo is the red
 herring: a fat 40x payout at 2%, which is a -18% expected return.
 
-No automation in this shop: with 200 flips the game is about sizing,
-not pressing.
+The shop groups into Upgrades (autoclicker, flip helpers, percentage
+allocator) and Intel (tracker, glasses, The Elegant Universe, uncle).
+Collecting uncle's complete works unlocks asking for a refund, which
+costs money and yields only his fondest farewell.
 
 -}
 
 import CoinFlipGame exposing (NextLevelLink(..), TrackerOffer(..), UncleOffer(..))
-import MultiCoinGame exposing (AllocatorOffer(..), AutoclickerOffer(..), CoinOdds(..), CorrelationBookOffer(..), FlipHelperOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), TurnBudget(..), gameProgram)
+import MultiCoinGame exposing (AllocatorOffer(..), AutoclickerOffer(..), CoinOdds(..), CorrelationBookOffer(..), FlipHelperOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), RefundOffer(..), TurnBudget(..), gameProgram)
 
 
 levelConfig : MultiCoinConfig
@@ -40,21 +42,28 @@ levelConfig =
     , profileAssignment = ProfilesShuffledAcrossCoins
     , trackerOffer = TrackerForSale 1500
     , glassesOffer = GoldenGlassesForSale 2000
-    , autoclickerOffer = NoAutoclicker
-    , flipHelperOffer = NoFlipHelpers
+    , autoclickerOffer = AutoclickerForSale 1000
+    , flipHelperOffer = FlipHelpersForSale { basePriceCents = 100, priceIncreasePercent = 10 }
     , allocatorOffer = AllocatorForSale 1000
     , bookOffer = CorrelationBookForSale 2000
+    , refundOffer =
+        RefundForSale
+            { priceCents = 1000
+            , reply = "Son, I gave you my best tricks, you're set for life now. The money though, I invested it all in a very promising cuckoo, so that ship has sailed. No need to thank me."
+            }
     , uncleOffer =
         UncleAdviceForSale
             { priceCents = 500
             , firstPhrase = "Don't split your money son, pick a winner and commit."
             , morePhrases =
-                [ "Oh I don't know son, I'd put it all on the cuckoo."
-                , "The cuckoo is due, I can feel it."
+                [ "The cuckoo is due, I can feel it."
                 , "A real gambler doesn't hedge."
                 , "Diversification is for people who don't know what they're doing."
-                , "Just bet whichever bird won last time, they get on streaks."
-                , "Sunbird AND Rainbird? One of them always loses, that's throwing money away."
+                , "Starlings and swallows are basically the same bird, so same bet really."
+                , "Correlation? That's when birds fly in a V, right?"
+                , "When one bird loses, bet it harder, it owes you."
+                , "I read half a physics book once. Everything is strings, so nothing matters."
+                , "Your aunt once knitted a swallow. Beautiful bird. What were we talking about?"
                 ]
             }
     , introLogLine = "Three birds, one sky, two hundred flips. Stake any of them on heads and press flip. Good luck!"

--- a/elm/src/CoinFlipLevel4.elm
+++ b/elm/src/CoinFlipLevel4.elm
@@ -3,9 +3,11 @@ module CoinFlipLevel4 exposing (levelConfig, main)
 {-| Level 4 of the rigged-coin game: birds of a feather
 (birds-of-a-feather.html), the correlation level.
 
-One hidden weather roll per round (sun 60%, rain 40%). Sunbird wins
-exactly when it is sunny paying 0.8x, Rainbird exactly when it rains
-paying 1.8x: perfectly anti-correlated, exactly one wins every round.
+One hidden weather roll per round (sun 60%, rain 40%). One profile
+wins exactly when it is sunny paying 0.8x, another exactly when it
+rains paying 1.8x: perfectly anti-correlated, exactly one wins every
+round. The three profiles are dealt across Starling, Swallow, and
+Cuckoo at random every game.
 Their payouts form a Dutch book (0.8 * 1.8 > 1), so the right stake
 split (about 61/39) nets a guaranteed ~9.6% per flip, reaching $999 in
 41 presses. Either bird alone is positive EV but grows ~0.4% per flip
@@ -18,28 +20,30 @@ not pressing.
 -}
 
 import CoinFlipGame exposing (NextLevelLink(..), TrackerOffer(..), UncleOffer(..))
-import MultiCoinGame exposing (AutoclickerOffer(..), CoinOdds(..), FlipHelperOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), TurnBudget(..), gameProgram)
+import MultiCoinGame exposing (AllocatorOffer(..), AutoclickerOffer(..), CoinOdds(..), CorrelationBookOffer(..), FlipHelperOffer(..), GlassesOffer(..), Model, Msg, MultiCoinConfig, ProfileAssignment(..), TurnBudget(..), gameProgram)
 
 
 levelConfig : MultiCoinConfig
 levelConfig =
     { title = "\u{1FA99} Rigged Coin Trader IV: Birds of a Feather"
     , coins =
-        [ { coinName = "Sunbird", odds = WinsWhenSunny, payoutPercent = 80 }
-        , { coinName = "Rainbird", odds = WinsWhenRainy, payoutPercent = 180 }
+        [ { coinName = "Starling", odds = WinsWhenSunny, payoutPercent = 80 }
+        , { coinName = "Swallow", odds = WinsWhenRainy, payoutPercent = 180 }
         , { coinName = "Cuckoo", odds = IndependentPercent 2, payoutPercent = 4000 }
         ]
     , weatherSunPercent = 60
     , turnBudget = FlipLimit 200
     , nextLevelLink = NoNextLevelLink
 
-    -- As written: the bird names are the weather hint, shuffling would
-    -- detach them from their roles.
-    , profileAssignment = ProfilesAsWritten
+    -- Shuffled: the names carry no weather hint, so which bird got
+    -- which profile must be rediscovered every game.
+    , profileAssignment = ProfilesShuffledAcrossCoins
     , trackerOffer = TrackerForSale 1500
     , glassesOffer = GoldenGlassesForSale 2000
     , autoclickerOffer = NoAutoclicker
     , flipHelperOffer = NoFlipHelpers
+    , allocatorOffer = AllocatorForSale 1000
+    , bookOffer = CorrelationBookForSale 2000
     , uncleOffer =
         UncleAdviceForSale
             { priceCents = 500

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -300,8 +300,6 @@ type alias Model =
     , allocationMode : AllocationMode
     , book : CorrelationBook
     , pairTallies : List PairTally
-    , upgradesFold : ShopFold
-    , intelFold : ShopFold
     , adviceHeard : List String
     , refund : RefundState
     , autoclicker : Autoclicker
@@ -338,8 +336,6 @@ type Msg
     | FlipHelperHired
     | FlipHelpersTicked
     | ShopToggled
-    | UpgradesToggled
-    | IntelToggled
     | RefundRequested
     | PurchaseConsidered ShopItemKind ClickPoint
     | PurchaseConfirmed
@@ -425,8 +421,6 @@ initialModel config =
     , allocationMode = DollarAllocation
     , book = BookNotBought
     , pairTallies = initialPairTallies (List.length config.coins)
-    , upgradesFold = ShopCollapsed
-    , intelFold = ShopCollapsed
     , adviceHeard = []
     , refund = RefundNotAsked
     , autoclicker = ClickerNotBought
@@ -488,12 +482,6 @@ update config msg model =
 
         ShopToggled ->
             ( { model | shopFold = toggleFold model.shopFold }, Cmd.none )
-
-        UpgradesToggled ->
-            ( { model | upgradesFold = toggleFold model.upgradesFold }, Cmd.none )
-
-        IntelToggled ->
-            ( { model | intelFold = toggleFold model.intelFold }, Cmd.none )
 
         RefundRequested ->
             ( requestRefund config.uncleOffer config.refundOffer model, Cmd.none )
@@ -1756,8 +1744,8 @@ viewShop config model =
 
                             ShopExpanded ->
                                 List.concat
-                                    [ viewShopGroup UpgradesToggled "Upgrades" model.upgradesFold upgradeItems
-                                    , viewShopGroup IntelToggled "Intel" model.intelFold intelItems
+                                    [ viewShopGroup "Upgrades" upgradeItems
+                                    , viewShopGroup "Intel" intelItems
                                     , viewPurchaseDialog config model
                                     ]
                        )
@@ -1765,24 +1753,17 @@ viewShop config model =
             ]
 
 
-{-| A shop submenu: a collapsible group header with its items, hidden
-entirely when the group has nothing for sale.
+{-| A shop section: a plain heading with its items, hidden entirely
+when the section has nothing for sale.
 -}
-viewShopGroup : Msg -> String -> ShopFold -> List (Html Msg) -> List (Html Msg)
-viewShopGroup onToggle label fold groupItems =
+viewShopGroup : String -> List (Html Msg) -> List (Html Msg)
+viewShopGroup label groupItems =
     case groupItems of
         [] ->
             []
 
         _ ->
-            ShopDialog.viewShopGroupToggle onToggle label fold
-                :: (case fold of
-                        ShopCollapsed ->
-                            []
-
-                        ShopExpanded ->
-                            groupItems
-                   )
+            ShopDialog.viewShopGroupHeading label :: groupItems
 
 
 {-| The confirm/cancel dialog a considered purchase opens, explaining

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -865,7 +865,7 @@ settleRound config landedRound model =
 
             roundLogLines =
                 List.map
-                    (\line -> { line | text = "#" ++ String.fromInt roundNumber ++ " " ++ line.text })
+                    (\line -> { line | text = String.fromInt roundNumber ++ ": " ++ line.text })
                     (List.concatMap .logLines outcomes)
         in
         gloatIfBusted config.uncleOffer

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -739,50 +739,8 @@ type alias CoinOutcome =
     }
 
 
-{-| The other weather coin's name, for the "therefore" clause in the
-log: a sunny coin's partner is the rainy coin and vice versa.
-Independent coins have none.
--}
-partnerNameFor : List CoinConfig -> CoinConfig -> Maybe String
-partnerNameFor coins coin =
-    case coin.odds of
-        IndependentPercent _ ->
-            Nothing
-
-        WinsWhenSunny ->
-            oddsCoinName WinsWhenRainy coins
-
-        WinsWhenRainy ->
-            oddsCoinName WinsWhenSunny coins
-
-
-oddsCoinName : CoinOdds -> List CoinConfig -> Maybe String
-oddsCoinName odds coins =
-    List.filter (\coin -> coin.odds == odds) coins
-        |> List.head
-        |> Maybe.map .coinName
-
-
-{-| The correlation, spelled out: when a weather coin lands, its
-partner necessarily landed the other way.
--}
-thereforeClause : Maybe String -> CoinSide -> String
-thereforeClause mPartner landed =
-    case mPartner of
-        Nothing ->
-            ""
-
-        Just partnerName ->
-            case landed of
-                Heads ->
-                    " Therefore " ++ partnerName ++ " loses."
-
-                Tails ->
-                    " Therefore " ++ partnerName ++ " wins."
-
-
-resolveCoin : SkyState -> Maybe String -> CoinConfig -> CoinTally -> Int -> Int -> CoinOutcome
-resolveCoin sky mPartner coin tally stake roll =
+resolveCoin : SkyState -> CoinConfig -> CoinTally -> Int -> Int -> CoinOutcome
+resolveCoin sky coin tally stake roll =
     if stake <= 0 then
         { tally = tally, deltaCents = 0, landedSide = Nothing, logLines = [] }
 
@@ -835,7 +793,6 @@ resolveCoin sky mPartner coin tally stake roll =
                                 ++ ", of which $"
                                 ++ formatCents stake
                                 ++ " is your stake."
-                                ++ thereforeClause mPartner Heads
                       }
                     ]
                 }
@@ -851,7 +808,6 @@ resolveCoin sky mPartner coin tally stake roll =
                                 ++ " landed tails. You lost your $"
                                 ++ formatCents stake
                                 ++ " stake."
-                                ++ thereforeClause mPartner Tails
                       }
                     ]
                 }
@@ -874,11 +830,8 @@ settleRound config landedRound model =
                 else
                     Rainy
 
-            partners =
-                List.map (partnerNameFor model.coins) model.coins
-
             outcomes =
-                List.map5 (resolveCoin sky) partners model.coins model.tallies landedRound.stakes landedRound.rolls
+                List.map4 (resolveCoin sky) model.coins model.tallies landedRound.stakes landedRound.rolls
 
             newBalance =
                 max 0 (model.balanceCents + List.sum (List.map .deltaCents outcomes))

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -8,6 +8,7 @@ module MultiCoinGame exposing
     , BustCause(..)
     , CorrelationBook(..)
     , CorrelationBookOffer(..)
+    , ExtraTurnsOffer(..)
     , CoinConfig
     , CoinOdds(..)
     , CoinTally
@@ -124,6 +125,15 @@ type TurnBudget
     | FlipLimit Int
 
 
+{-| Buying more turns: satire made purchasable. Only offered in
+flip-limited games, repeatable, and priced so that only someone who has
+basically already won can afford to keep playing.
+-}
+type ExtraTurnsOffer
+    = NoExtraTurns
+    | ExtraTurnsForSale { priceCents : Int, extraFlips : Int }
+
+
 {-| The golden glasses reveal every coin's payout multiplier while
 playing (the win percents stay hidden; that is what the ratio tracker
 approximates). Price in cents.
@@ -237,6 +247,7 @@ type ShopItemKind
     | AllocatorItem
     | BookItem
     | RefundItem
+    | ExtraTurnsItem
     | UncleAdviceItem
 
 
@@ -274,6 +285,7 @@ type alias MultiCoinConfig =
     , allocatorOffer : AllocatorOffer
     , bookOffer : CorrelationBookOffer
     , refundOffer : RefundOffer
+    , extraTurnsOffer : ExtraTurnsOffer
     , introLogLine : String
     }
 
@@ -302,6 +314,7 @@ type alias Model =
     , pairTallies : List PairTally
     , adviceHeard : List String
     , refund : RefundState
+    , extraFlipsBought : Int
     , autoclicker : Autoclicker
     , flipHold : FlipHold
     , flipHelperCount : Int
@@ -337,6 +350,7 @@ type Msg
     | FlipHelpersTicked
     | ShopToggled
     | RefundRequested
+    | ExtraTurnsPurchased
     | PurchaseConsidered ShopItemKind ClickPoint
     | PurchaseConfirmed
     | PurchaseCancelled
@@ -423,6 +437,7 @@ initialModel config =
     , pairTallies = initialPairTallies (List.length config.coins)
     , adviceHeard = []
     , refund = RefundNotAsked
+    , extraFlipsBought = 0
     , autoclicker = ClickerNotBought
     , flipHold = FlipReleased
     , flipHelperCount = 0
@@ -486,6 +501,9 @@ update config msg model =
         RefundRequested ->
             ( requestRefund config.uncleOffer config.refundOffer model, Cmd.none )
 
+        ExtraTurnsPurchased ->
+            ( purchaseExtraTurns config.extraTurnsOffer model, Cmd.none )
+
         PurchaseConsidered itemKind clickPoint ->
             ( { model | pendingPurchase = Considering itemKind clickPoint }, Cmd.none )
 
@@ -527,6 +545,10 @@ update config msg model =
                         { model | pendingPurchase = NoPendingPurchase }
                     , Cmd.none
                     )
+
+                Considering ExtraTurnsItem _ ->
+                    -- Stays open: the house sells time by the armful.
+                    ( purchaseExtraTurns config.extraTurnsOffer model, Cmd.none )
 
                 Considering RefundItem _ ->
                     ( requestRefund config.uncleOffer
@@ -904,7 +926,7 @@ endWhenOutOfFlips budget model =
             model
 
         FlipLimit flipLimit ->
-            if model.phase == Playing && model.roundCount >= flipLimit then
+            if model.phase == Playing && model.roundCount >= flipLimit + model.extraFlipsBought then
                 { model | phase = RanOutOfTime }
 
             else
@@ -1125,6 +1147,36 @@ purchaseAllocator offer model =
                     { model
                         | balanceCents = model.balanceCents - priceCents
                         , allocationMode = PercentAllocation
+                    }
+
+
+{-| Buy more flips. Repeatable: the house is always happy to extend
+your opportunity to give it money.
+-}
+purchaseExtraTurns : ExtraTurnsOffer -> Model -> Model
+purchaseExtraTurns offer model =
+    case offer of
+        NoExtraTurns ->
+            model
+
+        ExtraTurnsForSale sale ->
+            if model.phase /= Playing then
+                model
+
+            else if model.balanceCents <= sale.priceCents then
+                logLine NeutralTone "You cannot afford more flips." model
+
+            else
+                logLine NeutralTone
+                    ("Bought "
+                        ++ String.fromInt sale.extraFlips
+                        ++ " more flips for $"
+                        ++ formatCents sale.priceCents
+                        ++ ". Money can buy time after all."
+                    )
+                    { model
+                        | balanceCents = model.balanceCents - sale.priceCents
+                        , extraFlipsBought = model.extraFlipsBought + sale.extraFlips
                     }
 
 
@@ -1455,7 +1507,11 @@ viewStats config model =
                 Html.div []
                     [ Html.text "Flips left: "
                     , Html.span [ Html.Attributes.class "timer" ]
-                        [ Html.text (String.fromInt (max 0 (flipLimit - model.roundCount))) ]
+                        [ Html.text
+                            (String.fromInt
+                                (max 0 (flipLimit + model.extraFlipsBought - model.roundCount))
+                            )
+                        ]
                     ]
         ]
 
@@ -1676,6 +1732,7 @@ viewShop config model =
             viewAutoclickerShopItem config.autoclickerOffer model
                 ++ viewFlipHelperShopItem config.flipHelperOffer model
                 ++ viewAllocatorShopItem config.allocatorOffer model
+                ++ viewExtraTurnsShopItem config
 
         intelItems =
             viewTrackerShopItem config.trackerOffer model
@@ -1775,6 +1832,9 @@ itemDisplayName itemKind =
         RefundItem ->
             "your money back from uncle"
 
+        ExtraTurnsItem ->
+            "more flips"
+
         UncleAdviceItem ->
             "uncle's advice"
 
@@ -1802,6 +1862,9 @@ itemExplanation itemKind =
 
         RefundItem ->
             "After all that terrible advice, surely a refund is in order. Asking costs money, he is a busy man."
+
+        ExtraTurnsItem ->
+            "Out of flips? Nonsense. The house happily extends your opportunity to give it money."
 
         UncleAdviceItem ->
             "Uncle's advice speaks for itself. He's your uncle, surely he knows best."
@@ -1864,6 +1927,14 @@ itemPriceCents config model itemKind =
 
                 RefundForSale refund ->
                     refund.priceCents
+
+        ExtraTurnsItem ->
+            case config.extraTurnsOffer of
+                NoExtraTurns ->
+                    0
+
+                ExtraTurnsForSale sale ->
+                    sale.priceCents
 
         UncleAdviceItem ->
             case config.uncleOffer of
@@ -1985,6 +2056,28 @@ viewUncleShopItem offer =
 
         UncleAdviceForSale uncle ->
             [ viewShopItem (PurchaseConsidered UncleAdviceItem) "Ask uncle for advice" uncle.priceCents ]
+
+
+{-| More flips, for sale forever, but only where a flip limit exists to
+extend: under a time limit the item would be nonsense.
+-}
+viewExtraTurnsShopItem : MultiCoinConfig -> List (Html Msg)
+viewExtraTurnsShopItem config =
+    case ( config.extraTurnsOffer, config.turnBudget ) of
+        ( NoExtraTurns, TimeLimit _ ) ->
+            []
+
+        ( NoExtraTurns, FlipLimit _ ) ->
+            []
+
+        ( ExtraTurnsForSale _, TimeLimit _ ) ->
+            []
+
+        ( ExtraTurnsForSale sale, FlipLimit _ ) ->
+            [ viewShopItem (PurchaseConsidered ExtraTurnsItem)
+                ("Buy " ++ String.fromInt sale.extraFlips ++ " more flips")
+                sale.priceCents
+            ]
 
 
 {-| Only for sale once uncle's complete works have been heard, and only

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -3,8 +3,11 @@ module MultiCoinGame exposing
     , AutoclickerOffer(..)
     , BustCause(..)
     , CoinConfig
+    , CoinOdds(..)
     , CoinTally
     , FlipHelperOffer(..)
+    , SkyState(..)
+    , TurnBudget(..)
     , FlipHold(..)
     , GlassesOffer(..)
     , GoldenGlasses(..)
@@ -57,6 +60,7 @@ import CoinFlipGame
         , GamePhase(..)
         , LogLine
         , LogTone(..)
+        , NextLevelLink(..)
         , TrackerOffer(..)
         , TrackerState(..)
         , UncleGloat(..)
@@ -78,14 +82,40 @@ import ShopDialog exposing (ClickPoint, ShopFold(..))
 import Time
 
 
-{-| One coin on the table. The win percent and the payout (as a percent
-of the stake: 100 = 1:1, 3000 = 30x) are never shown to the player.
+{-| One coin on the table. The odds and the payout (as a percent of the
+stake: 100 = 1:1, 3000 = 30x) are never shown to the player.
 -}
 type alias CoinConfig =
     { coinName : String
-    , winPercent : Int
+    , odds : CoinOdds
     , payoutPercent : Int
     }
+
+
+{-| How a coin decides its landing. Independent coins roll their own
+die; weather coins win exactly when the round's single hidden weather
+roll goes their way, which makes a sunny and a rainy coin perfectly
+anti-correlated: exactly one of them wins every round.
+-}
+type CoinOdds
+    = IndependentPercent Int
+    | WinsWhenSunny
+    | WinsWhenRainy
+
+
+{-| The hidden weather of one round, drawn once and shared by every
+weather coin.
+-}
+type SkyState
+    = Sunny
+    | Rainy
+
+
+{-| Whether the game ends by clock or by a fixed number of flips.
+-}
+type TurnBudget
+    = TimeLimit Int
+    | FlipLimit Int
 
 
 {-| The golden glasses reveal every coin's payout multiplier while
@@ -166,6 +196,9 @@ type ProfileAssignment
 type alias MultiCoinConfig =
     { title : String
     , coins : List CoinConfig
+    , weatherSunPercent : Int
+    , turnBudget : TurnBudget
+    , nextLevelLink : NextLevelLink
     , profileAssignment : ProfileAssignment
     , trackerOffer : TrackerOffer
     , uncleOffer : UncleOffer
@@ -233,7 +266,7 @@ type Msg
     | PurchaseConfirmed
     | PurchaseCancelled
     | DialogClicked
-    | CoinsLanded { stakes : List Int, rolls : List Int }
+    | CoinsLanded { stakes : List Int, weatherRoll : Int, rolls : List Int }
     | ClockTicked
     | TrackerPurchased
     | GlassesPurchased
@@ -247,7 +280,7 @@ gameProgram config =
     Browser.element
         { init = init config
         , update = update config
-        , subscriptions = subscriptions
+        , subscriptions = subscriptions config
         , view = view config
         }
 
@@ -270,9 +303,9 @@ init config () =
     )
 
 
-{-| Deal the (win percent, payout) profiles across the coin names at
-random: the names keep their display order, the profiles land on a
-random coin each.
+{-| Deal the (odds, payout) profiles across the coin names at random:
+the names keep their display order, the profiles land on a random coin
+each.
 -}
 shuffledCoinsGenerator : List CoinConfig -> Random.Generator (List CoinConfig)
 shuffledCoinsGenerator coins =
@@ -280,7 +313,7 @@ shuffledCoinsGenerator coins =
         (\sortKeys ->
             List.map2
                 (\coin profile ->
-                    { coin | winPercent = profile.winPercent, payoutPercent = profile.payoutPercent }
+                    { coin | odds = profile.odds, payoutPercent = profile.payoutPercent }
                 )
                 coins
                 (List.map Tuple.second
@@ -298,7 +331,13 @@ initialModel config =
     , tallies = List.map (\_ -> { headsCount = 0, flipCount = 0 }) config.coins
     , phase = Playing
     , clock = ClockIdle
-    , secondsLeft = timeLimitSeconds
+    , secondsLeft =
+        case config.turnBudget of
+            TimeLimit seconds ->
+                seconds
+
+            FlipLimit _ ->
+                0
     , roundCount = 0
     , tracker = TrackerNotBought
     , glasses = GlassesNotBought
@@ -504,8 +543,13 @@ pressFlip config model =
                 else
                     ( { model | clock = ClockRunning }
                     , Random.generate
-                        (\rolls -> CoinsLanded { stakes = stakes, rolls = rolls })
-                        (Random.list (List.length model.coins) (Random.int 1 100))
+                        (\( weatherRoll, rolls ) ->
+                            CoinsLanded { stakes = stakes, weatherRoll = weatherRoll, rolls = rolls }
+                        )
+                        (Random.pair
+                            (Random.int 1 100)
+                            (Random.list (List.length model.coins) (Random.int 1 100))
+                        )
                     )
 
 
@@ -570,19 +614,37 @@ type alias CoinOutcome =
     }
 
 
-resolveCoin : CoinConfig -> CoinTally -> Int -> Int -> CoinOutcome
-resolveCoin coin tally stake roll =
+resolveCoin : SkyState -> CoinConfig -> CoinTally -> Int -> Int -> CoinOutcome
+resolveCoin sky coin tally stake roll =
     if stake <= 0 then
         { tally = tally, deltaCents = 0, logLines = [] }
 
     else
         let
             landed =
-                if roll <= coin.winPercent then
-                    Heads
+                case coin.odds of
+                    IndependentPercent winPercent ->
+                        if roll <= winPercent then
+                            Heads
 
-                else
-                    Tails
+                        else
+                            Tails
+
+                    WinsWhenSunny ->
+                        case sky of
+                            Sunny ->
+                                Heads
+
+                            Rainy ->
+                                Tails
+
+                    WinsWhenRainy ->
+                        case sky of
+                            Sunny ->
+                                Tails
+
+                            Rainy ->
+                                Heads
         in
         case landed of
             Heads ->
@@ -623,15 +685,22 @@ resolveCoin coin tally stake roll =
 {-| Apply a landed round: pay out or collect per staked coin, update the
 tallies, and check for the win/bust end states.
 -}
-settleRound : MultiCoinConfig -> { stakes : List Int, rolls : List Int } -> Model -> Model
+settleRound : MultiCoinConfig -> { stakes : List Int, weatherRoll : Int, rolls : List Int } -> Model -> Model
 settleRound config landedRound model =
     if model.phase /= Playing then
         model
 
     else
         let
+            sky =
+                if landedRound.weatherRoll <= config.weatherSunPercent then
+                    Sunny
+
+                else
+                    Rainy
+
             outcomes =
-                List.map4 resolveCoin model.coins model.tallies landedRound.stakes landedRound.rolls
+                List.map4 (resolveCoin sky) model.coins model.tallies landedRound.stakes landedRound.rolls
 
             newBalance =
                 max 0 (model.balanceCents + List.sum (List.map .deltaCents outcomes))
@@ -640,14 +709,34 @@ settleRound config landedRound model =
                 List.concatMap .logLines outcomes
         in
         gloatIfBusted config.uncleOffer
-            (checkEndState BustByBetting
-                { model
-                    | balanceCents = newBalance
-                    , tallies = List.map .tally outcomes
-                    , roundCount = model.roundCount + 1
-                    , log = List.reverse roundLogLines ++ model.log
-                }
+            (endWhenOutOfFlips config.turnBudget
+                (checkEndState BustByBetting
+                    { model
+                        | balanceCents = newBalance
+                        , tallies = List.map .tally outcomes
+                        , roundCount = model.roundCount + 1
+                        , log = List.reverse roundLogLines ++ model.log
+                    }
+                )
             )
+
+
+{-| With a flip budget, the game ends once the last flip has settled.
+Winning or busting on that final flip takes precedence: this only fires
+while still playing.
+-}
+endWhenOutOfFlips : TurnBudget -> Model -> Model
+endWhenOutOfFlips budget model =
+    case budget of
+        TimeLimit _ ->
+            model
+
+        FlipLimit flipLimit ->
+            if model.phase == Playing && model.roundCount >= flipLimit then
+                { model | phase = RanOutOfTime }
+
+            else
+                model
 
 
 checkEndState : BustCause -> Model -> Model
@@ -885,10 +974,10 @@ logLine tone text model =
     { model | log = { tone = tone, text = text } :: model.log }
 
 
-subscriptions : Model -> Sub Msg
-subscriptions model =
+subscriptions : MultiCoinConfig -> Model -> Sub Msg
+subscriptions config model =
     Sub.batch
-        [ clockSubscription model
+        [ clockSubscription config model
         , autoclickerSubscription model
         , flipHelperSubscription model
         , dialogDismissSubscription model
@@ -933,25 +1022,30 @@ flipHelperSubscription model =
             Sub.none
 
 
-clockSubscription : Model -> Sub Msg
-clockSubscription model =
-    case model.phase of
-        Playing ->
-            case model.clock of
-                ClockRunning ->
-                    Time.every 1000 (\_ -> ClockTicked)
+clockSubscription : MultiCoinConfig -> Model -> Sub Msg
+clockSubscription config model =
+    case config.turnBudget of
+        FlipLimit _ ->
+            Sub.none
 
-                ClockIdle ->
+        TimeLimit _ ->
+            case model.phase of
+                Playing ->
+                    case model.clock of
+                        ClockRunning ->
+                            Time.every 1000 (\_ -> ClockTicked)
+
+                        ClockIdle ->
+                            Sub.none
+
+                WonGame ->
                     Sub.none
 
-        WonGame ->
-            Sub.none
+                WentBust ->
+                    Sub.none
 
-        WentBust ->
-            Sub.none
-
-        RanOutOfTime ->
-            Sub.none
+                RanOutOfTime ->
+                    Sub.none
 
 
 {-| While a bought autoclicker's flip button is held down, a flip fires
@@ -997,7 +1091,7 @@ view config model =
     Html.div [ Html.Attributes.id "coin-flip-game" ]
         (List.concat
             [ [ Html.h3 [] [ Html.text config.title ]
-              , viewStats model
+              , viewStats config model
               , viewProgressBar model
               , Html.div []
                     [ Html.text "Total flips: "
@@ -1017,15 +1111,24 @@ view config model =
         )
 
 
-viewStats : Model -> Html Msg
-viewStats model =
+viewStats : MultiCoinConfig -> Model -> Html Msg
+viewStats config model =
     Html.div [ Html.Attributes.class "stats" ]
         [ Html.div [] [ Html.text ("Target: $" ++ String.fromInt (targetBalanceCents // 100)) ]
-        , Html.div []
-            [ Html.text "Time left: "
-            , Html.span [ Html.Attributes.class "timer" ]
-                [ Html.text (formatClock model.secondsLeft) ]
-            ]
+        , case config.turnBudget of
+            TimeLimit _ ->
+                Html.div []
+                    [ Html.text "Time left: "
+                    , Html.span [ Html.Attributes.class "timer" ]
+                        [ Html.text (formatClock model.secondsLeft) ]
+                    ]
+
+            FlipLimit flipLimit ->
+                Html.div []
+                    [ Html.text "Flips left: "
+                    , Html.span [ Html.Attributes.class "timer" ]
+                        [ Html.text (String.fromInt (max 0 (flipLimit - model.roundCount))) ]
+                    ]
         ]
 
 
@@ -1406,12 +1509,13 @@ viewGameOver : MultiCoinConfig -> Model -> Html Msg
 viewGameOver config model =
     let
         ( message, tone ) =
-            gameOverMessage model
+            gameOverMessage config model
     in
     Html.div
         [ Html.Attributes.class ("game-over " ++ CoinFlipGame.toneClass tone) ]
         (List.concat
             [ [ Html.text message ]
+            , viewNextLevelLink config.nextLevelLink model
             , viewUncleBustCallout model
             , [ Html.div []
                     [ Html.text "It took you exactly "
@@ -1439,8 +1543,8 @@ viewUncleBustCallout model =
             ]
 
 
-gameOverMessage : Model -> ( String, LogTone )
-gameOverMessage model =
+gameOverMessage : MultiCoinConfig -> Model -> ( String, LogTone )
+gameOverMessage config model =
     case model.phase of
         Playing ->
             ( "", NeutralTone )
@@ -1452,7 +1556,28 @@ gameOverMessage model =
             ( "\u{1F480} REKT! You hit $0.00. Bankrupt.", LoseTone )
 
         RanOutOfTime ->
-            ( "Time's up! You failed to reach the target.", LoseTone )
+            case config.turnBudget of
+                TimeLimit _ ->
+                    ( "Time's up! You failed to reach the target.", LoseTone )
+
+                FlipLimit _ ->
+                    ( "Out of flips! You failed to reach the target.", LoseTone )
+
+
+viewNextLevelLink : NextLevelLink -> Model -> List (Html Msg)
+viewNextLevelLink link model =
+    case link of
+        NoNextLevelLink ->
+            []
+
+        NextLevelLinkTo nextLevel ->
+            if model.phase == WonGame then
+                [ Html.text " "
+                , Html.a [ Html.Attributes.href nextLevel.url ] [ Html.text nextLevel.label ]
+                ]
+
+            else
+                []
 
 
 {-| A payout percent as a multiplier: 3000 -> "30x", 50 -> "0.5x".

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -1,7 +1,11 @@
 module MultiCoinGame exposing
-    ( Autoclicker(..)
+    ( AllocationMode(..)
+    , AllocatorOffer(..)
+    , Autoclicker(..)
     , AutoclickerOffer(..)
     , BustCause(..)
+    , CorrelationBook(..)
+    , CorrelationBookOffer(..)
     , CoinConfig
     , CoinOdds(..)
     , CoinTally
@@ -132,6 +136,49 @@ type GoldenGlasses
     | GlassesBought
 
 
+{-| The percentage allocator upgrades the stake inputs: amounts become
+percentages of the live balance, re-sized automatically on every flip.
+Price in cents.
+-}
+type AllocatorOffer
+    = NoAllocator
+    | AllocatorForSale Int
+
+
+{-| How the stake inputs are read: dollar amounts, or (after buying the
+allocator) percentages of the current balance.
+-}
+type AllocationMode
+    = DollarAllocation
+    | PercentAllocation
+
+
+{-| The Elegant Universe, a book about strings: it reveals which coins
+move together by tracking how often each pair lands the same way.
+Price in cents.
+-}
+type CorrelationBookOffer
+    = NoCorrelationBook
+    | CorrelationBookForSale Int
+
+
+type CorrelationBook
+    = BookNotBought
+    | BookBought
+
+
+{-| Same-outcome bookkeeping for one pair of coins, counting only
+rounds where both were staked. Indices point into the coin list, whose
+names never move (only profiles shuffle).
+-}
+type alias PairTally =
+    { firstIndex : Int
+    , secondIndex : Int
+    , sameCount : Int
+    , bothCount : Int
+    }
+
+
 {-| The autoclicker spares the player's mouse finger: once bought,
 holding the flip button down fires a flip every 100ms. Price in cents.
 -}
@@ -171,6 +218,8 @@ type ShopItemKind
     | GlassesItem
     | AutoclickerItem
     | FlipHelperItem
+    | AllocatorItem
+    | BookItem
     | UncleAdviceItem
 
 
@@ -205,6 +254,8 @@ type alias MultiCoinConfig =
     , glassesOffer : GlassesOffer
     , autoclickerOffer : AutoclickerOffer
     , flipHelperOffer : FlipHelperOffer
+    , allocatorOffer : AllocatorOffer
+    , bookOffer : CorrelationBookOffer
     , introLogLine : String
     }
 
@@ -228,6 +279,9 @@ type alias Model =
     , roundCount : Int
     , tracker : TrackerState
     , glasses : GoldenGlasses
+    , allocationMode : AllocationMode
+    , book : CorrelationBook
+    , pairTallies : List PairTally
     , autoclicker : Autoclicker
     , flipHold : FlipHold
     , flipHelperCount : Int
@@ -270,6 +324,8 @@ type Msg
     | ClockTicked
     | TrackerPurchased
     | GlassesPurchased
+    | AllocatorPurchased
+    | BookPurchased
     | AutoclickerPurchased
     | UncleAdviceRequested
     | UncleAdviceGiven String
@@ -341,6 +397,9 @@ initialModel config =
     , roundCount = 0
     , tracker = TrackerNotBought
     , glasses = GlassesNotBought
+    , allocationMode = DollarAllocation
+    , book = BookNotBought
+    , pairTallies = initialPairTallies (List.length config.coins)
     , autoclicker = ClickerNotBought
     , flipHold = FlipReleased
     , flipHelperCount = 0
@@ -441,6 +500,18 @@ update config msg model =
                     -- Stays open: fleets are hired by mashing confirm.
                     ( hireFlipHelper config.flipHelperOffer model, Cmd.none )
 
+                Considering AllocatorItem _ ->
+                    ( purchaseAllocator config.allocatorOffer
+                        { model | pendingPurchase = NoPendingPurchase }
+                    , Cmd.none
+                    )
+
+                Considering BookItem _ ->
+                    ( purchaseBook config.bookOffer
+                        { model | pendingPurchase = NoPendingPurchase }
+                    , Cmd.none
+                    )
+
                 Considering UncleAdviceItem _ ->
                     -- Stays open: uncle appreciates repeat customers.
                     purchaseUncleAdvice config.uncleOffer model
@@ -464,6 +535,12 @@ update config msg model =
 
         GlassesPurchased ->
             ( purchaseGlasses config.glassesOffer model, Cmd.none )
+
+        AllocatorPurchased ->
+            ( purchaseAllocator config.allocatorOffer model, Cmd.none )
+
+        BookPurchased ->
+            ( purchaseBook config.bookOffer model, Cmd.none )
 
         AutoclickerPurchased ->
             ( purchaseAutoclicker config.autoclickerOffer model, Cmd.none )
@@ -525,8 +602,16 @@ pressFlip config model =
                 , Cmd.none
                 )
 
-            ReadableStakes stakes ->
+            ReadableStakes parsedStakes ->
                 let
+                    stakes =
+                        case model.allocationMode of
+                            DollarAllocation ->
+                                parsedStakes
+
+                            PercentAllocation ->
+                                List.map (percentStakeCents model.balanceCents) parsedStakes
+
                     totalStaked =
                         List.sum stakes
                 in
@@ -596,6 +681,19 @@ prependStake cents validated =
             ReadableStakes (cents :: stakes)
 
 
+{-| A percent-mode stake: the input parses to hundredths of a percent
+("24.4" -> 2440), applied to the live balance, floored to whole cents
+but never zero while a percentage was actually entered.
+-}
+percentStakeCents : Int -> Int -> Int
+percentStakeCents balanceCents percentHundredths =
+    if percentHundredths <= 0 then
+        0
+
+    else
+        max 1 (balanceCents * percentHundredths // 10000)
+
+
 {-| What a win on this stake pays out (the profit; the stake itself is
 never taken on a win, matching levels 1 and 2). Floored to whole cents
 but never zero: a "win" that pays nothing would be a silent lie.
@@ -610,14 +708,57 @@ payoutCents payoutPercent stake =
 type alias CoinOutcome =
     { tally : CoinTally
     , deltaCents : Int
+    , landedSide : Maybe CoinSide
     , logLines : List LogLine
     }
 
 
-resolveCoin : SkyState -> CoinConfig -> CoinTally -> Int -> Int -> CoinOutcome
-resolveCoin sky coin tally stake roll =
+{-| The other weather coin's name, for the "therefore" clause in the
+log: a sunny coin's partner is the rainy coin and vice versa.
+Independent coins have none.
+-}
+partnerNameFor : List CoinConfig -> CoinConfig -> Maybe String
+partnerNameFor coins coin =
+    case coin.odds of
+        IndependentPercent _ ->
+            Nothing
+
+        WinsWhenSunny ->
+            oddsCoinName WinsWhenRainy coins
+
+        WinsWhenRainy ->
+            oddsCoinName WinsWhenSunny coins
+
+
+oddsCoinName : CoinOdds -> List CoinConfig -> Maybe String
+oddsCoinName odds coins =
+    List.filter (\coin -> coin.odds == odds) coins
+        |> List.head
+        |> Maybe.map .coinName
+
+
+{-| The correlation, spelled out: when a weather coin lands, its
+partner necessarily landed the other way.
+-}
+thereforeClause : Maybe String -> CoinSide -> String
+thereforeClause mPartner landed =
+    case mPartner of
+        Nothing ->
+            ""
+
+        Just partnerName ->
+            case landed of
+                Heads ->
+                    " Therefore " ++ partnerName ++ " loses."
+
+                Tails ->
+                    " Therefore " ++ partnerName ++ " wins."
+
+
+resolveCoin : SkyState -> Maybe String -> CoinConfig -> CoinTally -> Int -> Int -> CoinOutcome
+resolveCoin sky mPartner coin tally stake roll =
     if stake <= 0 then
-        { tally = tally, deltaCents = 0, logLines = [] }
+        { tally = tally, deltaCents = 0, landedSide = Nothing, logLines = [] }
 
     else
         let
@@ -658,6 +799,7 @@ resolveCoin sky coin tally stake roll =
                 -- winnings alone: the stake never left the balance.
                 { tally = { headsCount = tally.headsCount + 1, flipCount = tally.flipCount + 1 }
                 , deltaCents = paidOut
+                , landedSide = Just Heads
                 , logLines =
                     [ { tone = WinTone
                       , text =
@@ -667,6 +809,7 @@ resolveCoin sky coin tally stake roll =
                                 ++ ", of which $"
                                 ++ formatCents stake
                                 ++ " is your stake."
+                                ++ thereforeClause mPartner Heads
                       }
                     ]
                 }
@@ -674,9 +817,15 @@ resolveCoin sky coin tally stake roll =
             Tails ->
                 { tally = { headsCount = tally.headsCount, flipCount = tally.flipCount + 1 }
                 , deltaCents = -stake
+                , landedSide = Just Tails
                 , logLines =
                     [ { tone = LoseTone
-                      , text = coin.coinName ++ " landed tails. You lost your $" ++ formatCents stake ++ " stake."
+                      , text =
+                            coin.coinName
+                                ++ " landed tails. You lost your $"
+                                ++ formatCents stake
+                                ++ " stake."
+                                ++ thereforeClause mPartner Tails
                       }
                     ]
                 }
@@ -699,8 +848,11 @@ settleRound config landedRound model =
                 else
                     Rainy
 
+            partners =
+                List.map (partnerNameFor model.coins) model.coins
+
             outcomes =
-                List.map4 (resolveCoin sky) model.coins model.tallies landedRound.stakes landedRound.rolls
+                List.map5 (resolveCoin sky) partners model.coins model.tallies landedRound.stakes landedRound.rolls
 
             newBalance =
                 max 0 (model.balanceCents + List.sum (List.map .deltaCents outcomes))
@@ -714,11 +866,52 @@ settleRound config landedRound model =
                     { model
                         | balanceCents = newBalance
                         , tallies = List.map .tally outcomes
+                        , pairTallies =
+                            updatePairTallies (List.map .landedSide outcomes) model.pairTallies
                         , roundCount = model.roundCount + 1
                         , log = List.reverse roundLogLines ++ model.log
                     }
                 )
             )
+
+
+{-| Count same-outcome landings for every pair where both coins were
+staked this round.
+-}
+updatePairTallies : List (Maybe CoinSide) -> List PairTally -> List PairTally
+updatePairTallies landedSides pairTallies =
+    List.map (updatePairTally landedSides) pairTallies
+
+
+updatePairTally : List (Maybe CoinSide) -> PairTally -> PairTally
+updatePairTally landedSides tally =
+    case ( landedSideAt tally.firstIndex landedSides, landedSideAt tally.secondIndex landedSides ) of
+        ( Just firstSide, Just secondSide ) ->
+            { tally
+                | bothCount = tally.bothCount + 1
+                , sameCount =
+                    if firstSide == secondSide then
+                        tally.sameCount + 1
+
+                    else
+                        tally.sameCount
+            }
+
+        ( Just _, Nothing ) ->
+            tally
+
+        ( Nothing, Just _ ) ->
+            tally
+
+        ( Nothing, Nothing ) ->
+            tally
+
+
+landedSideAt : Int -> List (Maybe CoinSide) -> Maybe CoinSide
+landedSideAt index landedSides =
+    List.drop index landedSides
+        |> List.head
+        |> Maybe.andThen identity
 
 
 {-| With a flip budget, the game ends once the last flip has settled.
@@ -902,6 +1095,91 @@ hireFlipHelper offer model =
 raisePriceByPercent : Int -> Int -> Int
 raisePriceByPercent increasePercent priceCents =
     (priceCents * (100 + increasePercent) + 50) // 100
+
+
+{-| Every unordered pair of coin indices, tallies at zero.
+-}
+initialPairTallies : Int -> List PairTally
+initialPairTallies coinCount =
+    List.concatMap
+        (\firstIndex ->
+            List.map
+                (\secondIndex ->
+                    { firstIndex = firstIndex
+                    , secondIndex = secondIndex
+                    , sameCount = 0
+                    , bothCount = 0
+                    }
+                )
+                (List.range (firstIndex + 1) (coinCount - 1))
+        )
+        (List.range 0 (coinCount - 1))
+
+
+{-| Buy the percentage allocator. Same wipe-out guard as the tracker.
+-}
+purchaseAllocator : AllocatorOffer -> Model -> Model
+purchaseAllocator offer model =
+    case ( offer, model.allocationMode ) of
+        ( NoAllocator, DollarAllocation ) ->
+            model
+
+        ( NoAllocator, PercentAllocation ) ->
+            model
+
+        ( AllocatorForSale _, PercentAllocation ) ->
+            model
+
+        ( AllocatorForSale priceCents, DollarAllocation ) ->
+            if model.phase /= Playing then
+                model
+
+            else if model.balanceCents <= priceCents then
+                logLine NeutralTone "You cannot afford the percentage allocator." model
+
+            else
+                logLine NeutralTone
+                    ("Bought the percentage allocator for $"
+                        ++ formatCents priceCents
+                        ++ ". Stakes are now percentages of your balance, re-sized every flip."
+                    )
+                    { model
+                        | balanceCents = model.balanceCents - priceCents
+                        , allocationMode = PercentAllocation
+                    }
+
+
+{-| Buy The Elegant Universe. Same wipe-out guard as the tracker.
+-}
+purchaseBook : CorrelationBookOffer -> Model -> Model
+purchaseBook offer model =
+    case ( offer, model.book ) of
+        ( NoCorrelationBook, BookNotBought ) ->
+            model
+
+        ( NoCorrelationBook, BookBought ) ->
+            model
+
+        ( CorrelationBookForSale _, BookBought ) ->
+            model
+
+        ( CorrelationBookForSale priceCents, BookNotBought ) ->
+            if model.phase /= Playing then
+                model
+
+            else if model.balanceCents <= priceCents then
+                logLine NeutralTone "You cannot afford The Elegant Universe." model
+
+            else
+                logLine NeutralTone
+                    ("Bought The Elegant Universe for $"
+                        ++ formatCents priceCents
+                        ++ ". It tracks how often each pair of coins lands the same way."
+                    )
+                    { model
+                        | balanceCents = model.balanceCents - priceCents
+                        , book = BookBought
+                    }
 
 
 {-| Buy the autoclicker. Same wipe-out guard as the tracker.
@@ -1151,7 +1429,7 @@ viewControls : MultiCoinConfig -> Model -> Html Msg
 viewControls config model =
     Html.div [ Html.Attributes.class "controls" ]
         (List.concat
-            [ List.indexedMap viewCoinRow
+            [ List.indexedMap (viewCoinRow model.allocationMode)
                 (List.map2 Tuple.pair model.coins model.stakeInputs)
             , [ Html.button
                     (Html.Attributes.class "flip-button"
@@ -1161,6 +1439,7 @@ viewControls config model =
                     [ Html.text "FLIP" ]
               ]
             , viewGlassesPayouts model
+            , viewCorrelations model
             , viewTally config model
             , viewFlipHelpers model
             , viewShop config model
@@ -1235,10 +1514,21 @@ flipHoldEvents clicker =
             ]
 
 
-viewCoinRow : Int -> ( CoinConfig, String ) -> Html Msg
-viewCoinRow coinIndex ( coin, stakeInput ) =
+viewCoinRow : AllocationMode -> Int -> ( CoinConfig, String ) -> Html Msg
+viewCoinRow mode coinIndex ( coin, stakeInput ) =
     Html.div [ Html.Attributes.class "coin-bet" ]
-        [ Html.label [] [ Html.text (coin.coinName ++ " $:") ]
+        [ Html.label []
+            [ Html.text
+                (coin.coinName
+                    ++ (case mode of
+                            DollarAllocation ->
+                                " $:"
+
+                            PercentAllocation ->
+                                " %:"
+                       )
+                )
+            ]
         , Html.input
             [ Html.Attributes.class "bet-amount"
             , Html.Attributes.type_ "number"
@@ -1252,6 +1542,50 @@ viewCoinRow coinIndex ( coin, stakeInput ) =
             ]
             []
         ]
+
+
+{-| The Elegant Universe's readings: how often each pair of coins
+landed the same way, over the rounds both were staked. Only rendered
+once the book is bought.
+-}
+viewCorrelations : Model -> List (Html Msg)
+viewCorrelations model =
+    case model.book of
+        BookNotBought ->
+            []
+
+        BookBought ->
+            [ Html.div [ Html.Attributes.class "correlations" ]
+                [ Html.text
+                    ("\u{1F4D6} Same landing: "
+                        ++ String.join " \u{00B7} "
+                            (List.map (pairTallyText model.coins) model.pairTallies)
+                    )
+                ]
+            ]
+
+
+pairTallyText : List CoinConfig -> PairTally -> String
+pairTallyText coins tally =
+    coinNameAt tally.firstIndex coins
+        ++ "+"
+        ++ coinNameAt tally.secondIndex coins
+        ++ " "
+        ++ String.fromInt tally.sameCount
+        ++ "/"
+        ++ String.fromInt tally.bothCount
+
+
+{-| A coin's display name by position. The fallback is unreachable:
+pair tallies are built from the same list's length at init and names
+never move.
+-}
+coinNameAt : Int -> List CoinConfig -> String
+coinNameAt index coins =
+    List.drop index coins
+        |> List.head
+        |> Maybe.map .coinName
+        |> Maybe.withDefault "?"
 
 
 {-| The per-coin tally the ratio tracker paints under the flip button.
@@ -1292,6 +1626,8 @@ viewShop config model =
             ++ viewGlassesShopItem config.glassesOffer model
             ++ viewAutoclickerShopItem config.autoclickerOffer model
             ++ viewFlipHelperShopItem config.flipHelperOffer model
+            ++ viewAllocatorShopItem config.allocatorOffer model
+            ++ viewBookShopItem config.bookOffer model
             ++ viewUncleShopItem config.uncleOffer
     of
         [] ->
@@ -1358,6 +1694,12 @@ itemDisplayName itemKind =
         FlipHelperItem ->
             "a flip helper"
 
+        AllocatorItem ->
+            "the percentage allocator"
+
+        BookItem ->
+            "The Elegant Universe"
+
         UncleAdviceItem ->
             "uncle's advice"
 
@@ -1376,6 +1718,12 @@ itemExplanation itemKind =
 
         FlipHelperItem ->
             "A tireless helper who presses flip for you once every five seconds. Every next hire asks 10% more."
+
+        AllocatorItem ->
+            "Your stakes become percentages of your balance instead of dollars, re-sized automatically on every flip."
+
+        BookItem ->
+            "A book about strings. It tracks how often each pair of coins lands the same way, revealing which ones are attached."
 
         UncleAdviceItem ->
             "Uncle's advice speaks for itself. He's your uncle, surely he knows best."
@@ -1414,6 +1762,22 @@ itemPriceCents config model itemKind =
 
         FlipHelperItem ->
             model.nextHelperPriceCents
+
+        AllocatorItem ->
+            case config.allocatorOffer of
+                NoAllocator ->
+                    0
+
+                AllocatorForSale priceCents ->
+                    priceCents
+
+        BookItem ->
+            case config.bookOffer of
+                NoCorrelationBook ->
+                    0
+
+                CorrelationBookForSale priceCents ->
+                    priceCents
 
         UncleAdviceItem ->
             case config.uncleOffer of
@@ -1493,6 +1857,38 @@ viewFlipHelperShopItem offer model =
 
         FlipHelpersForSale _ ->
             [ viewShopItem (PurchaseConsidered FlipHelperItem) "Hire flip helper" model.nextHelperPriceCents ]
+
+
+viewAllocatorShopItem : AllocatorOffer -> Model -> List (Html Msg)
+viewAllocatorShopItem offer model =
+    case ( offer, model.allocationMode ) of
+        ( NoAllocator, DollarAllocation ) ->
+            []
+
+        ( NoAllocator, PercentAllocation ) ->
+            []
+
+        ( AllocatorForSale _, PercentAllocation ) ->
+            []
+
+        ( AllocatorForSale priceCents, DollarAllocation ) ->
+            [ viewShopItem (PurchaseConsidered AllocatorItem) "Buy percentage allocator" priceCents ]
+
+
+viewBookShopItem : CorrelationBookOffer -> Model -> List (Html Msg)
+viewBookShopItem offer model =
+    case ( offer, model.book ) of
+        ( NoCorrelationBook, BookNotBought ) ->
+            []
+
+        ( NoCorrelationBook, BookBought ) ->
+            []
+
+        ( CorrelationBookForSale _, BookBought ) ->
+            []
+
+        ( CorrelationBookForSale priceCents, BookNotBought ) ->
+            [ viewShopItem (PurchaseConsidered BookItem) "Buy The Elegant Universe" priceCents ]
 
 
 viewUncleShopItem : UncleOffer -> List (Html Msg)

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -858,8 +858,15 @@ settleRound config landedRound model =
             newBalance =
                 max 0 (model.balanceCents + List.sum (List.map .deltaCents outcomes))
 
+            -- Flip lines carry their round number, so lines from the
+            -- same round can be told apart at a glance in the log.
+            roundNumber =
+                model.roundCount + 1
+
             roundLogLines =
-                List.concatMap .logLines outcomes
+                List.map
+                    (\line -> { line | text = "#" ++ String.fromInt roundNumber ++ " " ++ line.text })
+                    (List.concatMap .logLines outcomes)
         in
         gloatIfBusted config.uncleOffer
             (endWhenOutOfFlips config.turnBudget

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -1,6 +1,8 @@
 module MultiCoinGame exposing
     ( AllocationMode(..)
     , AllocatorOffer(..)
+    , RefundOffer(..)
+    , RefundState(..)
     , Autoclicker(..)
     , AutoclickerOffer(..)
     , BustCause(..)
@@ -167,6 +169,20 @@ type CorrelationBook
     | BookBought
 
 
+{-| The refund request: only for sale once the player has collected
+every one of uncle's phrases, and asking naturally costs money too.
+The reply is configurable because it is the whole joke.
+-}
+type RefundOffer
+    = NoRefund
+    | RefundForSale { priceCents : Int, reply : String }
+
+
+type RefundState
+    = RefundNotAsked
+    | RefundAsked
+
+
 {-| Same-outcome bookkeeping for one pair of coins, counting only
 rounds where both were staked. Indices point into the coin list, whose
 names never move (only profiles shuffle).
@@ -220,6 +236,7 @@ type ShopItemKind
     | FlipHelperItem
     | AllocatorItem
     | BookItem
+    | RefundItem
     | UncleAdviceItem
 
 
@@ -256,6 +273,7 @@ type alias MultiCoinConfig =
     , flipHelperOffer : FlipHelperOffer
     , allocatorOffer : AllocatorOffer
     , bookOffer : CorrelationBookOffer
+    , refundOffer : RefundOffer
     , introLogLine : String
     }
 
@@ -282,6 +300,10 @@ type alias Model =
     , allocationMode : AllocationMode
     , book : CorrelationBook
     , pairTallies : List PairTally
+    , upgradesFold : ShopFold
+    , intelFold : ShopFold
+    , adviceHeard : List String
+    , refund : RefundState
     , autoclicker : Autoclicker
     , flipHold : FlipHold
     , flipHelperCount : Int
@@ -316,6 +338,9 @@ type Msg
     | FlipHelperHired
     | FlipHelpersTicked
     | ShopToggled
+    | UpgradesToggled
+    | IntelToggled
+    | RefundRequested
     | PurchaseConsidered ShopItemKind ClickPoint
     | PurchaseConfirmed
     | PurchaseCancelled
@@ -400,6 +425,10 @@ initialModel config =
     , allocationMode = DollarAllocation
     , book = BookNotBought
     , pairTallies = initialPairTallies (List.length config.coins)
+    , upgradesFold = ShopCollapsed
+    , intelFold = ShopCollapsed
+    , adviceHeard = []
+    , refund = RefundNotAsked
     , autoclicker = ClickerNotBought
     , flipHold = FlipReleased
     , flipHelperCount = 0
@@ -458,17 +487,16 @@ update config msg model =
             pressFlip config { model | helperFlipCount = model.helperFlipCount + 1 }
 
         ShopToggled ->
-            ( { model
-                | shopFold =
-                    case model.shopFold of
-                        ShopCollapsed ->
-                            ShopExpanded
+            ( { model | shopFold = toggleFold model.shopFold }, Cmd.none )
 
-                        ShopExpanded ->
-                            ShopCollapsed
-              }
-            , Cmd.none
-            )
+        UpgradesToggled ->
+            ( { model | upgradesFold = toggleFold model.upgradesFold }, Cmd.none )
+
+        IntelToggled ->
+            ( { model | intelFold = toggleFold model.intelFold }, Cmd.none )
+
+        RefundRequested ->
+            ( requestRefund config.uncleOffer config.refundOffer model, Cmd.none )
 
         PurchaseConsidered itemKind clickPoint ->
             ( { model | pendingPurchase = Considering itemKind clickPoint }, Cmd.none )
@@ -512,6 +540,13 @@ update config msg model =
                     , Cmd.none
                     )
 
+                Considering RefundItem _ ->
+                    ( requestRefund config.uncleOffer
+                        config.refundOffer
+                        { model | pendingPurchase = NoPendingPurchase }
+                    , Cmd.none
+                    )
+
                 Considering UncleAdviceItem _ ->
                     -- Stays open: uncle appreciates repeat customers.
                     purchaseUncleAdvice config.uncleOffer model
@@ -550,7 +585,10 @@ update config msg model =
 
         UncleAdviceGiven phrase ->
             ( gloatIfBusted config.uncleOffer
-                (logLine NeutralTone ("\u{1F9D3} Uncle: \u{201C}" ++ phrase ++ "\u{201D}") model)
+                (logLine NeutralTone
+                    ("\u{1F9D3} Uncle: \u{201C}" ++ phrase ++ "\u{201D}")
+                    (hearAdvice phrase model)
+                )
             , Cmd.none
             )
 
@@ -1215,6 +1253,77 @@ purchaseAutoclicker offer model =
                     }
 
 
+toggleFold : ShopFold -> ShopFold
+toggleFold fold =
+    case fold of
+        ShopCollapsed ->
+            ShopExpanded
+
+        ShopExpanded ->
+            ShopCollapsed
+
+
+{-| Remember each distinct phrase, so the refund request can unlock
+once uncle's complete works have been collected.
+-}
+hearAdvice : String -> Model -> Model
+hearAdvice phrase model =
+    if List.member phrase model.adviceHeard then
+        model
+
+    else
+        { model | adviceHeard = phrase :: model.adviceHeard }
+
+
+{-| Whether every one of uncle's phrases has been heard at least once.
+-}
+allAdviceHeard : UncleOffer -> Model -> Bool
+allAdviceHeard offer model =
+    case offer of
+        NoUncleAdvice ->
+            False
+
+        UncleAdviceForSale uncle ->
+            List.length model.adviceHeard >= 1 + List.length uncle.morePhrases
+
+
+{-| Ask uncle for the money back. Asking costs money too, uncle can
+take your last dollars doing it (he is family, after all), and the
+configured reply is the only thing you get. No async advice is in
+flight here, so the gloat lands right away when asking was the final
+straw.
+-}
+requestRefund : UncleOffer -> RefundOffer -> Model -> Model
+requestRefund uncleOffer offer model =
+    case ( offer, model.refund ) of
+        ( NoRefund, RefundNotAsked ) ->
+            model
+
+        ( NoRefund, RefundAsked ) ->
+            model
+
+        ( RefundForSale _, RefundAsked ) ->
+            model
+
+        ( RefundForSale refund, RefundNotAsked ) ->
+            if model.phase /= Playing then
+                model
+
+            else if model.balanceCents < refund.priceCents then
+                logLine NeutralTone "You cannot afford to ask uncle for your money back." model
+
+            else
+                gloatIfBusted uncleOffer
+                    (logLine NeutralTone ("\u{1F9D3} Uncle: \u{201C}" ++ refund.reply ++ "\u{201D}")
+                        (checkEndState BustByUncleAdvice
+                            { model
+                                | balanceCents = model.balanceCents - refund.priceCents
+                                , refund = RefundAsked
+                            }
+                        )
+                    )
+
+
 {-| Pay uncle and draw one of his pre-programmed pearls of wisdom.
 Unlike the tracker and glasses, uncle happily takes your last dollars:
 spending yourself into bankruptcy on advice is a lesson the game wants
@@ -1621,19 +1730,24 @@ coinTallyText coin tally =
 
 viewShop : MultiCoinConfig -> Model -> List (Html Msg)
 viewShop config model =
-    case
-        viewTrackerShopItem config.trackerOffer model
-            ++ viewGlassesShopItem config.glassesOffer model
-            ++ viewAutoclickerShopItem config.autoclickerOffer model
-            ++ viewFlipHelperShopItem config.flipHelperOffer model
-            ++ viewAllocatorShopItem config.allocatorOffer model
-            ++ viewBookShopItem config.bookOffer model
-            ++ viewUncleShopItem config.uncleOffer
-    of
+    let
+        upgradeItems =
+            viewAutoclickerShopItem config.autoclickerOffer model
+                ++ viewFlipHelperShopItem config.flipHelperOffer model
+                ++ viewAllocatorShopItem config.allocatorOffer model
+
+        intelItems =
+            viewTrackerShopItem config.trackerOffer model
+                ++ viewGlassesShopItem config.glassesOffer model
+                ++ viewBookShopItem config.bookOffer model
+                ++ viewUncleShopItem config.uncleOffer
+                ++ viewRefundShopItem config model
+    in
+    case upgradeItems ++ intelItems of
         [] ->
             []
 
-        shopItems ->
+        _ ->
             [ Html.div [ Html.Attributes.class "shop" ]
                 (viewShopToggle model.shopFold
                     :: (case model.shopFold of
@@ -1641,10 +1755,34 @@ viewShop config model =
                                 []
 
                             ShopExpanded ->
-                                shopItems ++ viewPurchaseDialog config model
+                                List.concat
+                                    [ viewShopGroup UpgradesToggled "Upgrades" model.upgradesFold upgradeItems
+                                    , viewShopGroup IntelToggled "Intel" model.intelFold intelItems
+                                    , viewPurchaseDialog config model
+                                    ]
                        )
                 )
             ]
+
+
+{-| A shop submenu: a collapsible group header with its items, hidden
+entirely when the group has nothing for sale.
+-}
+viewShopGroup : Msg -> String -> ShopFold -> List (Html Msg) -> List (Html Msg)
+viewShopGroup onToggle label fold groupItems =
+    case groupItems of
+        [] ->
+            []
+
+        _ ->
+            ShopDialog.viewShopGroupToggle onToggle label fold
+                :: (case fold of
+                        ShopCollapsed ->
+                            []
+
+                        ShopExpanded ->
+                            groupItems
+                   )
 
 
 {-| The confirm/cancel dialog a considered purchase opens, explaining
@@ -1700,6 +1838,9 @@ itemDisplayName itemKind =
         BookItem ->
             "The Elegant Universe"
 
+        RefundItem ->
+            "your money back from uncle"
+
         UncleAdviceItem ->
             "uncle's advice"
 
@@ -1724,6 +1865,9 @@ itemExplanation itemKind =
 
         BookItem ->
             "A book about strings. It tracks how often each pair of coins lands the same way, revealing which ones are attached."
+
+        RefundItem ->
+            "After all that terrible advice, surely a refund is in order. Asking costs money, he is a busy man."
 
         UncleAdviceItem ->
             "Uncle's advice speaks for itself. He's your uncle, surely he knows best."
@@ -1778,6 +1922,14 @@ itemPriceCents config model itemKind =
 
                 CorrelationBookForSale priceCents ->
                     priceCents
+
+        RefundItem ->
+            case config.refundOffer of
+                NoRefund ->
+                    0
+
+                RefundForSale refund ->
+                    refund.priceCents
 
         UncleAdviceItem ->
             case config.uncleOffer of
@@ -1899,6 +2051,29 @@ viewUncleShopItem offer =
 
         UncleAdviceForSale uncle ->
             [ viewShopItem (PurchaseConsidered UncleAdviceItem) "Ask uncle for advice" uncle.priceCents ]
+
+
+{-| Only for sale once uncle's complete works have been heard, and only
+once: uncle does not do repeat refund conversations.
+-}
+viewRefundShopItem : MultiCoinConfig -> Model -> List (Html Msg)
+viewRefundShopItem config model =
+    case ( config.refundOffer, model.refund ) of
+        ( NoRefund, RefundNotAsked ) ->
+            []
+
+        ( NoRefund, RefundAsked ) ->
+            []
+
+        ( RefundForSale _, RefundAsked ) ->
+            []
+
+        ( RefundForSale refund, RefundNotAsked ) ->
+            if allAdviceHeard config.uncleOffer model then
+                [ viewShopItem (PurchaseConsidered RefundItem) "Ask your money back" refund.priceCents ]
+
+            else
+                []
 
 
 viewGameOver : MultiCoinConfig -> Model -> Html Msg

--- a/elm/src/ShopDialog.elm
+++ b/elm/src/ShopDialog.elm
@@ -3,6 +3,7 @@ module ShopDialog exposing
     , ShopFold(..)
     , clickPointDecoder
     , viewPurchaseDialog
+    , viewShopGroupToggle
     , viewShopItem
     , viewShopToggle
     )
@@ -65,6 +66,26 @@ viewShopToggle onToggle fold =
 
                 ShopExpanded ->
                     "\u{1F6D2} Shop \u{25BE}"
+            )
+        ]
+
+
+{-| A collapsible group header inside the shop, for submenus like
+"Upgrades" and "Intel".
+-}
+viewShopGroupToggle : msg -> String -> ShopFold -> Html msg
+viewShopGroupToggle onToggle label fold =
+    Html.button
+        [ Html.Attributes.class "shop-subtoggle", Html.Events.onClick onToggle ]
+        [ Html.text
+            (label
+                ++ (case fold of
+                        ShopCollapsed ->
+                            " \u{25B8}"
+
+                        ShopExpanded ->
+                            " \u{25BE}"
+                   )
             )
         ]
 

--- a/elm/src/ShopDialog.elm
+++ b/elm/src/ShopDialog.elm
@@ -3,7 +3,7 @@ module ShopDialog exposing
     , ShopFold(..)
     , clickPointDecoder
     , viewPurchaseDialog
-    , viewShopGroupToggle
+    , viewShopGroupHeading
     , viewShopItem
     , viewShopToggle
     )
@@ -70,24 +70,13 @@ viewShopToggle onToggle fold =
         ]
 
 
-{-| A collapsible group header inside the shop, for submenus like
-"Upgrades" and "Intel".
+{-| A group heading inside the shop, for sections like "Upgrades" and
+"Intel". Plain text, always visible; the items below it get indented by
+CSS.
 -}
-viewShopGroupToggle : msg -> String -> ShopFold -> Html msg
-viewShopGroupToggle onToggle label fold =
-    Html.button
-        [ Html.Attributes.class "shop-subtoggle", Html.Events.onClick onToggle ]
-        [ Html.text
-            (label
-                ++ (case fold of
-                        ShopCollapsed ->
-                            " \u{25B8}"
-
-                        ShopExpanded ->
-                            " \u{25BE}"
-                   )
-            )
-        ]
+viewShopGroupHeading : String -> Html msg
+viewShopGroupHeading label =
+    Html.div [ Html.Attributes.class "shop-group-heading" ] [ Html.text label ]
 
 
 {-| One row in the shop: item name left, price right. The click carries

--- a/elm/tests/CoinFlipGameTest.elm
+++ b/elm/tests/CoinFlipGameTest.elm
@@ -96,6 +96,13 @@ gambleSuite =
                 in
                 ( busted.phase, busted.balanceCents )
                     |> Expect.equal ( WentBust, 0 )
+        , test "flip log lines carry their flip number" <|
+            \_ ->
+                apply CoinFlipLevel1.levelConfig
+                    [ landedFlip Heads 1000 Heads, landedFlip Heads 500 Tails ]
+                    level1Start
+                    |> latestLogText
+                    |> Expect.equal "2: Landed Tails! You lost $5.00"
         , test "flips count both what was bet and what landed" <|
             \_ ->
                 let

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -1,4 +1,4 @@
-module MultiCoinGameTest exposing (correlationSuite, correlationUpgradeSuite, flipSuite, refundSuite, gatingSuite, payoutSuite, shopSuite, shuffleSuite, stakeSuite)
+module MultiCoinGameTest exposing (correlationSuite, correlationUpgradeSuite, extraTurnsSuite, flipSuite, refundSuite, gatingSuite, payoutSuite, shopSuite, shuffleSuite, stakeSuite)
 
 {-| Tests for the multi-coin engine behind level 3 (black-swan.html).
 They drive the real `update` with the real level config; the coins
@@ -806,4 +806,38 @@ refundSuite =
                         , WentBust
                         , "\u{1F9D3} Uncle: \u{201C}I'm proud of you kid\u{201D} \u{1F911}"
                         )
+        ]
+
+
+{-| Buying more turns: $500 for 50 flips, repeatable, satire.
+-}
+extraTurnsSuite : Test
+extraTurnsSuite =
+    describe "MultiCoinGame extra turns (level 4)"
+        [ test "buying 50 more flips costs $500 and extends the budget" <|
+            \_ ->
+                let
+                    extended =
+                        apply4 [ ExtraTurnsPurchased, sunnyRound [ 100, 0, 0 ] ]
+                            { level4Start | balanceCents = 60000, roundCount = 199 }
+                in
+                ( extended.balanceCents, extended.phase )
+                    |> Expect.equal ( 60000 - 50000 + 80, Playing )
+        , test "without the purchase the same flip ends the game" <|
+            \_ ->
+                apply4 [ sunnyRound [ 100, 0, 0 ] ]
+                    { level4Start | balanceCents = 60000, roundCount = 199 }
+                    |> .phase
+                    |> Expect.equal RanOutOfTime
+        , test "buying flips is repeatable" <|
+            \_ ->
+                apply4 [ ExtraTurnsPurchased, ExtraTurnsPurchased ]
+                    { level4Start | balanceCents = 110000 }
+                    |> .extraFlipsBought
+                    |> Expect.equal 100
+        , test "more flips are refused below the price" <|
+            \_ ->
+                apply4 [ ExtraTurnsPurchased ] { level4Start | balanceCents = 50000 }
+                    |> .extraFlipsBought
+                    |> Expect.equal 0
         ]

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -424,21 +424,15 @@ gatingSuite =
                 view CoinFlipLevel3.levelConfig level3Start
                     |> Query.fromHtml
                     |> Query.hasNot [ class "shop-item" ]
-        , test "the open shop shows submenus, not items" <|
+        , test "the open shop shows the section headings and their items" <|
             \_ ->
                 apply [ ShopToggled ] level3Start
                     |> view CoinFlipLevel3.levelConfig
                     |> Query.fromHtml
                     |> Expect.all
-                        [ Query.has [ class "shop-subtoggle" ]
-                        , Query.hasNot [ class "shop-item" ]
+                        [ Query.has [ class "shop-group-heading" ]
+                        , Query.has [ class "shop-item" ]
                         ]
-        , test "toggling a submenu reveals its items" <|
-            \_ ->
-                apply [ ShopToggled, IntelToggled ] level3Start
-                    |> view CoinFlipLevel3.levelConfig
-                    |> Query.fromHtml
-                    |> Query.has [ class "shop-item" ]
         , test "toggling twice collapses the shop again" <|
             \_ ->
                 apply [ ShopToggled, ShopToggled ] level3Start
@@ -784,13 +778,13 @@ refundSuite =
                     |> Expect.equal 1
         , test "the refund is not for sale before the complete works are heard" <|
             \_ ->
-                apply4 [ ShopToggled, IntelToggled ] level4Start
+                apply4 [ ShopToggled ] level4Start
                     |> view CoinFlipLevel4.levelConfig
                     |> Query.fromHtml
                     |> Query.hasNot [ text "Ask your money back" ]
         , test "hearing every phrase puts the refund up for sale" <|
             \_ ->
-                apply4 [ ShopToggled, IntelToggled ] heardEverything
+                apply4 [ ShopToggled ] heardEverything
                     |> view CoinFlipLevel4.levelConfig
                     |> Query.fromHtml
                     |> Query.has [ text "Ask your money back" ]

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -659,12 +659,12 @@ correlationUpgradeSuite =
                 apply4 [ sunnyRound [ 100, 0, 0 ] ] level4Start
                     |> latestLogText
                     |> Expect.equal
-                        "#1 Starling landed heads! You win $1.80, of which $1.00 is your stake."
+                        "1: Starling landed heads! You win $1.80, of which $1.00 is your stake."
         , test "a losing weather coin's line is equally silent about its partner" <|
             \_ ->
                 apply4 [ rainyRound [ 100, 0, 0 ] ] level4Start
                     |> latestLogText
-                    |> Expect.equal "#1 Starling landed tails. You lost your $1.00 stake."
+                    |> Expect.equal "1: Starling landed tails. You lost your $1.00 stake."
         , test "buying the allocator costs $10 and switches to percent mode" <|
             \_ ->
                 let

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -1,4 +1,4 @@
-module MultiCoinGameTest exposing (correlationSuite, flipSuite, gatingSuite, payoutSuite, shopSuite, shuffleSuite, stakeSuite)
+module MultiCoinGameTest exposing (correlationSuite, correlationUpgradeSuite, flipSuite, gatingSuite, payoutSuite, shopSuite, shuffleSuite, stakeSuite)
 
 {-| Tests for the multi-coin engine behind level 3 (black-swan.html).
 They drive the real `update` with the real level config; the coins
@@ -17,9 +17,11 @@ import CoinFlipLevel4
 import Expect
 import MultiCoinGame
     exposing
-        ( Autoclicker(..)
+        ( AllocationMode(..)
+        , Autoclicker(..)
         , BustCause(..)
         , CoinOdds(..)
+        , CorrelationBook(..)
         , FlipHold(..)
         , GoldenGlasses(..)
         , Model
@@ -639,4 +641,96 @@ correlationSuite =
                     { level4Start | roundCount = 198 }
                     |> .phase
                     |> Expect.equal Playing
+        ]
+
+
+{-| The correlation upgrades: therefore-clauses in the log, the
+percentage allocator, and The Elegant Universe's pair tallies.
+-}
+correlationUpgradeSuite : Test
+correlationUpgradeSuite =
+    describe "MultiCoinGame correlation upgrades (level 4)"
+        [ test "a weather coin's log line names its partner's fate" <|
+            \_ ->
+                apply4 [ sunnyRound [ 100, 0, 0 ] ] level4Start
+                    |> latestLogText
+                    |> Expect.equal
+                        "Starling landed heads! You win $1.80, of which $1.00 is your stake. Therefore Swallow loses."
+        , test "the losing weather coin's line says the partner wins" <|
+            \_ ->
+                apply4 [ rainyRound [ 100, 0, 0 ] ] level4Start
+                    |> latestLogText
+                    |> Expect.equal
+                        "Starling landed tails. You lost your $1.00 stake. Therefore Swallow wins."
+        , test "the independent cuckoo gets no therefore clause" <|
+            \_ ->
+                apply4 [ CoinsLanded { stakes = [ 0, 0, 10 ], weatherRoll = 1, rolls = [ 100, 100, 100 ] } ]
+                    level4Start
+                    |> latestLogText
+                    |> Expect.equal "Cuckoo landed tails. You lost your $0.10 stake."
+        , test "buying the allocator costs $10 and switches to percent mode" <|
+            \_ ->
+                let
+                    bought =
+                        apply4 [ AllocatorPurchased ] level4Start
+                in
+                ( bought.balanceCents, bought.allocationMode )
+                    |> Expect.equal ( 1500, PercentAllocation )
+        , test "percent stakes are taken from the live balance" <|
+            \_ ->
+                -- After the $10 allocator: balance $15.00, staking 10%
+                -- of it on the sunny coin is $1.50, winning 0.8x pays
+                -- $1.20: balance 1500 + 120.
+                apply4
+                    [ AllocatorPurchased
+                    , StakeInputChanged 0 "10"
+                    , FlipPressed
+                    ]
+                    level4Start
+                    |> (\beforeLanding ->
+                            apply4 [ sunnyRound [ 150, 0, 0 ] ] beforeLanding
+                       )
+                    |> .balanceCents
+                    |> Expect.equal (1500 + 120)
+        , test "percent totals above 100 are refused like overdrawn dollars" <|
+            \_ ->
+                apply4
+                    [ AllocatorPurchased
+                    , StakeInputChanged 0 "60"
+                    , StakeInputChanged 1 "50"
+                    , FlipPressed
+                    ]
+                    level4Start
+                    |> latestLogText
+                    |> Expect.equal "You cannot bet more than your current balance!"
+        , test "buying the book costs $20 and starts tracking pairs" <|
+            \_ ->
+                let
+                    read =
+                        apply4
+                            [ BookPurchased
+                            , sunnyRound [ 100, 100, 10 ]
+                            , rainyRound [ 100, 100, 0 ]
+                            ]
+                            level4Start
+                in
+                ( read.balanceCents |> (\_ -> read.book)
+                , read.pairTallies
+                )
+                    |> Expect.equal
+                        ( BookBought
+                        , [ { firstIndex = 0, secondIndex = 1, sameCount = 0, bothCount = 2 }
+                          , { firstIndex = 0, secondIndex = 2, sameCount = 0, bothCount = 1 }
+                          , { firstIndex = 1, secondIndex = 2, sameCount = 1, bothCount = 1 }
+                          ]
+                        )
+        , test "pairs only count rounds where both coins were staked" <|
+            \_ ->
+                apply4 [ sunnyRound [ 100, 0, 0 ] ] level4Start
+                    |> .pairTallies
+                    |> Expect.equal
+                        [ { firstIndex = 0, secondIndex = 1, sameCount = 0, bothCount = 0 }
+                        , { firstIndex = 0, secondIndex = 2, sameCount = 0, bothCount = 0 }
+                        , { firstIndex = 1, secondIndex = 2, sameCount = 0, bothCount = 0 }
+                        ]
         ]

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -1,4 +1,4 @@
-module MultiCoinGameTest exposing (correlationSuite, correlationUpgradeSuite, flipSuite, gatingSuite, payoutSuite, shopSuite, shuffleSuite, stakeSuite)
+module MultiCoinGameTest exposing (correlationSuite, correlationUpgradeSuite, flipSuite, refundSuite, gatingSuite, payoutSuite, shopSuite, shuffleSuite, stakeSuite)
 
 {-| Tests for the multi-coin engine behind level 3 (black-swan.html).
 They drive the real `update` with the real level config; the coins
@@ -19,6 +19,7 @@ import MultiCoinGame
     exposing
         ( AllocationMode(..)
         , Autoclicker(..)
+        , RefundState(..)
         , BustCause(..)
         , CoinOdds(..)
         , CorrelationBook(..)
@@ -423,9 +424,18 @@ gatingSuite =
                 view CoinFlipLevel3.levelConfig level3Start
                     |> Query.fromHtml
                     |> Query.hasNot [ class "shop-item" ]
-        , test "toggling the shop reveals the items" <|
+        , test "the open shop shows submenus, not items" <|
             \_ ->
                 apply [ ShopToggled ] level3Start
+                    |> view CoinFlipLevel3.levelConfig
+                    |> Query.fromHtml
+                    |> Expect.all
+                        [ Query.has [ class "shop-subtoggle" ]
+                        , Query.hasNot [ class "shop-item" ]
+                        ]
+        , test "toggling a submenu reveals its items" <|
+            \_ ->
+                apply [ ShopToggled, IntelToggled ] level3Start
                     |> view CoinFlipLevel3.levelConfig
                     |> Query.fromHtml
                     |> Query.has [ class "shop-item" ]
@@ -733,4 +743,80 @@ correlationUpgradeSuite =
                         , { firstIndex = 0, secondIndex = 2, sameCount = 0, bothCount = 0 }
                         , { firstIndex = 1, secondIndex = 2, sameCount = 0, bothCount = 0 }
                         ]
+        ]
+
+
+{-| Uncle's complete works: 1 first phrase + 8 more in the level-4
+config. Hearing all nine unlocks asking for the money back.
+-}
+allUnclePhrases : List String
+allUnclePhrases =
+    [ "Don't split your money son, pick a winner and commit."
+    , "The cuckoo is due, I can feel it."
+    , "A real gambler doesn't hedge."
+    , "Diversification is for people who don't know what they're doing."
+    , "Starlings and swallows are basically the same bird, so same bet really."
+    , "Correlation? That's when birds fly in a V, right?"
+    , "When one bird loses, bet it harder, it owes you."
+    , "I read half a physics book once. Everything is strings, so nothing matters."
+    , "Your aunt once knitted a swallow. Beautiful bird. What were we talking about?"
+    ]
+
+
+heardEverything : Model
+heardEverything =
+    apply4 (List.map UncleAdviceGiven allUnclePhrases)
+        { level4Start | balanceCents = 10000 }
+
+
+refundSuite : Test
+refundSuite =
+    describe "MultiCoinGame refund request (level 4)"
+        [ test "hearing a phrase twice counts once" <|
+            \_ ->
+                apply4
+                    (List.map UncleAdviceGiven
+                        [ "A real gambler doesn't hedge.", "A real gambler doesn't hedge." ]
+                    )
+                    level4Start
+                    |> .adviceHeard
+                    |> List.length
+                    |> Expect.equal 1
+        , test "the refund is not for sale before the complete works are heard" <|
+            \_ ->
+                apply4 [ ShopToggled, IntelToggled ] level4Start
+                    |> view CoinFlipLevel4.levelConfig
+                    |> Query.fromHtml
+                    |> Query.hasNot [ text "Ask your money back" ]
+        , test "hearing every phrase puts the refund up for sale" <|
+            \_ ->
+                apply4 [ ShopToggled, IntelToggled ] heardEverything
+                    |> view CoinFlipLevel4.levelConfig
+                    |> Query.fromHtml
+                    |> Query.has [ text "Ask your money back" ]
+        , test "asking costs $10 and uncle replies with his farewell" <|
+            \_ ->
+                let
+                    asked =
+                        apply4 [ RefundRequested ] heardEverything
+                in
+                ( asked.balanceCents, asked.refund, String.contains "that ship has sailed" (latestLogText asked) )
+                    |> Expect.equal ( 9000, RefundAsked, True )
+        , test "uncle does not do repeat refund conversations" <|
+            \_ ->
+                apply4 [ RefundRequested, RefundRequested ] heardEverything
+                    |> .balanceCents
+                    |> Expect.equal 9000
+        , test "asking with your last ten dollars goes bust, gloat and all" <|
+            \_ ->
+                let
+                    busted =
+                        apply4 [ RefundRequested ] { heardEverything | balanceCents = 1000 }
+                in
+                ( busted.balanceCents, busted.phase, latestLogText busted )
+                    |> Expect.equal
+                        ( 0
+                        , WentBust
+                        , "\u{1F9D3} Uncle: \u{201C}I'm proud of you kid\u{201D} \u{1F911}"
+                        )
         ]

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -659,12 +659,12 @@ correlationUpgradeSuite =
                 apply4 [ sunnyRound [ 100, 0, 0 ] ] level4Start
                     |> latestLogText
                     |> Expect.equal
-                        "Starling landed heads! You win $1.80, of which $1.00 is your stake."
+                        "#1 Starling landed heads! You win $1.80, of which $1.00 is your stake."
         , test "a losing weather coin's line is equally silent about its partner" <|
             \_ ->
                 apply4 [ rainyRound [ 100, 0, 0 ] ] level4Start
                     |> latestLogText
-                    |> Expect.equal "Starling landed tails. You lost your $1.00 stake."
+                    |> Expect.equal "#1 Starling landed tails. You lost your $1.00 stake."
         , test "buying the allocator costs $10 and switches to percent mode" <|
             \_ ->
                 let

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -654,24 +654,17 @@ percentage allocator, and The Elegant Universe's pair tallies.
 correlationUpgradeSuite : Test
 correlationUpgradeSuite =
     describe "MultiCoinGame correlation upgrades (level 4)"
-        [ test "a weather coin's log line names its partner's fate" <|
+        [ test "weather coin log lines stay plain, revealing nothing" <|
             \_ ->
                 apply4 [ sunnyRound [ 100, 0, 0 ] ] level4Start
                     |> latestLogText
                     |> Expect.equal
-                        "Starling landed heads! You win $1.80, of which $1.00 is your stake. Therefore Swallow loses."
-        , test "the losing weather coin's line says the partner wins" <|
+                        "Starling landed heads! You win $1.80, of which $1.00 is your stake."
+        , test "a losing weather coin's line is equally silent about its partner" <|
             \_ ->
                 apply4 [ rainyRound [ 100, 0, 0 ] ] level4Start
                     |> latestLogText
-                    |> Expect.equal
-                        "Starling landed tails. You lost your $1.00 stake. Therefore Swallow wins."
-        , test "the independent cuckoo gets no therefore clause" <|
-            \_ ->
-                apply4 [ CoinsLanded { stakes = [ 0, 0, 10 ], weatherRoll = 1, rolls = [ 100, 100, 100 ] } ]
-                    level4Start
-                    |> latestLogText
-                    |> Expect.equal "Cuckoo landed tails. You lost your $0.10 stake."
+                    |> Expect.equal "Starling landed tails. You lost your $1.00 stake."
         , test "buying the allocator costs $10 and switches to percent mode" <|
             \_ ->
                 let

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -1,4 +1,4 @@
-module MultiCoinGameTest exposing (flipSuite, gatingSuite, payoutSuite, shopSuite, shuffleSuite, stakeSuite)
+module MultiCoinGameTest exposing (correlationSuite, flipSuite, gatingSuite, payoutSuite, shopSuite, shuffleSuite, stakeSuite)
 
 {-| Tests for the multi-coin engine behind level 3 (black-swan.html).
 They drive the real `update` with the real level config; the coins
@@ -13,11 +13,13 @@ import CoinFlipGame
         , TrackerState(..)
         )
 import CoinFlipLevel3
+import CoinFlipLevel4
 import Expect
 import MultiCoinGame
     exposing
         ( Autoclicker(..)
         , BustCause(..)
+        , CoinOdds(..)
         , FlipHold(..)
         , GoldenGlasses(..)
         , Model
@@ -55,7 +57,7 @@ level3Start =
 
 landedRound : List Int -> List Int -> Msg
 landedRound stakes rolls =
-    CoinsLanded { stakes = stakes, rolls = rolls }
+    CoinsLanded { stakes = stakes, weatherRoll = 1, rolls = rolls }
 
 
 clickAtOrigin : ShopDialog.ClickPoint
@@ -486,9 +488,9 @@ shuffleSuite =
             \_ ->
                 let
                     reassigned =
-                        [ { coinName = "Swan", winPercent = 60, payoutPercent = 50 }
-                        , { coinName = "Magpie", winPercent = 5, payoutPercent = 3000 }
-                        , { coinName = "Sparrow", winPercent = 45, payoutPercent = 100 }
+                        [ { coinName = "Swan", odds = IndependentPercent 60, payoutPercent = 50 }
+                        , { coinName = "Magpie", odds = IndependentPercent 5, payoutPercent = 3000 }
+                        , { coinName = "Sparrow", odds = IndependentPercent 45, payoutPercent = 100 }
                         ]
                 in
                 apply [ ProfilesShuffled reassigned ] level3Start
@@ -500,9 +502,9 @@ shuffleSuite =
                 -- swan profile: a winning roll of 5 on Magpie pays 30x.
                 apply
                     [ ProfilesShuffled
-                        [ { coinName = "Swan", winPercent = 60, payoutPercent = 50 }
-                        , { coinName = "Magpie", winPercent = 5, payoutPercent = 3000 }
-                        , { coinName = "Sparrow", winPercent = 45, payoutPercent = 100 }
+                        [ { coinName = "Swan", odds = IndependentPercent 60, payoutPercent = 50 }
+                        , { coinName = "Magpie", odds = IndependentPercent 5, payoutPercent = 3000 }
+                        , { coinName = "Sparrow", odds = IndependentPercent 45, payoutPercent = 100 }
                         ]
                     , landedRound [ 0, 100, 0 ] [ 50, 5, 50 ]
                     ]
@@ -513,9 +515,9 @@ shuffleSuite =
             \_ ->
                 apply
                     [ ProfilesShuffled
-                        [ { coinName = "Swan", winPercent = 60, payoutPercent = 50 }
-                        , { coinName = "Magpie", winPercent = 5, payoutPercent = 3000 }
-                        , { coinName = "Sparrow", winPercent = 45, payoutPercent = 100 }
+                        [ { coinName = "Swan", odds = IndependentPercent 60, payoutPercent = 50 }
+                        , { coinName = "Magpie", odds = IndependentPercent 5, payoutPercent = 3000 }
+                        , { coinName = "Sparrow", odds = IndependentPercent 45, payoutPercent = 100 }
                         ]
                     ]
                     { level3Start | glasses = GlassesBought }
@@ -541,10 +543,100 @@ shuffleSuite =
         ]
 
 
-{-| The (win percent, payout) profiles of a coin list, order-insensitive,
-for comparing a shuffle against the original deal.
+{-| The (odds, payout) profiles of a coin list, order-insensitive, for
+comparing a shuffle against the original deal.
 -}
-sortedProfiles : List MultiCoinGame.CoinConfig -> List { winPercent : Int, payoutPercent : Int }
+sortedProfiles : List MultiCoinGame.CoinConfig -> List { odds : CoinOdds, payoutPercent : Int }
 sortedProfiles coins =
-    List.sortBy .winPercent
-        (List.map (\coin -> { winPercent = coin.winPercent, payoutPercent = coin.payoutPercent }) coins)
+    List.sortBy .payoutPercent
+        (List.map (\coin -> { odds = coin.odds, payoutPercent = coin.payoutPercent }) coins)
+
+
+{-| Level 4 (birds of a feather): weather-driven anti-correlated coins,
+a flip budget instead of a clock, and the Dutch-book portfolio.
+Sun percent is 60, so weather rolls 1-60 are sunny and 61-100 rainy.
+-}
+apply4 : List Msg -> Model -> Model
+apply4 msgs model =
+    List.foldl
+        (\msg current -> Tuple.first (update CoinFlipLevel4.levelConfig msg current))
+        model
+        msgs
+
+
+level4Start : Model
+level4Start =
+    initialModel CoinFlipLevel4.levelConfig
+
+
+sunnyRound : List Int -> Msg
+sunnyRound stakes =
+    CoinsLanded { stakes = stakes, weatherRoll = 1, rolls = [ 100, 100, 100 ] }
+
+
+rainyRound : List Int -> Msg
+rainyRound stakes =
+    CoinsLanded { stakes = stakes, weatherRoll = 100, rolls = [ 100, 100, 100 ] }
+
+
+correlationSuite : Test
+correlationSuite =
+    describe "MultiCoinGame weather correlation (level 4)"
+        [ test "on a sunny round the sunbird wins and the rainbird loses" <|
+            \_ ->
+                apply4 [ sunnyRound [ 100, 100, 0 ] ] level4Start
+                    |> .tallies
+                    |> Expect.equal
+                        [ { headsCount = 1, flipCount = 1 }
+                        , { headsCount = 0, flipCount = 1 }
+                        , { headsCount = 0, flipCount = 0 }
+                        ]
+        , test "on a rainy round the rainbird wins and the sunbird loses" <|
+            \_ ->
+                apply4 [ rainyRound [ 100, 100, 0 ] ] level4Start
+                    |> .tallies
+                    |> Expect.equal
+                        [ { headsCount = 0, flipCount = 1 }
+                        , { headsCount = 1, flipCount = 1 }
+                        , { headsCount = 0, flipCount = 0 }
+                        ]
+        , test "the Dutch-book split profits on a sunny round" <|
+            \_ ->
+                -- $6.10 on Sunbird (pays 0.8x) and $3.90 on Rainbird:
+                -- sunny nets 610*0.8 - 390 = +98 cents.
+                apply4 [ sunnyRound [ 610, 390, 0 ] ] level4Start
+                    |> .balanceCents
+                    |> Expect.equal (2500 + 488 - 390)
+        , test "the Dutch-book split profits on a rainy round too" <|
+            \_ ->
+                -- rainy nets 390*1.8 - 610 = +92 cents.
+                apply4 [ rainyRound [ 610, 390, 0 ] ] level4Start
+                    |> .balanceCents
+                    |> Expect.equal (2500 + 702 - 610)
+        , test "the cuckoo rolls independently of the weather" <|
+            \_ ->
+                -- rainy round, but the cuckoo's own roll of 1 (<= 2) wins:
+                -- 40x on a $0.10 stake pays $4.00.
+                apply4 [ CoinsLanded { stakes = [ 0, 0, 10 ], weatherRoll = 100, rolls = [ 100, 100, 1 ] } ]
+                    level4Start
+                    |> .balanceCents
+                    |> Expect.equal (2500 + 400)
+        , test "the game ends after the flip budget is spent" <|
+            \_ ->
+                apply4 [ sunnyRound [ 100, 0, 0 ] ]
+                    { level4Start | roundCount = 199 }
+                    |> .phase
+                    |> Expect.equal RanOutOfTime
+        , test "winning on the final flip beats running out of flips" <|
+            \_ ->
+                apply4 [ rainyRound [ 0, 55000, 0 ] ]
+                    { level4Start | roundCount = 199, balanceCents = 55000 }
+                    |> .phase
+                    |> Expect.equal WonGame
+        , test "flips before the budget runs out keep the game going" <|
+            \_ ->
+                apply4 [ sunnyRound [ 100, 0, 0 ] ]
+                    { level4Start | roundCount = 198 }
+                    |> .phase
+                    |> Expect.equal Playing
+        ]

--- a/shake/Shakefile.hs
+++ b/shake/Shakefile.hs
@@ -142,6 +142,7 @@ shakeRules = do
       buildCoinFlipLevel1
       buildCoinFlipLevel2
       buildCoinFlipLevel3
+      buildCoinFlipLevel4
 
       -- Build penguin site
       need ["build-penguin"]
@@ -184,6 +185,7 @@ shakeRules = do
       buildCoinFlipLevel1
       buildCoinFlipLevel2
       buildCoinFlipLevel3
+      buildCoinFlipLevel4
 
       -- Build penguin + webwinkel sites, with penguin's webwinkelverhuis.nl
       -- links pointing at the locally served copy instead of the live site.
@@ -635,6 +637,10 @@ buildCoinFlipLevel2 = buildBlogElmApp "src/CoinFlipLevel2.elm" "coin-flip-level2
 -- | Level 3, the black swan (black-swan.html).
 buildCoinFlipLevel3 :: Action ()
 buildCoinFlipLevel3 = buildBlogElmApp "src/CoinFlipLevel3.elm" "coin-flip-level3.js"
+
+-- | Level 4, correlation (birds-of-a-feather.html).
+buildCoinFlipLevel4 :: Action ()
+buildCoinFlipLevel4 = buildBlogElmApp "src/CoinFlipLevel4.elm" "coin-flip-level4.js"
 
 -- | The /prijzen price calculator.
 buildPrijsCalculator :: Action ()


### PR DESCRIPTION
Level 4 of the rigged-coin series, mounted on the new post `birds-of-a-feather.html` (TODO article, game only, per the usual pattern). The lesson: decorrelation pays, and here it is the *only* road to victory.

## The game

- One hidden weather roll per round: sun 60%, rain 40%.
- **Sunbird** wins exactly when sunny, paying 0.8×; **Rainbird** exactly when rainy, paying 1.8×. Perfectly anti-correlated: exactly one wins every round, discoverable from the log.
- Their payouts form a Dutch book (0.8 × 1.8 > 1, implied probabilities sum to 0.91): staking ~61/39 across both nets a **guaranteed ~9.6% per flip**, rain or shine, $999 in 41 presses. A naive 50/50 split loses every sunny round — the ratio is the skill.
- Either bird alone is positive EV but grows ≤0.4%/flip optimally Kelly-sized, needing 900+ perfect rounds: hopeless inside the **200-flip budget** (a `TurnBudget` replaces the clock this level).
- **Cuckoo** is the red herring: fat 40× payout at 2%, an 18% negative expected return.
- Shop: tracker, glasses, uncle with fresh correlation-flavored bad advice ("A real gambler doesn't hedge."). No automation items: 200 flips make it about sizing, not pressing.

## Engine

`CoinOdds` (independent percent, or wins-on-shared-weather) replaces the flat `winPercent`; `TurnBudget` adds flip-limited games ("Flips left" stat, "Out of flips!" ending, win/bust on the final flip taking precedence); the multi-coin game over gains the next-level link, and level 3's win now links onward to level 4.

## Verification

Live played: the 6.10/3.90 split raised the balance every single round for 50 straight rounds (33 sunny / 17 rainy, matching 60/40), cuckoo rolls independent of weather, flips-left counts down, index shows only the teaser. 194 Elm tests pass (8 new for correlation, the Dutch-book branches, and the flip budget). `nix-build nix/ci.nix` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
