### PR TITLE
A divider line between turns in every game's log

### DIFF
--- a/content/birds-of-a-feather.md
+++ b/content/birds-of-a-feather.md
@@ -106,6 +106,7 @@ TODO
     padding-top: 0.5em;
     margin-top: 0.8em;
   }
+  #coin-flip-game .log-divider { border-top: 1px solid #333; margin: 0.25em 0; }
   #coin-flip-game .win-text { color: #1e7d1e; }
   #coin-flip-game .lose-text { color: #b03030; }
   #coin-flip-game .game-over { font-weight: bold; text-align: center; font-size: 1.1em; margin: 0.5em 0; }
@@ -113,6 +114,7 @@ TODO
   @media (prefers-color-scheme: dark) {
     #coin-flip-game { background: rgba(0, 0, 0, 0.85); }
     #coin-flip-game .progress-track { background: #134013; }
+    #coin-flip-game .log-divider { border-color: #888; }
     #coin-flip-game .win-text { color: #7dff7d; }
     #coin-flip-game .lose-text { color: #ff6b6b; }
     #coin-flip-game .purchase-dialog { background: #062606; }

--- a/content/black-swan.md
+++ b/content/black-swan.md
@@ -116,6 +116,7 @@ of a gambler may succeed.
     padding-top: 0.5em;
     margin-top: 0.8em;
   }
+  #coin-flip-game .log-divider { border-top: 1px solid #333; margin: 0.25em 0; }
   #coin-flip-game .win-text { color: #1e7d1e; }
   #coin-flip-game .lose-text { color: #b03030; }
   #coin-flip-game .game-over { font-weight: bold; text-align: center; font-size: 1.1em; margin: 0.5em 0; }
@@ -123,6 +124,7 @@ of a gambler may succeed.
   @media (prefers-color-scheme: dark) {
     #coin-flip-game { background: rgba(0, 0, 0, 0.85); }
     #coin-flip-game .progress-track { background: #134013; }
+    #coin-flip-game .log-divider { border-color: #888; }
     #coin-flip-game .win-text { color: #7dff7d; }
     #coin-flip-game .lose-text { color: #ff6b6b; }
     #coin-flip-game .purchase-dialog { background: #062606; }

--- a/content/hidden-rewards.md
+++ b/content/hidden-rewards.md
@@ -98,6 +98,7 @@ I won't tell which. Good luck!
     padding-top: 0.5em;
     margin-top: 0.8em;
   }
+  #coin-flip-game .log-divider { border-top: 1px solid #333; margin: 0.25em 0; }
   #coin-flip-game .win-text { color: #1e7d1e; }
   #coin-flip-game .lose-text { color: #b03030; }
   #coin-flip-game .game-over { font-weight: bold; text-align: center; font-size: 1.1em; margin: 0.5em 0; }
@@ -105,6 +106,7 @@ I won't tell which. Good luck!
   @media (prefers-color-scheme: dark) {
     #coin-flip-game { background: rgba(0, 0, 0, 0.85); }
     #coin-flip-game .progress-track { background: #134013; }
+    #coin-flip-game .log-divider { border-color: #888; }
     #coin-flip-game .win-text { color: #7dff7d; }
     #coin-flip-game .lose-text { color: #ff6b6b; }
     #coin-flip-game .purchase-dialog { background: #062606; }

--- a/content/sizing.md
+++ b/content/sizing.md
@@ -73,6 +73,7 @@ Try it out:
     padding-top: 0.5em;
     margin-top: 0.8em;
   }
+  #coin-flip-game .log-divider { border-top: 1px solid #333; margin: 0.25em 0; }
   #coin-flip-game .win-text { color: #1e7d1e; }
   #coin-flip-game .lose-text { color: #b03030; }
   #coin-flip-game .game-over { font-weight: bold; text-align: center; font-size: 1.1em; margin: 0.5em 0; }
@@ -80,6 +81,7 @@ Try it out:
   @media (prefers-color-scheme: dark) {
     #coin-flip-game { background: rgba(0, 0, 0, 0.85); }
     #coin-flip-game .progress-track { background: #134013; }
+    #coin-flip-game .log-divider { border-color: #888; }
     #coin-flip-game .win-text { color: #7dff7d; }
     #coin-flip-game .lose-text { color: #ff6b6b; }
   }

--- a/elm/src/CoinFlipGame.elm
+++ b/elm/src/CoinFlipGame.elm
@@ -166,6 +166,7 @@ type LogTone
     = WinTone
     | LoseTone
     | NeutralTone
+    | DividerTone
 
 
 {-| Whether uncle already dropped his "proud of you" line. He gloats
@@ -471,7 +472,7 @@ settleFlip uncleOffer flip model =
                         LoseTone
                     )
                     outcomeText
-                    counted
+                    (logLine DividerTone "" counted)
                 )
             )
 
@@ -1188,6 +1189,9 @@ viewLogLine line =
         LoseTone ->
             Html.div [ Html.Attributes.class (toneClass line.tone) ] [ Html.text line.text ]
 
+        DividerTone ->
+            Html.div [ Html.Attributes.class "log-divider" ] []
+
 
 toneClass : LogTone -> String
 toneClass tone =
@@ -1199,4 +1203,7 @@ toneClass tone =
             "lose-text"
 
         NeutralTone ->
+            ""
+
+        DividerTone ->
             ""

--- a/elm/src/MultiCoinGame.elm
+++ b/elm/src/MultiCoinGame.elm
@@ -863,10 +863,14 @@ settleRound config landedRound model =
             roundNumber =
                 model.roundCount + 1
 
+            -- The divider goes first so that after the List.reverse in
+            -- the log update it ends up between this round's lines and
+            -- the older entries.
             roundLogLines =
-                List.map
-                    (\line -> { line | text = String.fromInt roundNumber ++ ": " ++ line.text })
-                    (List.concatMap .logLines outcomes)
+                { tone = DividerTone, text = "" }
+                    :: List.map
+                        (\line -> { line | text = String.fromInt roundNumber ++ ": " ++ line.text })
+                        (List.concatMap .logLines outcomes)
         in
         gloatIfBusted config.uncleOffer
             (endWhenOutOfFlips config.turnBudget
@@ -2262,3 +2266,6 @@ viewLogLine line =
         LoseTone ->
             Html.div [ Html.Attributes.class (CoinFlipGame.toneClass line.tone) ]
                 [ Html.text line.text ]
+
+        DividerTone ->
+            Html.div [ Html.Attributes.class "log-divider" ] []

--- a/elm/tests/CoinFlipGameTest.elm
+++ b/elm/tests/CoinFlipGameTest.elm
@@ -13,6 +13,7 @@ import CoinFlipGame
         , CoinSide(..)
         , GamePhase(..)
         , LevelConfig
+        , LogTone(..)
         , Model
         , Msg(..)
         , TrackerState(..)
@@ -103,6 +104,15 @@ gambleSuite =
                     level1Start
                     |> latestLogText
                     |> Expect.equal "2: Landed Tails! You lost $5.00"
+        , test "every settled flip adds one log divider" <|
+            \_ ->
+                apply CoinFlipLevel1.levelConfig
+                    [ landedFlip Heads 100 Heads, landedFlip Heads 100 Tails ]
+                    level1Start
+                    |> .log
+                    |> List.filter (\line -> line.tone == DividerTone)
+                    |> List.length
+                    |> Expect.equal 2
         , test "flips count both what was bet and what landed" <|
             \_ ->
                 let

--- a/elm/tests/MultiCoinGameTest.elm
+++ b/elm/tests/MultiCoinGameTest.elm
@@ -106,6 +106,14 @@ flipSuite =
                 in
                 ( played.balanceCents, List.map .flipCount played.tallies )
                     |> Expect.equal ( 2300, [ 0, 1, 0 ] )
+        , test "every settled round adds one log divider" <|
+            \_ ->
+                apply [ landedRound [ 100, 0, 0 ] [ 5, 100, 100 ], landedRound [ 100, 0, 0 ] [ 5, 100, 100 ] ]
+                    level3Start
+                    |> .log
+                    |> List.filter (\line -> line.tone == CoinFlipGame.DividerTone)
+                    |> List.length
+                    |> Expect.equal 2
         , test "tallies count heads per staked coin" <|
             \_ ->
                 apply


### PR DESCRIPTION
Each settled turn drops a thin black rule (grey in dark mode) into the log, so turns read as visually separated blocks across all four levels. In the multi-coin games a round's lines group between two rules, which pairs with the recently added turn numbers. Purchases, errors, and uncle's commentary flow within the blocks.

Verified live in both engines (one 1px rule per turn, correct placement between rounds). 214 Elm tests pass (per-turn divider counts asserted in both suites). `nix-build nix/ci.nix` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
